### PR TITLE
Create/update widgets from descriptor files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 	webpack
 
 lint:
-	eslint lib/
+	eslint lib/ bin/ test/
 
 clean:
 	rm -rf dist/*
@@ -23,7 +23,7 @@ gh-pages:
 test: test-unit test-integration
 
 test-unit:
-	_mocha test/unit/**/*.js
+	_mocha test/unit/**/*-test.js
 
 test-integration:
-	_mocha test/integration/**/*.js
+	_mocha test/integration/**/*-test.js

--- a/bin/cf-widget-create
+++ b/bin/cf-widget-create
@@ -39,20 +39,15 @@ yargs
     type: 'string',
     requiresArg: true
   },
+  'descriptor': {
+    description: 'Path to a widget descriptor file',
+    type: 'string',
+    requiresArg: true
+  },
   'host': {
     description: 'API host',
     type: 'string',
     requiresArg: true
-  }
-})
-.check(function (argv) {
-  if (
-    (argv.f && argv.u) ||
-    (!argv.f && !argv.u)
-  ) {
-    throw new Error('One of -f or -u is required');
-  } else {
-    return true;
   }
 });
 
@@ -62,7 +57,9 @@ let options = {};
 options.url = argv.u;
 options.file = argv.f;
 options.id = argv.id;
-options.space = argv.spaceId;
+options.spaceId = argv.spaceId;
+options.descriptor = argv.descriptor || './widget.json';
+options.descriptor = path.resolve(process.cwd(), options.descriptor);
 
 let context = {
   host: argv.host || 'https://api.contentful.com',

--- a/bin/cf-widget-delete
+++ b/bin/cf-widget-delete
@@ -45,7 +45,7 @@ let argv = yargs.argv;
 let options = {};
 
 options.id = argv.id;
-options.space = argv.spaceId;
+options.spaceId = argv.spaceId;
 options.version = argv.v;
 
 let context = {

--- a/bin/cf-widget-read
+++ b/bin/cf-widget-read
@@ -40,7 +40,7 @@ let argv = yargs.argv;
 let options = {};
 
 options.id = argv.id;
-options.space = argv.spaceId;
+options.spaceId = argv.spaceId;
 
 let context = {
   host: argv.host || 'https://api.contentful.com/',

--- a/bin/cf-widget-update
+++ b/bin/cf-widget-update
@@ -6,6 +6,7 @@ var yargs = require('yargs');
 var request = require('request');
 var http = require('../lib/cli/http');
 var update = require('../lib/cli/command/update');
+var path = require('path');
 
 let token = process.env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN;
 
@@ -24,7 +25,6 @@ yargs
     requiresArg: true
   },
   'id': {
-    required: true,
     description: 'Id of the widget to update',
     type: 'string',
     requiresArg: true,
@@ -44,20 +44,15 @@ yargs
     type: 'string',
     requiresArg: true,
   },
+  'descriptor': {
+    description: 'Path to a widget descriptor file',
+    type: 'string',
+    requiresArg: true
+  },
   'host': {
     description: 'API host',
     type: 'string',
     requiresArg: true
-  }
-})
-.check(function (argv) {
-  if (
-    (argv.f && argv.u) ||
-    (!argv.f && !argv.u)
-  ) {
-    throw new Error('One of -f or -u is required');
-  } else {
-    return true;
   }
 });
 
@@ -68,7 +63,9 @@ options.url = argv.u;
 options.file = argv.f;
 options.version = argv.v;
 options.id = argv.id;
-options.space = argv.spaceId;
+options.spaceId = argv.spaceId;
+options.descriptor = argv.descriptor || './widget.json';
+options.descriptor = path.resolve(process.cwd(), options.descriptor);
 
 let context = {
   host: argv.host || 'https://api.contentful.com',

--- a/lib/cli/.eslintrc
+++ b/lib/cli/.eslintrc
@@ -2,5 +2,9 @@
   "extends": "../../.eslintrc",
   "rules": {
     "semi": [2, "always"]
+  },
+  "globals": {
+    "describe": true,
+    "it": true
   }
 }

--- a/lib/cli/README.md
+++ b/lib/cli/README.md
@@ -1,27 +1,49 @@
 ## Usage
 Following is an overview of the different operations supported by the CLI.
 
