### PR TITLE
Add --help flag to all commands

### DIFF
--- a/lib/cli/bin-helpers/command.js
+++ b/lib/cli/bin-helpers/command.js
@@ -6,10 +6,15 @@ var http = require('../http');
 var flags = require('./flags');
 
 module.exports = function (name) {
-  var command = require(`../command/${name}`);
+  let command = require(`../command/${name}`);
+  let options = flags.for(name);
+
+  if (options.help) {
+    console.log(flags.helpFor(name));
+    process.exit(0);
+  }
 
   let token = ensureCMAtoken();
-  let options = flags.for(name);
   let context = setupCommandContext({token: token, host: options.host});
 
   command(options, context);

--- a/lib/cli/bin-helpers/flags.js
+++ b/lib/cli/bin-helpers/flags.js
@@ -7,6 +7,11 @@ var yargs = require('yargs');
 yargs.locale('en');
 
 let OPTIONS = {
+  'help': {
+    description: 'Show this help',
+    type: 'boolean',
+    for: 'all'
+  },
   'space-id': {
     required: true,
     description: 'Id of a space in Contentful',
@@ -95,6 +100,13 @@ exports.for = function (command) {
   let ARGVValues = ARGVValuesForCommand(argv, optionDescriptors, command);
 
   return ARGVValues;
+};
+
+exports.helpFor = function (command) {
+  let optionDescriptors = optionDescriptorsForCommand(command);
+  let argv = yargs.options(optionDescriptors);
+
+  return argv.help();
 };
 
 function optionDescriptorsForCommand (command) {


### PR DESCRIPTION
## Summary

This PR brings the `--help` flag to all the commands. Including this flag when executing a command will print the help output generated by `yargs`.
