### PR TITLE
--src and --srcdoc take exclude srcdoc and src

### DIFF
--- a/lib/cli/command/utils/maybe-extend-options.js
+++ b/lib/cli/command/utils/maybe-extend-options.js
@@ -25,6 +25,17 @@ function findMissingOptions (options, specs) {
 }
 
 module.exports = function (options, descriptor, required) {
+  // --src and --srcdoc options exclude src and srdoc
+  // properties in descriptor file
+
+  if (options.src) {
+    descriptor = _.omit(descriptor, 'srcdoc');
+  }
+
+  if (options.srcdoc) {
+    descriptor = _.omit(descriptor, 'src');
+  }
+
   return Bluebird.try(function () {
     options = _.defaults(options, descriptor);
 

--- a/test/integration/commands-test.js
+++ b/test/integration/commands-test.js
@@ -588,7 +588,7 @@ describe('Commands', function () {
       });
     });
 
-    it('does not update the sidebar property', function () {
+    it('removes the sidebar property (when ommited)', function () {
       let createCmd = 'create --space-id 123 --name lol --src l.com --id 456 --name foo --sidebar --host http://localhost:3000';
       let updateCmd = 'update --space-id 123 --id 456 --name foo --force --host http://localhost:3000';
 
@@ -599,7 +599,7 @@ describe('Commands', function () {
       .then(function (stdout) {
         let widget = JSON.parse(stdout);
 
-        expect(widget.sidebar).to.be.true();
+        expect(widget).to.not.have.ownProperty('sidebar');
       });
     });
 

--- a/test/integration/descriptor-file-test.js
+++ b/test/integration/descriptor-file-test.js
@@ -235,6 +235,32 @@ describe('Descriptor file', function () {
           });
         }
       );
+
+      example(
+        {
+          create: 'create --space-id 123 --src foo.com --host http://localhost:3000',
+          update: [
+            'create --space-id 123 --src wow.com --host http://localhost:3000',
+            'update --space-id 123 --src foo.com --force --host http://localhost:3000'
+          ]
+        },
+        function (commandName, commands) {
+          it(`${commandName} --src excludes the srdoc property in the descriptor`, function () {
+            delete descriptor.src;
+            descriptor.srcdoc = srdoc;
+
+            return fs.writeFileAsync(file, JSON.stringify(descriptor))
+            .then(runCommands(commands, execOptions))
+            .then(function (stdout) {
+              let widget = JSON.parse(stdout);
+
+              expect(widget).to.not.have.ownProperty('srcdoc');
+              expect(widget.src).to.eql('foo.com');
+              expect(widget.sys.id).to.eql(descriptor.id);
+            });
+          });
+        }
+      );
     });
 
     example(
@@ -341,6 +367,29 @@ describe('Descriptor file', function () {
             .then(function (stdout) {
               let widget = JSON.parse(stdout);
 
+              expect(widget.srcdoc).to.eql(b);
+              expect(widget.sys.id).to.eql(descriptor.id);
+            });
+          });
+        }
+      );
+
+      example(
+        {
+          create: `create --space-id 123 --srcdoc ${f} --host http://localhost:3000`,
+          update: [
+            'create --space-id 123 --id 456  --host http://localhost:3000',
+            `update --space-id 123 --srcdoc ${f} --force --host http://localhost:3000`
+          ]
+        },
+        function (commandName, commands) {
+          it(`${commandName} --srcdoc excludes the src property in the descriptor`, function () {
+            return fs.writeFileAsync(file, JSON.stringify(descriptor))
+            .then(runCommands(commands, execOptions))
+            .then(function (stdout) {
+              let widget = JSON.parse(stdout);
+
+              expect(widget).to.not.have.ownProperty('src');
               expect(widget.srcdoc).to.eql(b);
               expect(widget.sys.id).to.eql(descriptor.id);
             });

--- a/test/integration/http-server.js
+++ b/test/integration/http-server.js
@@ -72,7 +72,9 @@ app.put('/spaces/:space/widgets/:id', function (req, res) {
       res.status(409);
       res.end();
     } else {
-      widget = _.extend(widget, req.body);
+      let sys = widget.sys;
+      widget = req.body;
+      widget.sys = sys;
       widget.sys.version = widget.sys.version + 1;
       res.json(widget);
       res.status(200);


### PR DESCRIPTION
## Summary

This PR contains the following changes:
- If there's a descriptor file and it contains a `src` property and the CLI is run with the `--srdoc` option then the value of `--srcdoc` is used and the `src` property in the descriptor file is ignored.
- If there's a descriptor file and it contains a `srcdoc` property and the CLI is run with the `--src` option then the value of `--src` is used and the `srcdoc` property in the descriptor file is ignored.
