### PR TITLE
Override OS locale and LC_ALL with `en` locale

### DIFF
--- a/lib/cli/bin-helpers/flags.js
+++ b/lib/cli/bin-helpers/flags.js
@@ -3,6 +3,9 @@
 var _ = require('lodash');
 var yargs = require('yargs');
 
+// Override OS locale and LC_ALL
+yargs.locale('en');
+
 let OPTIONS = {
   'space-id': {
     required: true,


### PR DESCRIPTION
## Summary

As pointed out by @geigerzaehler (https://github.com/contentful/widget-sdk/pull/8) the integration tests will :boom: if another locale but the :gb: is present.  With this PR we override the locale set in the OS and also the env variable `LC_ALL`.
