### PR TITLE
Cleanup contentful widget

### DIFF
--- a/bin/contentful-widget
+++ b/bin/contentful-widget
@@ -4,15 +4,10 @@
 
 var path = require('path');
 var fs = require('fs');
-
 var _ = require('lodash');
 var yargs = require('yargs');
 
-// TODO: use yargs.demand to require at least one command
-// TODO: get the names of the available commands
-// from the executables in bin/cf-widget-X
-var yargs = require('yargs')
-  .command('read')
+yargs.command('read')
   .command('update')
   .command('delete')
   .command('create');


### PR DESCRIPTION
## Summary

**note** this PR is based on https://github.com/contentful/widget-sdk/pull/18. Will rebase on top of `master` once #18 has been merged.

Remove some leftover comments and fix a linting issue in the `bin/contentful-widget` executable.
