### PR TITLE
Force update without version

### DIFF
--- a/bin/cf-widget-update
+++ b/bin/cf-widget-update
@@ -63,6 +63,10 @@ yargs
     type: 'boolean',
     default: undefined
   },
+  'force': {
+    description: 'Force update without explicit version',
+    type: 'boolean'
+  },
   'host': {
     description: 'API host',
     type: 'string',
@@ -82,6 +86,7 @@ options.spaceId = argv.spaceId;
 options.descriptor = argv.descriptor;
 options.fieldTypes = argv.fieldTypes;
 options.sidebar = argv.sidebar;
+options.force = argv.force;
 
 let context = {
   host: argv.host || 'https://api.contentful.com',

--- a/lib/cli/command/update.js
+++ b/lib/cli/command/update.js
@@ -19,6 +19,10 @@ module.exports = function (options, context) {
       if (options.version) {
         return options;
       } else {
+        if (!options.force) {
+          throw new Error('to update without version use the --force flag');
+        }
+
         return loadCurrentVersion(options, context);
       }
     }).then(function (options) {

--- a/test/integration/commands-test.js
+++ b/test/integration/commands-test.js
@@ -322,9 +322,21 @@ describe('Commands', function () {
         });
     });
 
+    it('fails to update the widget if no version is given and force option not present', function () {
+      let updateCmd = 'update --space-id 123 --id 456 --src foo.com --host http://localhost:3000';
+
+      return command(updateCmd, execOptions)
+        .then(assert.fail)
+        .catch(function (error) {
+          let msg = /to update without version use the --force flag/;
+          expect(error.error.code).to.eql(1);
+          expect(error.stderr).to.match(msg);
+        });
+    });
+
     it('updates a widget without explicitely giving it version', function () {
       let createCmd = 'create --space-id 123 --name lol --src lol.com --id 456 --host http://localhost:3000';
-      let updateCmd = 'update --space-id 123 --id 456 --src foo.com --host http://localhost:3000';
+      let updateCmd = 'update --space-id 123 --id 456 --src foo.com --force --host http://localhost:3000';
 
       return command(createCmd, execOptions)
         .then(function () {
@@ -350,7 +362,7 @@ describe('Commands', function () {
 
     it('updates the name of a widget', function () {
       let createCmd = 'create --space-id 123 --name lol --src l.com --id 456 --name foo --host http://localhost:3000';
-      let updateCmd = 'update --space-id 123 --id 456 --name doge --host http://localhost:3000';
+      let updateCmd = 'update --space-id 123 --id 456 --name doge --force --host http://localhost:3000';
 
       return command(createCmd, execOptions)
         .then(function () {
@@ -365,7 +377,7 @@ describe('Commands', function () {
 
     it('upates the fieldTypes of a widget', function () {
       let createCmd = 'create --space-id 123 --name lol --src l.com --id 456 --name foo --host http://localhost:3000';
-      let updateCmd = 'update --space-id 123 --id 456 --field-types t1 t2 --host http://localhost:3000';
+      let updateCmd = 'update --space-id 123 --id 456 --field-types t1 t2 --force --host http://localhost:3000';
 
       return command(createCmd, execOptions)
         .then(function () {
@@ -380,7 +392,7 @@ describe('Commands', function () {
 
     it('updates the sibebar property to true', function () {
       let createCmd = 'create --space-id 123 --name lol --src l.com --id 456 --name foo --no-sidebar --host http://localhost:3000';
-      let updateCmd = 'update --space-id 123 --id 456 --sidebar --host http://localhost:3000';
+      let updateCmd = 'update --space-id 123 --id 456 --sidebar --force --host http://localhost:3000';
 
       return command(createCmd, execOptions)
       .then(function () {
@@ -395,7 +407,7 @@ describe('Commands', function () {
 
     it('updates the sidebar property to false', function () {
       let createCmd = 'create --space-id 123 --name lol --src l.com --id 456 --name foo --sidebar --host http://localhost:3000';
-      let updateCmd = 'update --space-id 123 --id 456 --no-sidebar --host http://localhost:3000';
+      let updateCmd = 'update --space-id 123 --id 456 --no-sidebar --force --host http://localhost:3000';
 
       return command(createCmd, execOptions)
       .then(function () {
@@ -410,7 +422,7 @@ describe('Commands', function () {
 
     it('does not update the sidebar property', function () {
       let createCmd = 'create --space-id 123 --name lol --src l.com --id 456 --name foo --sidebar --host http://localhost:3000';
-      let updateCmd = 'update --space-id 123 --id 456 --name foo --host http://localhost:3000';
+      let updateCmd = 'update --space-id 123 --id 456 --name foo --force --host http://localhost:3000';
 
       return command(createCmd, execOptions)
       .then(function () {
@@ -437,7 +449,7 @@ describe('Commands', function () {
 
       it('reports the error when the API request fails (without version)', function () {
         let createCmd = 'create --space-id 123 --name lol --src lol.com --id fail-update --host http://localhost:3000';
-        let updateCmd = `update --space-id 123 --id fail-update --srcdoc ${file} --host http://localhost:3000`;
+        let updateCmd = `update --space-id 123 --id fail-update --srcdoc ${file} --force --host http://localhost:3000`;
 
         return command(createCmd, execOptions)
           .then(function () {
@@ -451,7 +463,7 @@ describe('Commands', function () {
       });
 
       it('reports the error when the API request fails (without version, reading current)', function () {
-        let updateCmd = `update --space-id 123 --id fail --srcdoc ${file} --host http://localhost:3000`;
+        let updateCmd = `update --space-id 123 --id fail --srcdoc ${file} --force --host http://localhost:3000`;
 
         return command(updateCmd, execOptions)
           .then(assert.fail)
@@ -463,7 +475,7 @@ describe('Commands', function () {
 
       it('reports the error when the API request fails (with version)', function () {
         let createCmd = 'create --space-id 123 --name lol --src lol.com --id fail-update --host http://localhost:3000';
-        let updateCmd = `update --space-id 123 -v 1 --id fail-update --srcdoc ${file} --host http://localhost:3000`;
+        let updateCmd = `update --space-id 123 -v 1 --id fail-update --srcdoc ${file} --force --host http://localhost:3000`;
 
         return command(createCmd, execOptions)
           .then(function () {
@@ -478,7 +490,7 @@ describe('Commands', function () {
 
       it('updates a widget from a file without explicitely giving its version', function () {
         let createCmd = 'create --space-id 123 --name lol --src lol.com --id 456 --host http://localhost:3000';
-        let updateCmd = `update --space-id 123 --id 456 --srcdoc ${file} --host http://localhost:3000`;
+        let updateCmd = `update --space-id 123 --id 456 --srcdoc ${file} --force --host http://localhost:3000`;
 
         return command(createCmd, execOptions)
           .then(function () {

--- a/test/integration/descriptor-file-test.js
+++ b/test/integration/descriptor-file-test.js
@@ -76,7 +76,7 @@ describe('Descriptor file', function () {
       create: `create  --space-id 123 --descriptor ${customDescriptorPath} --host http://localhost:3000`,
       update: [
         'create --space-id 123 --id 123 --name lol --src foo.com --host http://localhost:3000',
-        `update --space-id 123 --descriptor ${customDescriptorPath} --host http://localhost:3000`
+        `update --space-id 123 --descriptor ${customDescriptorPath} --force --host http://localhost:3000`
       ]
     },
     function (commandName, commands) {
@@ -178,7 +178,7 @@ describe('Descriptor file', function () {
         create: 'create --space-id 123 --host http://localhost:3000',
         update: [
           'create --space-id 123 --id 456 --src foo.com --host http://localhost:3000',
-          'update --space-id 123 --host http://localhost:3000'
+          'update --space-id 123 --force --host http://localhost:3000'
         ]
       },
       function (commandName, commands) {
@@ -214,7 +214,7 @@ describe('Descriptor file', function () {
           create: 'create --space-id 123 --host http://localhost:3000',
           update: [
             'create --space-id 123 --id 456 --src foo.com --host http://localhost:3000',
-            'update --space-id 123 --host http://localhost:3000'
+            'update --space-id 123 --force --host http://localhost:3000'
           ]
         },
         function (commandName, commands) {
@@ -240,7 +240,7 @@ describe('Descriptor file', function () {
         create: 'create --space-id 123 --src foo.com --host http://localhost:3000',
         update: [
           'create --space-id 123 --id 456  --host http://localhost:3000',
-          'update --space-id 123 --src foo.com --host http://localhost:3000'
+          'update --space-id 123 --src foo.com --force --host http://localhost:3000'
         ]
       },
       function (commandName, commands) {
@@ -261,7 +261,7 @@ describe('Descriptor file', function () {
         create: 'create --space-id 123 --name doge --host http://localhost:3000',
         update: [
           'create --space-id 123 --id 456  --host http://localhost:3000',
-          'update --space-id 123 --name doge --host http://localhost:3000'
+          'update --space-id 123 --name doge --force --host http://localhost:3000'
         ]
       },
       function (commandName, commands) {
@@ -282,7 +282,7 @@ describe('Descriptor file', function () {
         create: 'create --space-id 123 --field-types t3 t4 --host http://localhost:3000',
         update: [
           'create --space-id 123 --id 456  --host http://localhost:3000',
-          'update --space-id 123 --field-types t3 t4 --host http://localhost:3000'
+          'update --space-id 123 --field-types t3 t4 --force --host http://localhost:3000'
         ]
       },
       function (commandName, commands) {
@@ -326,7 +326,7 @@ describe('Descriptor file', function () {
           create: `create --space-id 123 --srcdoc ${f} --host http://localhost:3000`,
           update: [
             'create --space-id 123 --id 456  --host http://localhost:3000',
-            `update --space-id 123 --srcdoc ${f} --host http://localhost:3000`
+            `update --space-id 123 --srcdoc ${f} --force --host http://localhost:3000`
           ]
         },
         function (commandName, commands) {
@@ -354,7 +354,7 @@ describe('Descriptor file', function () {
           // TODO: use a different file when updating (or modify the
           // existing) one as now we are using the same descriptor file
           'create --space-id 123 --id 88 --host http://localhost:3000',
-          'update --space-id 123 --id 88 --host http://localhost:3000'
+          'update --space-id 123 --id 88 --force --host http://localhost:3000'
         ]
       },
       function (commandName, commands) {
@@ -375,7 +375,7 @@ describe('Descriptor file', function () {
         create: 'create --space-id 123 --id 88 --no-sidebar --host http://localhost:3000',
         update: [
           'create --space-id 123 --id 88 --name foo --host http://localhost:3000',
-          'update --space-id 123 --id 88 --no-sidebar --host http://localhost:3000'
+          'update --space-id 123 --id 88 --no-sidebar --force --host http://localhost:3000'
         ]
       },
       function (commandName, commands) {
@@ -478,16 +478,12 @@ describe('Descriptor file', function () {
           create: `create  --space-id 123 --descriptor ${customDescriptorPath} --host http://localhost:3000`,
           update: [
             'create --space-id 123 --id desc-123 --name lol --src foo.com --host http://localhost:3000',
-            `update --space-id 123 --descriptor ${customDescriptorPath} --host http://localhost:3000`
+            `update --space-id 123 --descriptor ${customDescriptorPath} --force --host http://localhost:3000`
           ]
         },
         function (commandName, commands) {
           it(`${commandName}s a widget`, function () {
             return runCommands(commands, execOptions)()
-            .catch(function (err) {
-              var util = require('util');
-              console.log(util.inspect(err, {showHidden: false, depth: null}));
-            })
             .then(function (stdout) {
               let widget = JSON.parse(stdout);
 


### PR DESCRIPTION
## Summary

**note** this PR is based on https://github.com/contentful/widget-sdk/pull/11

Before this PR customers had the possibility to update widgets without giving the current version number of the widget in question. This opened the door to accidental overwrites.

This PR introduces the `--force` flag. If a customer wants to update a widget without giving its version number he will have to explicitly use the `--force` flag.
