### PR TITLE
Force delete without version

### DIFF
--- a/bin/cf-widget-delete
+++ b/bin/cf-widget-delete
@@ -35,6 +35,10 @@ yargs
     type: 'string',
     requiresArg: true
   },
+  'force': {
+    description: 'Force delete without explicit version',
+    type: 'boolean'
+  },
   'host': {
     description: 'API host',
     type: 'string',
@@ -48,6 +52,7 @@ let options = {};
 options.id = argv.id;
 options.spaceId = argv.spaceId;
 options.version = argv.v;
+options.force = argv.force;
 
 let urlInfo = url.parse(argv.host || 'https://api.contentful.com');
 let host = urlInfo.host;

--- a/lib/cli/command/delete.js
+++ b/lib/cli/command/delete.js
@@ -4,6 +4,10 @@ var Widget = require('../widget');
 
 module.exports = function (options, context) {
   if (!options.version) {
+    if (!options.force) {
+      throw new Error('to delete without version use the --force flag');
+    }
+
     return new Widget(options, context).read()
       .catch(function () {
         console.error('Failed to delete the widget');

--- a/test/integration/commands-test.js
+++ b/test/integration/commands-test.js
@@ -526,8 +526,17 @@ describe('Commands', function () {
         });
     });
 
+    it('fails to delete the widget if no version is given and force option not present', function () {
+      return command('delete --space-id 123 --src foo.com --id 456 --host http://localshot', execOptions)
+        .then(assert.fail)
+        .catch(function (error) {
+          expect(error.error.code).to.eq(1);
+          expect(error.stderr).to.match(/to delete without version use the --force flag/);
+        });
+    });
+
     it('reports the error when the API request fails (without version, reading current)', function () {
-      let cmd = 'delete --space-id 123 --id fail --host http://localhost:3000';
+      let cmd = 'delete --space-id 123 --id fail --force --host http://localhost:3000';
 
       return command(cmd, execOptions)
         .then(assert.fail)
@@ -539,7 +548,7 @@ describe('Commands', function () {
 
     it('reports the error when the API request fails (without version, deleting)', function () {
       let createCmd = 'create --space-id 123 --name lol --src lol.com --id fail-delete --host http://localhost:3000';
-      let deleteCmd = 'delete --space-id 123 --id fail-delete --host http://localhost:3000';
+      let deleteCmd = 'delete --space-id 123 --id fail-delete --force --host http://localhost:3000';
 
       return command(createCmd, execOptions)
         .then(function () {
@@ -580,7 +589,7 @@ describe('Commands', function () {
 
     it('deletes a widget without explicitely giving its version', function () {
       let createCmd = 'create --space-id 123 --name lol --src lol.com --id 456 --host http://localhost:3000';
-      let deleteCmd = 'delete --space-id 123 --id 456 --host http://localhost:3000';
+      let deleteCmd = 'delete --space-id 123 --id 456 --force --host http://localhost:3000';
 
       return command(createCmd, execOptions)
         .then(function () {


### PR DESCRIPTION
## Summary

**note** this PR is based on https://github.com/contentful/widget-sdk/pull/13.Will rebase on top of `master` once #13  has been merged.

Before this PR customers had the possibility to delete widgets without giving the current version number of the widget in question. This opened the door to accidental deletions.

This PR introduces the `--force` flag for deleteions. If a customer wants to delete a widget without giving its version number he will have to explicitly use the `--force` flag.