+### Descriptor files
+The `create` and `update` commands may use a JSON file to get most of its data.
+The following is a list of properties that are read from the file:
+
+Property | Description
+---------|------------
+id | Corresponds to the sys.id property and gives the resource URL
+name |	 
+fieldTypes |	 
+src |
+srcdoc |	A file path. The content of the file is read and sent to the API in the srcdoc property
+
+By default the `create` and `update` commands will look in the current working directory for a descriptor file called `widget.json`. Another file can be used witht the `--descriptor` option.
+
+The properties included in a descriptor file can be overriden by its counterpart command line options.
 
 ### Creating a widget
 A widget can be created by providing a link to an URL where the widget code is or by uploading the code itself. The CLI supports both ways:
 
 ```
-$ cli create --space SPACE_ID -f PATH_TO_FILE
+$ cli create --space-id SPACE_ID -f PATH_TO_FILE
 ```
 
 ```
-$ cli create --space SPACE_ID -u URL
+$ cli create --space-id SPACE_ID -u URL
 ```
  
 The id of the widget can be specified:
 
 ```
-$ cli create --space SPACE_ID --id ID -u URL
+$ cli create --space-id SPACE_ID --id ID -u URL
 ```
 
 ```
-$ cli create --space SPACE_ID --id ID -f PATH_TO_FILE
+$ cli create --space-id SPACE_ID --id ID -f PATH_TO_FILE
 ```
+
+A specific descriptor file can be used:
+
+```
+$ cli create --space-id SPACE_ID --descriptor /path/to/descriptor
+```
+
 
 ### Fetching a wiget
 Fetch a widget from the API:
@@ -34,28 +56,34 @@ $ cli read --space SPACE_ID --id ID
 A widget can be update by providing a link to an URL where the widget code is or by uploading the code itself. The CLI supports both ways:
 
 ```
-$ cli update --space SPACE_ID --id ID -u URL -v VERSION
+$ cli update --space-id SPACE_ID --id ID -u URL -v VERSION
 ```
 
 ```
-$ cli update --space SPACE_ID --id ID -f PATH_TO_FILE -v VERSION
+$ cli update --space-id SPACE_ID --id ID -f PATH_TO_FILE -v VERSION
 ```
 
 A widget ca also be updated without passing the version value. The cli will fetch the current representation of the widget and use its version as the version for the update.
 
 ```
-$ cli update --space SPACE_ID --id ID -u URL
+$ cli update --space-id SPACE_ID --id ID -u URL
 ```
 
 ```
-$ cli update --space SPACE_ID --id ID -f PATH_TO_FILE
+$ cli update --space-id SPACE_ID --id ID -f PATH_TO_FILE
+```
+
+A specific descriptor file can be used:
+
+```
+$ cli update --space-id SPACE_ID --descriptor /path/to/descriptor
 ```
  
 ### Deleting a widget
 A widget can be deleted:
 
 ```
-$ cli delete --space SPACE_ID --id ID
+$ cli delete --space-id SPACE_ID --id ID
 ```
 
 ## Miscellaneous

--- a/lib/cli/command/create.js
+++ b/lib/cli/command/create.js
@@ -1,34 +1,22 @@
 'use strict';
 
-var Bluebird = require('bluebird');
-var fs = require('fs');
 var Widget = require('../widget');
