### PR TITLE
Set locale when testing yargs output

### DIFF
--- a/test/integration/commands-test.js
+++ b/test/integration/commands-test.js
@@ -41,6 +41,7 @@ describe('Commands', function () {
   beforeEach(function () {
     let env = _.clone(process.env);
     env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN = 'lol-token';
+    env.LC_ALL = 'en_US';
 
     execOptions = {env: env};
   });


### PR DESCRIPTION
When the locale comes from the execution environment and is different
from 'en_US' the tests may fail