-
-var readFile = Bluebird.promisify(fs.readFile);
+var maybeExtendOptionsFromDescriptor = require('./utils/maybe-extend-options-from-descriptor');
+var maybeReadSrcdocFile = require('./utils/maybe-read-srcdoc-file');
 
 module.exports = function (options, context) {
-  if (options.file) {
-    readFile(options.file)
-      .then(function (contents) {
-        options.bundle = contents.toString();
-
-        new Widget(options, context).save()
-        .then(function (widget) {
-          console.log(widget);
-        })
-        .catch(function () {
-          console.error('Failed to create the widget');
-          process.exit(1);
-        });
-      });
-  } else {
-    new Widget(options, context).save()
+  return maybeExtendOptionsFromDescriptor(options)
+    .then(function () {
+      return maybeReadSrcdocFile(options);
+    })
+    .then(function () {
+      return new Widget(options, context).save();
+    })
     .then(function (widget) {
       console.log(widget);
     })
-    .catch(function () {
-      console.error('Failed to create the widget');
+    .catch(function (e) {
+      console.error(`Failed to create the widget: ${e.message}`);
       process.exit(1);
     });
-  }
 };

--- a/lib/cli/command/update.js
+++ b/lib/cli/command/update.js
@@ -1,77 +1,40 @@
 'use strict';
 
-var Bluebird = require('bluebird');
-var fs = require('fs');
 var Widget = require('../widget');
-
-var readFile = Bluebird.promisify(fs.readFile);
+var maybeExtendOptionsFromDescriptor = require('./utils/maybe-extend-options-from-descriptor');
+var maybeReadSrcdocFile = require('./utils/maybe-read-srcdoc-file');
 
 module.exports = function (options, context) {
-  if (options.file) {
-    readFile(options.file).then(function (contents) {
-      options.bundle = contents.toString();
+  return maybeExtendOptionsFromDescriptor(options)
+    .then(function () {
+      if (!options.id) {
+        throw new Error('missing id');
+      }
 
+      return maybeReadSrcdocFile(options);
+    })
+    .then(function () {
       if (!options.version) {
-        new Widget(options, context).read()
-          .catch(function () {
-            console.error('Failed to update the widget');
-            process.exit(1);
-          })
+        return new Widget(options, context).read()
           .then(function (response) {
             response = JSON.parse(response);
             let version = response.sys.version;
             options.version = version;
 
             return new Widget(options, context).save()
-            .then(function (widget) {
-              console.log(widget);
-            })
-            .catch(function () {
-              console.error('Failed to update the widget');
-              process.exit(1);
-            });
+              .then(function (widget) {
+                console.log(widget);
+              });
           });
       } else {
-        new Widget(options, context).save()
+        return new Widget(options, context).save()
         .then(function (widget) {
           console.log(widget);
-        })
-        .catch(function () {
-          console.error('Failed to update the widget');
-          process.exit(1);
         });
       }
+    })
+    .catch(function (e) {
+      console.error(`Failed to update the widget: ${e.message}`);
+      process.exit(1);
     });
-  } else {
-    if (!options.version) {
-      new Widget(options, context).read()
-        .catch(function () {
-          console.error('Failed to update the widget');
-          process.exit(1);
-        })
-        .then(function (response) {
-          response = JSON.parse(response);
-          let version = response.sys.version;
-          options.version = version;
-
-          return new Widget(options, context).save()
-            .then(function (widget) {
-              console.log(widget);
-            })
-            .catch(function () {
-              console.error('Failed to update the widget');
-              process.exit(1);
-            });
-        });
-    } else {
-      new Widget(options, context).save()
-      .then(function (widget) {
-        console.log(widget);
-      })
-      .catch(function () {
-        console.error('Failed to update the widget');
-        process.exit(1);
-      });
-    }
-  }
 };

--- a/lib/cli/command/utils/maybe-extend-options-from-descriptor.js
+++ b/lib/cli/command/utils/maybe-extend-options-from-descriptor.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var Bluebird = require('bluebird');
+var fs = require('fs');
+
+var readFile = Bluebird.promisify(fs.readFile);
+
+module.exports = function (options) {
+  return readFile(options.descriptor)
+  .then(function (contents) {
+    try {
+      return JSON.parse(contents.toString());
+    } catch (e) {
+      // include path to the offending file
+      throw new Error(`${options.descriptor} ${e.message}`);
+    }
+  })
+  .then(function (descriptor) {
+    if (!descriptor.id) {
+      throw new Error('missing id in descriptor file');
+    }
+
+    if (!descriptor.src && !descriptor.srcdoc) {
+      throw new Error('missing src and srcdoc in descriptor file');
+    }
+
+    if (!options.url) {
+      options.url = descriptor.src;
+    }
+
+    if (!options.id) {
+      options.id = descriptor.id;
+    }
+
+    if (!options.file) {
+      options.file = descriptor.srcdoc;
+    }
+  })
+  .catch(function (e) {
+    if (e.code === 'ENOENT') {
+      if (!options.file && !options.url) {
+        throw new Error('no widget descriptor or -f or -u options present');
+      }
+
+      return;
+    }
+
+    throw e;
+  });
+};

--- a/lib/cli/command/utils/maybe-read-srcdoc-file.js
+++ b/lib/cli/command/utils/maybe-read-srcdoc-file.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var Bluebird = require('bluebird');
+var fs = require('fs');
+
+var readFile = Bluebird.promisify(fs.readFile);
+
+module.exports = function (options) {
+  // TODO handle failures while reading file
+
+  if (!options.file) {
+    return Bluebird.resolve();
+  }
+
+  return readFile(options.file)
+    .then(function (contents) {
+      options.bundle = contents.toString();
+    });
+};

--- a/lib/cli/http.js
+++ b/lib/cli/http.js
@@ -5,7 +5,7 @@ var urljoin = require('url-join');
 
 exports.post = function (options, context) {
   let post = Bluebird.promisify(context.request.post);
-  let path = `/spaces/${options.space}/widgets`;
+  let path = `/spaces/${options.spaceId}/widgets`;
   let url = urljoin(context.host, path);
   let requestOpts = {
     url: url,
@@ -28,7 +28,7 @@ exports.post = function (options, context) {
 
 exports.put = function (options, context) {
   let put = Bluebird.promisify(context.request.put);
-  let url = urljoin(context.host, 'spaces', options.space, 'widgets', options.id);
+  let url = urljoin(context.host, 'spaces', options.spaceId, 'widgets', options.id);
   let requestOpts = {
     url: url,
     body: JSON.stringify(options.payload),
@@ -54,7 +54,7 @@ exports.put = function (options, context) {
 
 exports.get = function (options, context) {
   let get = Bluebird.promisify(context.request.get);
-  let path = `/spaces/${options.space}/widgets`;
+  let path = `/spaces/${options.spaceId}/widgets`;
   let url = urljoin(context.host, path, options.id);
   let requestOpts = {
     url: url,
@@ -76,7 +76,7 @@ exports.get = function (options, context) {
 
 exports.delete = function (options, context) {
   let del = Bluebird.promisify(context.request.del);
-  let url = urljoin(context.host, 'spaces', options.space, 'widgets', options.id);
+  let url = urljoin(context.host, 'spaces', options.spaceId, 'widgets', options.id);
   let requestOpts = {
     url: url,
     headers: {

--- a/lib/cli/widget.js
+++ b/lib/cli/widget.js
@@ -12,7 +12,7 @@ module.exports = class Widget {
     let bundle = this.options.bundle;
     let url = this.options.url;
     let verb = 'post';
-    let options = _.pick(this.options, ['space', 'id', 'version']);
+    let options = _.pick(this.options, ['spaceId', 'id', 'version']);
 
     if (options.id) {
       verb = 'put';

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,12 @@
+{
+  "extends": "../.eslintrc",
+  "rules": {
+    "semi": [2, "always"]
+  },
+  "globals": {
+    "describe": true,
+    "it": true,
+    "beforeEach": true,
+    "afterEach": true
+  }
+}

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,4 +1,4 @@
-var chai      = require('chai');
+var chai = require('chai');
 var dirtyChai = require('dirty-chai');
 var sinonChai = require('sinon-chai');
 

--- a/test/integration/commands-test.js
+++ b/test/integration/commands-test.js
@@ -4,7 +4,7 @@ var temp = require('temp');
 var _ = require('lodash');
 var Bluebird = require('bluebird');
 var fs = Bluebird.promisifyAll(require('fs'));
-var exec   = require('child_process').exec;
+var exec = require('child_process').exec;
 var path = require('path');
 
 var chai = require('../helper');
@@ -77,12 +77,12 @@ describe('Commands', function () {
         .then(assert.fail)
         .catch(function (error) {
           expect(error.error.code).to.eq(1);
-          expect(error.stderr).to.match(/One of -f or -u is required/);
+          expect(error.stderr).to.match(/no widget descriptor or -f or -u options present/);
         });
     });
 
     it('creates a widget', function () {
-      //TODO add test that works with host without protocol
+      // TODO add test that works with host without protocol
       return command('create --space-id 123 -u lol.com --host http://localhost:3000', execOptions)
         .then(function (stdout) {
           let widget = JSON.parse(stdout);
@@ -161,7 +161,7 @@ describe('Commands', function () {
     });
 
     it('fails if no --id option is provided', function () {
-      return command('update --space-id 123 -u foo.com --host http://localhost:3000', execOptions)
+      return command('read --space-id 123 -u foo.com --host http://localhost:3000', execOptions)
         .then(assert.fail)
         .catch(function (error) {
           expect(error.error.code).to.eq(1);
@@ -212,7 +212,7 @@ describe('Commands', function () {
         .then(assert.fail)
         .catch(function (error) {
           expect(error.error.code).to.eq(1);
-          expect(error.stderr).to.match(/Missing required argument: id/);
+          expect(error.stderr).to.match(/missing id/);
         });
     });
 
@@ -221,7 +221,7 @@ describe('Commands', function () {
         .then(assert.fail)
         .catch(function (error) {
           expect(error.error.code).to.eq(1);
-          expect(error.stderr).to.match(/One of -f or -u is required/);
+          expect(error.stderr).to.match(/no widget descriptor or -f or -u options present/);
         });
     });
 
@@ -416,7 +416,6 @@ describe('Commands', function () {
           expect(error.error.code).to.eq(1);
           expect(error.stderr).to.match(/Failed to delete the widget/);
         });
-
     });
 
     it('deletes a widget', function () {

--- a/test/integration/descriptor-file-test.js
+++ b/test/integration/descriptor-file-test.js
@@ -1,0 +1,384 @@
+'use strict';
+
+var temp = require('temp');
+var _ = require('lodash');
+var Bluebird = require('bluebird');
+var fs = Bluebird.promisifyAll(require('fs'));
+var path = require('path');
+
+var command = require('./helpers/command');
+var chai = require('../helper');
+var expect = chai.expect;
+var assert = chai.assert;
+
+var server = require('./http-server');
+
+
+function example (options, test) {
+  Object.keys(options).forEach(function (key) {
+    let commands = options[key];
+
+    if (!_.isArray(commands)) {
+      commands = [commands];
+    }
+
+    test(key, commands);
+  });
+}
+
+function runCommands (commands, execOptions) {
+  return function () {
+    return Bluebird.reduce(commands, function (acc, c) {
+      return command(c, execOptions);
+    }, []); // give some non 'undefined' initial value
+  };
+}
+
+describe('Descriptor file', function () {
+  beforeEach(function () {
+    server.start();
+  });
+
+  afterEach(function () {
+    server.stop();
+  });
+
+  let execOptions;
+
+  beforeEach(function () {
+    let env = _.clone(process.env);
+    env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN = 'lol-token';
+
+    execOptions = {env: env};
+  });
+
+  example({
+    create: 'create  --space-id 123 --descriptor ./descriptor.json --host http://localhost:3000',
+    update: [
+      'create --space-id 123 --id 123 -u foo.com --host http://localhost:3000',
+      'update --space-id 123 --descriptor ./descriptor.json --host http://localhost:3000'
+    ]
+  },
+  function (commandName, commands) {
+    let customDescriptor, customDescriptorPath;
+
+    describe('when a descriptor file is given', function () {
+      beforeEach(function () {
+        customDescriptor = {
+          id: '123',
+          src: 'foo.com'
+        };
+
+        customDescriptorPath = path.resolve(process.cwd(), 'descriptor.json');
+        return fs.writeFileAsync(customDescriptorPath, JSON.stringify(customDescriptor));
+      });
+
+      afterEach(function () {
+        return fs.unlinkAsync(customDescriptorPath);
+      });
+
+      it(`${commandName}s a widget`, function () {
+        return runCommands(commands, execOptions)()
+          .then(function (stdout) {
+            let widget = JSON.parse(stdout);
+
+            expect(widget.src).to.eql(customDescriptor.src);
+            expect(widget.sys.id).to.eql(customDescriptor.id);
+            expect(widget.sys.space.sys.id).to.eql('123');
+          });
+      });
+    });
+  });
+
+  describe('when the descriptor file does not exist', function () {
+    let customDescriptorPath = path.resolve(process.cwd(), 'descriptor.json');
+
+    example(
+      {
+        create: `create --space-id 123 --descriptor ${customDescriptorPath}`,
+        update: `update --space-id 123 --descriptor ${customDescriptorPath}`
+      },
+      function (commandName, commands) {
+        it(`${commandName}s returns an error`, function () {
+          return runCommands(commands, execOptions)()
+          .then(assert.fail)
+          .catch(function (error) {
+            let cause = 'no widget descriptor or -f or -u options present';
+            let msg = new RegExp(`Failed to ${commandName} the widget: ${cause}`);
+            expect(error.error.code).to.eq(1);
+            expect(error.stderr).to.match(msg);
+          });
+        });
+      }
+    );
+  });
+
+  describe('when the cli can not open the file', function () {
+    let customDescriptorPath = path.resolve(process.cwd(), 'descriptor.json');
+
+    beforeEach(function () {
+      return fs.writeFileAsync(customDescriptorPath, JSON.stringify({}))
+      .then(function () {
+        return fs.chmodAsync(customDescriptorPath, '300');
+      });
+    });
+
+    afterEach(function () {
+      return fs.unlinkAsync(customDescriptorPath);
+    });
+
+    example(
+      {
+        create: `create --space-id 123 --descriptor ${customDescriptorPath}`,
+        update: `update --space-id 123 --descriptor ${customDescriptorPath}`
+      },
+      function (commandName, commands) {
+        it(`${commandName} returns an error`, function () {
+          return runCommands(commands, execOptions)()
+          .then(assert.fail)
+          .catch(function (error) {
+            let cause = 'EACCES: permission denied, open \'.+\/descriptor\.json\'';
+            let msg = new RegExp(`Failed to ${commandName} the widget: ${cause}`);
+            expect(error.error.code).to.eq(1);
+            expect(error.stderr).to.match(msg);
+          });
+        });
+      }
+    );
+  });
+
+  describe('when there is a widget.json file present', function () {
+    let file, descriptor;
+
+    beforeEach(function () {
+      descriptor = {
+        id: '456',
+        src: 'lol.com'
+      };
+
+      file = path.resolve(process.cwd(), 'widget.json');
+      return fs.writeFileAsync(file, JSON.stringify(descriptor));
+    });
+
+    afterEach(function () {
+      return fs.unlinkAsync(file);
+    });
+
+    example(
+      {
+        create: 'create --space-id 123 --host http://localhost:3000',
+        update: [
+          'create --space-id 123 --id 456 -u foo.com --host http://localhost:3000',
+          'update --space-id 123 --host http://localhost:3000'
+        ]
+      },
+      function (commandName, commands) {
+        it(`${commandName}s the widget using the values in descriptor file`, function () {
+          return runCommands(commands, execOptions)()
+          .then(function (stdout) {
+            let widget = JSON.parse(stdout);
+
+            expect(widget.src).to.eql(descriptor.src);
+            expect(widget.sys.id).to.eql(descriptor.id);
+          });
+        });
+      }
+    );
+
+    describe('when the descriptor file has the srcdoc property set', function () {
+      let srdoc, bundle;
+
+      beforeEach(function () {
+        srdoc = temp.path();
+        bundle = 'the-bundle-contents';
+
+        return fs.writeFileAsync(srdoc, bundle);
+      });
+
+      afterEach(function () {
+        return fs.unlinkAsync(srdoc);
+      });
+
+      example(
+        {
+          create: 'create --space-id 123 --host http://localhost:3000',
+          update: [
+            'create --space-id 123 --id 456 -u foo.com --host http://localhost:3000',
+            'update --space-id 123 --host http://localhost:3000'
+          ]
+        },
+        function (commandName, commands) {
+          it(`${commandName}s the widget using the values in the descriptor file`, function () {
+            delete descriptor.src;
+            descriptor.srcdoc = srdoc;
+
+            return fs.writeFileAsync(file, JSON.stringify(descriptor))
+            .then(runCommands(commands, execOptions))
+            .then(function (stdout) {
+              let widget = JSON.parse(stdout);
+
+              expect(widget.srcdoc).to.eql(bundle);
+              expect(widget.sys.id).to.eql(descriptor.id);
+            });
+          });
+        }
+      );
+    });
+
+    example(
+      {
+        create: 'create --space-id 123 -u foo.com --host http://localhost:3000',
+        update: [
+          'create --space-id 123 --id 456  --host http://localhost:3000',
+          'update --space-id 123 -u foo.com --host http://localhost:3000'
+        ]
+      },
+      function (commandName, commands) {
+        it('src option ovewrites src property in the descriptor', function () {
+          return runCommands(commands, execOptions)()
+            .then(function (stdout) {
+              let widget = JSON.parse(stdout);
+
+              expect(widget.src).to.eql('foo.com');
+              expect(widget.sys.id).to.eql(descriptor.id);
+            });
+        });
+      }
+    );
+
+    describe('when the -f option is used', function () {
+      let srcdoc, bundle, f, b;
+
+      f = temp.path();
+
+      beforeEach(function () {
+        srcdoc = temp.path();
+        bundle = 'the-bundle-contents';
+        b = 'another-bundle';
+
+        return Bluebird.all([
+          fs.writeFileAsync(srcdoc, bundle),
+          fs.writeFileAsync(f, b)
+        ]);
+      });
+
+      afterEach(function () {
+        return Bluebird.all([
+          fs.unlinkAsync(srcdoc),
+          fs.unlinkAsync(f)
+        ]);
+      });
+
+      example(
+        {
+          create: `create --space-id 123 -f ${f} --host http://localhost:3000`,
+          update: [
+            'create --space-id 123 --id 456  --host http://localhost:3000',
+            `update --space-id 123 -f ${f} --host http://localhost:3000`
+          ]
+        },
+        function (commandName, commands) {
+          it('-f option overwrites srdoc property in the descriptor', function () {
+            delete descriptor.src;
+            descriptor.srcdoc = srcdoc;
+
+            return fs.writeFileAsync(file, JSON.stringify(descriptor))
+            .then(runCommands(commands, execOptions))
+            .then(function (stdout) {
+              let widget = JSON.parse(stdout);
+
+              expect(widget.srcdoc).to.eql(b);
+              expect(widget.sys.id).to.eql(descriptor.id);
+            });
+          });
+        }
+      );
+    });
+
+    example(
+      {
+        create: 'create --space-id 123 --id 88 --host http://localhost:3000',
+        update: [
+          // TODO: use a different file when updating (or modify the
+          // existing) one as now we are using the same descriptor file
+          'create --space-id 123 --id 88 --host http://localhost:3000',
+          'update --space-id 123 --id 88 --host http://localhost:3000'
+        ]
+      },
+      function (commandName, commands) {
+        it('id option overwrites id property in the descriptor', function () {
+          return runCommands(commands, execOptions)()
+            .then(function (stdout) {
+              let widget = JSON.parse(stdout);
+
+              expect(widget.src).to.eql(descriptor.src);
+              expect(widget.sys.id).to.eql('88');
+            });
+        });
+      }
+    );
+
+    example(
+      {
+        create: 'create --space-id 123  --host http://localhost:3000',
+        update: 'update --space-id 123  --host http://localhost:3000'
+
+      },
+      function (commandName, commands) {
+        it('errors when the descriptor file is not valid JSON', function () {
+          return fs.writeFileAsync(file, 'not-valid-json')
+            .then(runCommands(commands, execOptions))
+            .then(assert.fail)
+            .catch(function (error) {
+              let cause = '.+\/widget\.json Unexpected token o';
+              let regexp = new RegExp(`Failed to ${commandName} the widget: ${cause}`);
+              expect(error.error.code).to.eq(1);
+              expect(error.stderr).to.match(regexp);
+            });
+        });
+      }
+    );
+
+    example(
+      {
+        create: 'create --space-id 123 --host http://localhost:3000',
+        update: 'update --space-id 123 --host http://localhost:3000'
+      },
+      function (commandName, commands) {
+        it('errors when there are missing properties on the file (id)', function () {
+          descriptor = {src: 'foo.com'};
+
+          return fs.writeFileAsync(file, JSON.stringify(descriptor))
+            .then(runCommands(commands, execOptions))
+            .then(assert.fail)
+            .catch(function (error) {
+              let regexp = new RegExp(`Failed to ${commandName} the widget`);
+              expect(error.error.code).to.eq(1);
+              expect(error.stderr).to.match(regexp);
+            });
+        });
+      }
+    );
+
+    example(
+      {
+        create: 'create --space-id 123 --host http://localshot:3000',
+        update: 'update --space-id 123 --host http://localshot:3000'
+      },
+      function (commandName, commands) {
+        it('errors when there are missing properties on the file (src or srcdoc)', function () {
+          descriptor = {id: 123};
+
+          return fs.writeFileAsync(file, JSON.stringify(descriptor))
+            .then(runCommands(commands, execOptions))
+            .then(assert.fail)
+            .catch(function (error) {
+              let msg = new RegExp(`Failed to ${commandName} the widget: missing src and srcdoc in descriptor file`);
+              expect(error.error.code).to.eq(1);
+              expect(error.stderr).to.match(msg);
+            });
+        });
+      }
+    );
+  });
+});

--- a/test/integration/helpers/command.js
+++ b/test/integration/helpers/command.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var path = require('path');
+var Bluebird = require('bluebird');
+var exec = require('child_process').exec;
+
+module.exports = function command (subcommand, options) {
+  let binary = path.resolve(__dirname, '../../../bin/cf-widget');
+
+  // TODO incllude the --host option in the exec call
+  // to remove duplication from the tests
+  return new Bluebird(function (resolve, reject) {
+    exec(`${binary} ${subcommand}`, options, function (error, stdout, stderr) {
+      if (error) {
+        return reject({error: error, stderr: stderr});
+      }
+
+      resolve(stdout);
+    });
+  });
+};

--- a/test/unit/cli/cf-widget-create-test.js
+++ b/test/unit/cli/cf-widget-create-test.js
@@ -1,9 +1,0 @@
-'use strict';
-
-var sinon = require('sinon');
-
-var expect = require('../../helper').expect;
-var http = require('../../../lib/cli/http');
-
-describe('cf-widget-create', function () {
-});

--- a/test/unit/cli/http-test.js
+++ b/test/unit/cli/http-test.js
@@ -31,7 +31,7 @@ describe('http', function () {
   describe('#get', function () {
     it('when the host includes a port', function () {
       let options = {
-        space: 123,
+        spaceId: 123,
         id: 456
       };
 
@@ -52,7 +52,7 @@ describe('http', function () {
 
     it('makes a GET request to the API', function () {
       let options = {
-        space: 123,
+        spaceId: 123,
         id: 456
       };
 
@@ -71,7 +71,7 @@ describe('http', function () {
 
     it('returns a JSON object', function () {
       let options = {
-        space: 123,
+        spaceId: 123,
         id: 456
       };
 
@@ -82,7 +82,7 @@ describe('http', function () {
 
     it('throws an error if the response status is not 200', function () {
       let options = {
-        space: 123,
+        spaceId: 123,
         id: 456
       };
 
@@ -97,7 +97,7 @@ describe('http', function () {
   describe('#post', function () {
     it('makes a POST request to the API', function () {
       let options = {
-        space: 123,
+        spaceId: 123,
         payload: {foo: 'bar'}
       };
 
@@ -117,7 +117,7 @@ describe('http', function () {
 
     it('throws an error if the response status is not 201', function () {
       let options = {
-        space: 123,
+        spaceId: 123,
         payload: {foo: 'bar'}
       };
 
@@ -133,7 +133,7 @@ describe('http', function () {
     describe('when a version option is not present', function () {
       it('makes a PUT request to the API', function () {
         let options = {
-          space: 123,
+          spaceId: 123,
           payload: {foo: 'bar'},
           id: 456
         };
@@ -156,9 +156,9 @@ describe('http', function () {
 
       it('throws an error if the response status is not 201', function () {
         let options = {
-          space: 123,
+          spaceId: 123,
           payload: {foo: 'bar'},
-          id: 456,
+          id: 456
         };
 
         requestStub.put.onFirstCall().callsArgWith(1, null, {statusCode: 400});
@@ -172,10 +172,10 @@ describe('http', function () {
     describe('when a version option is present', function () {
       it('makes a PUT request to the API', function () {
         let options = {
-          space: 123,
+          spaceId: 123,
           payload: {foo: 'bar'},
           id: 456,
-          version: 33,
+          version: 33
         };
 
         requestStub.put.onFirstCall().callsArgWith(1, null, {statusCode: 200});
@@ -197,7 +197,7 @@ describe('http', function () {
 
       it('throws an error if the response status is not 200', function () {
         let options = {
-          space: 123,
+          spaceId: 123,
           payload: {foo: 'bar'},
           id: 456,
           version: 33
@@ -215,7 +215,7 @@ describe('http', function () {
   describe('#delete', function () {
     it('makes a DELETE request to the API', function () {
       let options = {
-        space: 123,
+        spaceId: 123,
         id: 456,
         version: 33
       };

--- a/test/unit/cli/widget-test.js
+++ b/test/unit/cli/widget-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var sinon    = require('sinon');
+var sinon = require('sinon');
 var Bluebird = require('bluebird');
 var _ = require('lodash');
 
@@ -24,7 +24,7 @@ describe('Widget', function () {
     describe('when an id has been provided', function () {
       beforeEach(function () {
         options = {
-          space: 123,
+          spaceId: 123,
           url: 'the-url',
           id: 456
         };
@@ -36,7 +36,7 @@ describe('Widget', function () {
         return widget.save().then(function () {
           expect(http.put).to.have.been.calledWith(
             {
-              space: options.space,
+              spaceId: options.spaceId,
               payload: {src: options.url},
               id: options.id
             },
@@ -52,7 +52,7 @@ describe('Widget', function () {
           return widget.save().then(function () {
             expect(http.put).to.have.been.calledWith(
               {
-                space: options.space,
+                spaceId: options.spaceId,
                 payload: {src: options.url},
                 id: options.id,
                 version: options.version
@@ -67,7 +67,7 @@ describe('Widget', function () {
     describe('when a bundle has been provided', function () {
       beforeEach(function () {
         options = {
-          space: 123,
+          spaceId: 123,
           bundle: 'the-bundle'
         };
 
@@ -78,7 +78,7 @@ describe('Widget', function () {
         return widget.save().then(function () {
           expect(http.post).to.have.been.calledWith(
             {
-              space: options.space,
+              spaceId: options.spaceId,
               payload: {srcdoc: options.bundle}
             },
             context
@@ -90,7 +90,7 @@ describe('Widget', function () {
     describe('when a URL has been provided', function () {
       beforeEach(function () {
         options = {
-          space: 123,
+          spaceId: 123,
           url: 'the-url'
         };
 
@@ -101,7 +101,7 @@ describe('Widget', function () {
         return widget.save().then(function () {
           expect(http.post).to.have.been.calledWith(
             {
-              space: options.space,
+              spaceId: options.spaceId,
               payload: {src: options.url}
             },
             context
@@ -114,7 +114,7 @@ describe('Widget', function () {
   describe('#read', function () {
     beforeEach(function () {
       options = {
-        space: 123,
+        spaceId: 123,
         id: 456
       };
 
@@ -125,7 +125,7 @@ describe('Widget', function () {
       return widget.read().then(function () {
         expect(http.get).to.have.been.calledWith(
           {
-            space: options.space,
+            spaceId: options.spaceId,
             id: options.id
           },
           context
@@ -137,7 +137,7 @@ describe('Widget', function () {
   describe('#delete', function () {
     beforeEach(function () {
       options = {
-        space: 123,
+        spaceId: 123,
         id: 456
       };
 
@@ -148,7 +148,7 @@ describe('Widget', function () {
       return widget.delete().then(function () {
         expect(http.delete).to.have.been.calledWith(
           {
-            space: options.space,
+            spaceId: options.spaceId,
             id: options.id
           },
           context


### PR DESCRIPTION
## Summary

This PR brings support to use descriptor files to create widgets. Right now it only looks for the `src`, `srcdoc` and `id`. Support for other properties will added in following PRs.
