### PR TITLE
CLI: format widget according to schema

### DIFF
--- a/lib/cli/widget.js
+++ b/lib/cli/widget.js
@@ -17,9 +17,9 @@ module.exports = class Widget {
     let options = _.pick(this.options, ['spaceId', 'id', 'version']);
 
     let payloadProperties = ['src', 'srcdoc', 'name', 'fieldTypes', 'sidebar'];
-    let payload = _.pick(this.options, payloadProperties);
+    let payloadData = _.pick(this.options, payloadProperties);
 
-    options.payload = payload;
+    options.payload = buildAPIPayload(payloadData);
 
     if (options.id) {
       verb = 'put';
@@ -36,3 +36,45 @@ module.exports = class Widget {
     return this.context.http.delete(this.options, this.context);
   }
 };
+
+function buildAPIPayload (data) {
+  let widget = data;
+
+  if (data.fieldTypes) {
+    widget.fieldTypes = data.fieldTypes.map(fieldType);
+  }
+
+  return {widget: widget};
+}
+
+function fieldType (type) {
+  type = _.capitalize(type.toLowerCase());
+
+  if (type === 'Assets') {
+    return arrayFieldType('Link', 'Asset');
+  }
+
+  if (type === 'Entries') {
+    return arrayFieldType('Link', 'Entry');
+  }
+
+  if (type === 'Asset' || type === 'Entry') {
+    return {type: 'Link', linkType: type};
+  }
+
+  if (type === 'Symbols') {
+    return arrayFieldType('Symbol');
+  }
+
+  return {type: type};
+}
+
+function arrayFieldType (type, linkType) {
+  let array = {type: 'Array', items: {type: type}};
+
+  if (linkType) {
+    array.items.linkType = linkType;
+  }
+
+  return array;
+}

--- a/test/integration/commands-test.js
+++ b/test/integration/commands-test.js
@@ -65,11 +65,11 @@ describe('Commands', function () {
 
       return command('create --space-id 123 --field-types Symbol --id 456 --name foo --src foo.com', execOptions)
       .then(function (stdout) {
-        let widget = JSON.parse(stdout);
+        let payload = JSON.parse(stdout);
 
-        expect(widget.sys.id).to.eql('456');
-        expect(widget.name).to.eql('foo');
-        expect(widget.src).to.eql('foo.com');
+        expect(payload.sys.id).to.eql('456');
+        expect(payload.widget.name).to.eql('foo');
+        expect(payload.widget.src).to.eql('foo.com');
       });
     });
 
@@ -79,11 +79,11 @@ describe('Commands', function () {
 
       return command('create --space-id 123 --id 456 --name foo --field-types Symbol --src foo.com --host http://localhost:3000', execOptions)
       .then(function (stdout) {
-        let widget = JSON.parse(stdout);
+        let payload = JSON.parse(stdout);
 
-        expect(widget.sys.id).to.eql('456');
-        expect(widget.name).to.eql('foo');
-        expect(widget.src).to.eql('foo.com');
+        expect(payload.sys.id).to.eql('456');
+        expect(payload.widget.name).to.eql('foo');
+        expect(payload.widget.src).to.eql('foo.com');
       });
     });
 
@@ -128,10 +128,10 @@ describe('Commands', function () {
       // TODO add test that works with host without protocol
       return command('create --space-id 123 --field-types Symbol --src lol.com --name lol --host http://localhost:3000', execOptions)
         .then(function (stdout) {
-          let widget = JSON.parse(stdout);
+          let payload = JSON.parse(stdout);
 
-          expect(widget.src).to.eql('lol.com');
-          expect(widget.name).to.eql('lol');
+          expect(payload.widget.src).to.eql('lol.com');
+          expect(payload.widget.name).to.eql('lol');
         });
     });
 
@@ -140,9 +140,12 @@ describe('Commands', function () {
 
       return command(cmd, execOptions)
         .then(function (stdout) {
-          let widget = JSON.parse(stdout);
+          let payload = JSON.parse(stdout);
 
-          expect(widget.fieldTypes).to.eql(['Symbol', 'Text']);
+          expect(payload.widget.fieldTypes).to.eql([
+            {type: 'Symbol'},
+            {type: 'Text'}
+          ]);
         });
     });
 
@@ -151,9 +154,9 @@ describe('Commands', function () {
 
       return command(cmd, execOptions)
       .then(function (stdout) {
-        let widget = JSON.parse(stdout);
+        let payload = JSON.parse(stdout);
 
-        expect(widget.sidebar).to.be.true();
+        expect(payload.widget.sidebar).to.be.true();
       });
     });
 
@@ -162,9 +165,9 @@ describe('Commands', function () {
 
       return command(cmd, execOptions)
       .then(function (stdout) {
-        let widget = JSON.parse(stdout);
+        let payload = JSON.parse(stdout);
 
-        expect(widget.sidebar).to.be.false();
+        expect(payload.widget.sidebar).to.be.false();
       });
     });
 
@@ -173,9 +176,9 @@ describe('Commands', function () {
 
       return command(cmd, execOptions)
       .then(function (stdout) {
-        let widget = JSON.parse(stdout);
+        let payload = JSON.parse(stdout);
 
-        expect(widget.sidebar).to.be.undefined();
+        expect(payload.widget.sidebar).to.be.undefined();
       });
     });
 
@@ -184,10 +187,10 @@ describe('Commands', function () {
 
       return command(cmd, execOptions)
         .then(function (stdout) {
-          let widget = JSON.parse(stdout);
+          let payload = JSON.parse(stdout);
 
-          expect(widget.src).to.eql('lol.com');
-          expect(widget.sys.id).to.eql('456');
+          expect(payload.widget.src).to.eql('lol.com');
+          expect(payload.sys.id).to.eql('456');
         });
     });
 
@@ -229,9 +232,9 @@ describe('Commands', function () {
 
         return command(cmd, execOptions)
         .then(function (stdout) {
-          let widget = JSON.parse(stdout);
+          let payload = JSON.parse(stdout);
 
-          expect(widget.srcdoc).to.eql('the-bundle-contents');
+          expect(payload.widget.srcdoc).to.eql('the-bundle-contents');
         });
       });
     });
@@ -250,10 +253,10 @@ describe('Commands', function () {
           return command(readCmd, execOptions);
         })
         .then(function (stdout) {
-          let widget = JSON.parse(stdout);
+          let payload = JSON.parse(stdout);
 
-          expect(widget.src).to.eql('lol.com');
-          expect(widget.sys.id).to.eql('456');
+          expect(payload.widget.src).to.eql('lol.com');
+          expect(payload.sys.id).to.eql('456');
         });
     });
 
@@ -269,10 +272,10 @@ describe('Commands', function () {
           return command(readCmd, execOptions);
         })
         .then(function (stdout) {
-          let widget = JSON.parse(stdout);
+          let payload = JSON.parse(stdout);
 
-          expect(widget.src).to.eql('lol.com');
-          expect(widget.sys.id).to.eql('456');
+          expect(payload.widget.src).to.eql('lol.com');
+          expect(payload.sys.id).to.eql('456');
         });
     });
 
@@ -336,10 +339,10 @@ describe('Commands', function () {
           return command(readCmd, execOptions);
         })
         .then(function (stdout) {
-          let widget = JSON.parse(stdout);
+          let payload = JSON.parse(stdout);
 
-          expect(widget.src).to.eql('lol.com');
-          expect(widget.sys.id).to.eql('456');
+          expect(payload.widget.src).to.eql('lol.com');
+          expect(payload.sys.id).to.eql('456');
         });
     });
 
@@ -356,15 +359,15 @@ describe('Commands', function () {
         return command(readCmd, execOptions);
       })
       .then(function (stdout) {
-        let widgets = JSON.parse(stdout);
-        let lolWidget = _.find(widgets, {sys: {id: '456'}});
-        let fooWidget = _.find(widgets, {sys: {id: '789'}});
+        let payloads = JSON.parse(stdout);
+        let lolWidget = _.find(payloads, {sys: {id: '456'}});
+        let fooWidget = _.find(payloads, {sys: {id: '789'}});
 
-        expect(widgets.length).to.eq(2);
-        expect(lolWidget.name).to.eql('lol');
-        expect(lolWidget.src).to.eql('lol.com');
-        expect(fooWidget.name).to.eql('foo');
-        expect(fooWidget.src).to.eql('foo.com');
+        expect(payloads.length).to.eq(2);
+        expect(lolWidget.widget.name).to.eql('lol');
+        expect(lolWidget.widget.src).to.eql('lol.com');
+        expect(fooWidget.widget.name).to.eql('foo');
+        expect(fooWidget.widget.src).to.eql('foo.com');
       });
     });
 
@@ -392,9 +395,9 @@ describe('Commands', function () {
           return command(updateCmd, execOptions);
         })
         .then(function (stdout) {
-          let widget = JSON.parse(stdout);
+          let payload = JSON.parse(stdout);
 
-          expect(widget.src).to.eql('foo.com');
+          expect(payload.widget.src).to.eql('foo.com');
         });
     });
 
@@ -410,10 +413,10 @@ describe('Commands', function () {
           return command(readCmd, execOptions);
         })
         .then(function (stdout) {
-          let widget = JSON.parse(stdout);
+          let payload = JSON.parse(stdout);
 
-          expect(widget.src).to.eql('foo.com');
-          expect(widget.sys.id).to.eql('456');
+          expect(payload.widget.src).to.eql('foo.com');
+          expect(payload.sys.id).to.eql('456');
         });
     });
 
@@ -507,10 +510,10 @@ describe('Commands', function () {
           return command(updateCmd, execOptions);
         })
         .then(function (stdout) {
-          let widget = JSON.parse(stdout);
+          let payload = JSON.parse(stdout);
 
-          expect(widget.name).to.eql('foo');
-          expect(widget.src).to.eql('foo.com');
+          expect(payload.widget.name).to.eql('foo');
+          expect(payload.widget.src).to.eql('foo.com');
         });
     });
 
@@ -530,10 +533,10 @@ describe('Commands', function () {
           return command(updateCmd, execOptions);
         })
         .then(function (stdout) {
-          let widget = JSON.parse(stdout);
+          let payload = JSON.parse(stdout);
 
-          expect(widget.name).to.eql('foo');
-          expect(widget.src).to.eql('foo.com');
+          expect(payload.widget.name).to.eql('foo');
+          expect(payload.widget.src).to.eql('foo.com');
         });
     });
 
@@ -553,24 +556,28 @@ describe('Commands', function () {
           return command(updateCmd, execOptions);
         })
         .then(function (stdout) {
-          let widget = JSON.parse(stdout);
+          let payload = JSON.parse(stdout);
 
-          expect(widget.name).to.eql('doge');
+          expect(payload.widget.name).to.eql('doge');
         });
     });
 
-    it('upates the fieldTypes of a widget', function () {
+    it('updates the fieldTypes of a widget', function () {
       let createCmd = 'create --space-id 123 --name lol --src l.com --id 456 --field-types Symbol --name foo --host http://localhost:3000';
-      let updateCmd = 'update --space-id 123 --name lol --src l.com --id 456 --field-types Text Symbol --force --host http://localhost:3000';
+      let updateCmd = 'update --space-id 123 --name lol --src l.com --id 456 --field-types Text Symbol Assets --force --host http://localhost:3000';
 
       return command(createCmd, execOptions)
         .then(function () {
           return command(updateCmd, execOptions);
         })
         .then(function (stdout) {
-          let widget = JSON.parse(stdout);
+          let payload = JSON.parse(stdout);
 
-          expect(widget.fieldTypes).to.eql(['Text', 'Symbol']);
+          expect(payload.widget.fieldTypes).to.eql([
+            {type: 'Text'},
+            {type: 'Symbol'},
+            {type: 'Array', items: {type: 'Link', linkType: 'Asset'}}
+          ]);
         });
     });
 
@@ -583,9 +590,9 @@ describe('Commands', function () {
         return command(updateCmd, execOptions);
       })
       .then(function (stdout) {
-        let widget = JSON.parse(stdout);
+        let payload = JSON.parse(stdout);
 
-        expect(widget.sidebar).to.be.true();
+        expect(payload.widget.sidebar).to.be.true();
       });
     });
 
@@ -598,9 +605,9 @@ describe('Commands', function () {
         return command(updateCmd, execOptions);
       })
       .then(function (stdout) {
-        let widget = JSON.parse(stdout);
+        let payload = JSON.parse(stdout);
 
-        expect(widget.sidebar).to.be.false();
+        expect(payload.widget.sidebar).to.be.false();
       });
     });
 
@@ -613,9 +620,9 @@ describe('Commands', function () {
         return command(updateCmd, execOptions);
       })
       .then(function (stdout) {
-        let widget = JSON.parse(stdout);
+        let payload = JSON.parse(stdout);
 
-        expect(widget).to.not.have.ownProperty('sidebar');
+        expect(payload.widget).to.not.have.ownProperty('sidebar');
       });
     });
 
@@ -676,9 +683,9 @@ describe('Commands', function () {
             return command(updateCmd, execOptions);
           })
           .then(function (stdout) {
-            let widget = JSON.parse(stdout);
+            let payload = JSON.parse(stdout);
 
-            expect(widget.srcdoc).to.eql('the-bundle-contents');
+            expect(payload.widget.srcdoc).to.eql('the-bundle-contents');
           });
       });
     });

--- a/test/integration/descriptor-file-test.js
+++ b/test/integration/descriptor-file-test.js
@@ -63,7 +63,7 @@ describe('Descriptor file', function () {
         id: '123',
         src: 'foo.com',
         name: 'foo',
-        fieldTypes: ['t1', 't2'],
+        fieldTypes: ['Symbol', 'Assets'],
         sidebar: true
       };
 
@@ -85,14 +85,17 @@ describe('Descriptor file', function () {
       it(`${commandName}s a widget`, function () {
         return runCommands(commands, execOptions)()
           .then(function (stdout) {
-            let widget = JSON.parse(stdout);
+            let payload = JSON.parse(stdout);
 
-            expect(widget.name).to.eql(customDescriptor.name);
-            expect(widget.src).to.eql(customDescriptor.src);
-            expect(widget.fieldTypes).to.eql(customDescriptor.fieldTypes);
-            expect(widget.sidebar).to.be.true();
-            expect(widget.sys.id).to.eql(customDescriptor.id);
-            expect(widget.sys.space.sys.id).to.eql('123');
+            expect(payload.widget.name).to.eql(customDescriptor.name);
+            expect(payload.widget.src).to.eql(customDescriptor.src);
+            expect(payload.widget.fieldTypes).to.eql([
+              {type: 'Symbol'},
+              {type: 'Array', items: {type: 'Link', linkType: 'Asset'}}
+            ]);
+            expect(payload.widget.sidebar).to.be.true();
+            expect(payload.sys.id).to.eql(customDescriptor.id);
+            expect(payload.sys.space.sys.id).to.eql('123');
           });
       });
     });
@@ -163,7 +166,7 @@ describe('Descriptor file', function () {
         id: '456',
         src: 'lol.com',
         name: 'foo',
-        fieldTypes: ['t1', 't2'],
+        fieldTypes: ['Symbol', 'Assets'],
         sidebar: true
       };
 
@@ -187,11 +190,15 @@ describe('Descriptor file', function () {
         it(`${commandName}s the widget using the values in descriptor file`, function () {
           return runCommands(commands, execOptions)()
           .then(function (stdout) {
-            let widget = JSON.parse(stdout);
+            let payload = JSON.parse(stdout);
 
-            expect(widget.name).to.eql(descriptor.name);
-            expect(widget.src).to.eql(descriptor.src);
-            expect(widget.sys.id).to.eql(descriptor.id);
+            expect(payload.widget.name).to.eql(descriptor.name);
+            expect(payload.widget.src).to.eql(descriptor.src);
+            expect(payload.sys.id).to.eql(descriptor.id);
+            expect(payload.widget.fieldTypes).to.eql([
+              {type: 'Symbol'},
+              {type: 'Array', items: {type: 'Link', linkType: 'Asset'}}
+            ]);
           });
         });
       }
@@ -227,10 +234,10 @@ describe('Descriptor file', function () {
             return fs.writeFileAsync(file, JSON.stringify(descriptor))
             .then(runCommands(commands, execOptions))
             .then(function (stdout) {
-              let widget = JSON.parse(stdout);
+              let payload = JSON.parse(stdout);
 
-              expect(widget.srcdoc).to.eql(bundle);
-              expect(widget.sys.id).to.eql(descriptor.id);
+              expect(payload.widget.srcdoc).to.eql(bundle);
+              expect(payload.sys.id).to.eql(descriptor.id);
             });
           });
         }
@@ -252,11 +259,11 @@ describe('Descriptor file', function () {
             return fs.writeFileAsync(file, JSON.stringify(descriptor))
             .then(runCommands(commands, execOptions))
             .then(function (stdout) {
-              let widget = JSON.parse(stdout);
+              let payload = JSON.parse(stdout);
 
-              expect(widget).to.not.have.ownProperty('srcdoc');
-              expect(widget.src).to.eql('foo.com');
-              expect(widget.sys.id).to.eql(descriptor.id);
+              expect(payload.widget).to.not.have.ownProperty('srcdoc');
+              expect(payload.widget.src).to.eql('foo.com');
+              expect(payload.sys.id).to.eql(descriptor.id);
             });
           });
         }
@@ -275,10 +282,10 @@ describe('Descriptor file', function () {
         it(`${commandName} --src option overwrites src property in the descriptor`, function () {
           return runCommands(commands, execOptions)()
             .then(function (stdout) {
-              let widget = JSON.parse(stdout);
+              let payload = JSON.parse(stdout);
 
-              expect(widget.src).to.eql('foo.com');
-              expect(widget.sys.id).to.eql(descriptor.id);
+              expect(payload.widget.src).to.eql('foo.com');
+              expect(payload.sys.id).to.eql(descriptor.id);
             });
         });
       }
@@ -296,10 +303,10 @@ describe('Descriptor file', function () {
         it(`${commandName} --name option overwrites name property in the descriptor`, function () {
           return runCommands(commands, execOptions)()
             .then(function (stdout) {
-              let widget = JSON.parse(stdout);
+              let payload = JSON.parse(stdout);
 
-              expect(widget.name).to.eql('doge');
-              expect(widget.sys.id).to.eql(descriptor.id);
+              expect(payload.widget.name).to.eql('doge');
+              expect(payload.sys.id).to.eql(descriptor.id);
             });
         });
       }
@@ -307,20 +314,23 @@ describe('Descriptor file', function () {
 
     example(
       {
-        create: 'create --space-id 123 --field-types t3 t4 --host http://localhost:3000',
+        create: 'create --space-id 123 --field-types Number Date --host http://localhost:3000',
         update: [
           'create --space-id 123 --id 456  --host http://localhost:3000',
-          'update --space-id 123 --field-types t3 t4 --force --host http://localhost:3000'
+          'update --space-id 123 --field-types Number Date --force --host http://localhost:3000'
         ]
       },
       function (commandName, commands) {
         it(`${commandName} --field-types option overwrites fieldTypes property in the descriptor`, function () {
           return runCommands(commands, execOptions)()
             .then(function (stdout) {
-              let widget = JSON.parse(stdout);
+              let payload = JSON.parse(stdout);
 
-              expect(widget.fieldTypes).to.eql(['t3', 't4']);
-              expect(widget.sys.id).to.eql(descriptor.id);
+              expect(payload.widget.fieldTypes).to.eql([
+                {type: 'Number'},
+                {type: 'Date'}
+              ]);
+              expect(payload.sys.id).to.eql(descriptor.id);
             });
         });
       }
@@ -365,10 +375,10 @@ describe('Descriptor file', function () {
             return fs.writeFileAsync(file, JSON.stringify(descriptor))
             .then(runCommands(commands, execOptions))
             .then(function (stdout) {
-              let widget = JSON.parse(stdout);
+              let payload = JSON.parse(stdout);
 
-              expect(widget.srcdoc).to.eql(b);
-              expect(widget.sys.id).to.eql(descriptor.id);
+              expect(payload.widget.srcdoc).to.eql(b);
+              expect(payload.sys.id).to.eql(descriptor.id);
             });
           });
         }
@@ -387,11 +397,11 @@ describe('Descriptor file', function () {
             return fs.writeFileAsync(file, JSON.stringify(descriptor))
             .then(runCommands(commands, execOptions))
             .then(function (stdout) {
-              let widget = JSON.parse(stdout);
+              let payload = JSON.parse(stdout);
 
-              expect(widget).to.not.have.ownProperty('src');
-              expect(widget.srcdoc).to.eql(b);
-              expect(widget.sys.id).to.eql(descriptor.id);
+              expect(payload.widget).to.not.have.ownProperty('src');
+              expect(payload.widget.srcdoc).to.eql(b);
+              expect(payload.sys.id).to.eql(descriptor.id);
             });
           });
         }
@@ -412,10 +422,10 @@ describe('Descriptor file', function () {
         it(`${commandName} --id option overwrites id property in the descriptor`, function () {
           return runCommands(commands, execOptions)()
             .then(function (stdout) {
-              let widget = JSON.parse(stdout);
+              let payload = JSON.parse(stdout);
 
-              expect(widget.src).to.eql(descriptor.src);
-              expect(widget.sys.id).to.eql('88');
+              expect(payload.widget.src).to.eql(descriptor.src);
+              expect(payload.sys.id).to.eql('88');
             });
         });
       }
@@ -433,9 +443,9 @@ describe('Descriptor file', function () {
         it(`${commandName} --sidebar option overwrites sidebar property in the descriptor`, function () {
           return runCommands(commands, execOptions)()
             .then(function (stdout) {
-              let widget = JSON.parse(stdout);
+              let payload = JSON.parse(stdout);
 
-              expect(widget.sidebar).to.be.false();
+              expect(payload.widget.sidebar).to.be.false();
             });
         });
       }
@@ -514,7 +524,7 @@ describe('Descriptor file', function () {
             id: 'desc-123',
             src: 'desc-foo.com',
             name: 'desc-foo',
-            fieldTypes: ['desc-t1', 'desc-t2'],
+            fieldTypes: ['Asset', 'Text'],
             sidebar: true
           };
 
@@ -536,19 +546,22 @@ describe('Descriptor file', function () {
           it(`${commandName}s a widget`, function () {
             return runCommands(commands, execOptions)()
             .then(function (stdout) {
-              let widget = JSON.parse(stdout);
+              let payload = JSON.parse(stdout);
 
-              expect(widget.name).to.eql(customDescriptor.name);
-              expect(widget.src).to.eql(customDescriptor.src);
-              expect(widget.fieldTypes).to.eql(customDescriptor.fieldTypes);
-              expect(widget.sidebar).to.be.true();
-              expect(widget.sys.id).to.eql(customDescriptor.id);
-              expect(widget.sys.space.sys.id).to.eql('123');
+              expect(payload.widget.name).to.eql(customDescriptor.name);
+              expect(payload.widget.src).to.eql(customDescriptor.src);
+              expect(payload.widget.fieldTypes).to.eql([
+                {type: 'Link', linkType: 'Asset'},
+                {type: 'Text'}
+              ]);
+              expect(payload.widget.sidebar).to.be.true();
+              expect(payload.sys.id).to.eql(customDescriptor.id);
+              expect(payload.sys.space.sys.id).to.eql('123');
 
-              expect(widget.name).not.to.eql(descriptor.name);
-              expect(widget.src).not.to.eql(descriptor.src);
-              expect(widget.fieldTypes).not.to.eql(descriptor.fieldTypes);
-              expect(widget.sys.id).not.to.eql(descriptor.id);
+              expect(payload.widget.name).not.to.eql(descriptor.name);
+              expect(payload.widget.src).not.to.eql(descriptor.src);
+              expect(payload.widget.fieldTypes).not.to.eql(descriptor.fieldTypes);
+              expect(payload.sys.id).not.to.eql(descriptor.id);
             });
           });
         });

--- a/test/unit/cli/widget-test.js
+++ b/test/unit/cli/widget-test.js
@@ -7,6 +7,41 @@ var _ = require('lodash');
 var expect = require('../../helper').expect;
 var Widget = require('../../../lib/cli/widget');
 
+function buildWidgetPayload (options) {
+  var widget = {};
+  _.extend(widget, _.pick(options, ['src', 'srcdoc', 'fieldTypes']));
+
+  if (options.fieldTypes) {
+    widget.fieldTypes = [];
+
+    options.fieldTypes.forEach(function (fieldType) {
+      if (fieldType === 'Entries') {
+        widget.fieldTypes.push({type: 'Array', items: {type: 'Link', linkType: 'Entry'}});
+        return;
+      }
+
+      if (fieldType === 'Assets') {
+        widget.fieldTypes.push({type: 'Array', items: {type: 'Link', linkType: 'Asset'}});
+        return;
+      }
+
+      if (fieldType === 'Symbols') {
+        widget.fieldTypes.push({type: 'Array', items: {type: 'Symbol'}});
+        return;
+      }
+
+      if (fieldType === 'Entry' || fieldType === 'Asset') {
+        widget.fieldTypes.push({type: 'Link', linkType: fieldType});
+        return;
+      }
+
+      widget.fieldTypes.push({type: fieldType});
+    });
+  }
+
+  return {widget: widget};
+}
+
 describe('Widget', function () {
   let context, options, widget, http;
   beforeEach(function () {
@@ -33,11 +68,13 @@ describe('Widget', function () {
       });
 
       it('it calls the http.put method with the expected arguments', function () {
+        let payload = buildWidgetPayload({src: options.src});
+
         return widget.save().then(function () {
           expect(http.put).to.have.been.calledWith(
             {
               spaceId: options.spaceId,
-              payload: {src: options.src},
+              payload: payload,
               id: options.id
             },
             context
@@ -45,15 +82,16 @@ describe('Widget', function () {
         });
       });
 
-      describe('when a version has been provide', function () {
+      describe('when a version has been provided', function () {
         it('it calls the http.put method including the version', function () {
+          let payload = buildWidgetPayload({src: options.src});
           options = _.extend(options, {version: 66});
 
           return widget.save().then(function () {
             expect(http.put).to.have.been.calledWith(
               {
                 spaceId: options.spaceId,
-                payload: {src: options.src},
+                payload: payload,
                 id: options.id,
                 version: options.version
               },
@@ -75,11 +113,13 @@ describe('Widget', function () {
       });
 
       it('it saves a widget with the srcdoc property set', function () {
+        let payload = buildWidgetPayload({srcdoc: options.srcdoc});
+
         return widget.save().then(function () {
           expect(http.post).to.have.been.calledWith(
             {
               spaceId: options.spaceId,
-              payload: {srcdoc: options.srcdoc}
+              payload: payload
             },
             context
           );
@@ -98,11 +138,86 @@ describe('Widget', function () {
       });
 
       it('it saves a widget with the src property set', function () {
+        let payload = buildWidgetPayload({src: options.src});
+
         return widget.save().then(function () {
           expect(http.post).to.have.been.calledWith(
             {
               spaceId: options.spaceId,
-              payload: {src: options.src}
+              payload: payload
+            },
+            context
+          );
+        });
+      });
+    });
+
+    describe('when fieldTypes have been provided', function () {
+      beforeEach(function () {
+        options = {
+          spaceId: 123,
+          src: 'the-url'
+        };
+      });
+
+      [
+        'Symbol', 'Text', 'Date', 'Integer', 'Number', 'Location', 'Boolean', 'Object',
+        'Entry', 'Asset', 'Symbols', 'Assets', 'Entries'
+      ].forEach(function (fieldType) {
+        it(`saves the widget with the fieldType ${fieldType}`, function () {
+          options.fieldTypes = [fieldType];
+          let payload = buildWidgetPayload(options);
+
+          widget = new Widget(options, context);
+
+          return widget.save().then(function () {
+            expect(http.post).to.have.been.calledWith(
+              {
+                spaceId: options.spaceId,
+                payload: payload
+              },
+              context
+            );
+          });
+        });
+      });
+
+      it('saves the widget with multiple fieldTypes', function () {
+        options.fieldTypes = ['Symbol', 'Date', 'Symbols', 'Asset', 'Entries'];
+
+        let payload = buildWidgetPayload(options);
+
+        widget = new Widget(options, context);
+
+        return widget.save().then(function () {
+          expect(http.post).to.have.been.calledWith(
+            {
+              spaceId: options.spaceId,
+              payload: payload
+            },
+            context
+          );
+        });
+      });
+
+      it('saves the widget with multiple fieldTypes (capitalizes lowercase)', function () {
+        options.fieldTypes = ['symbol', 'entries'];
+
+        widget = new Widget(options, context);
+
+        return widget.save().then(function () {
+          expect(http.post).to.have.been.calledWith(
+            {
+              spaceId: options.spaceId,
+              payload: {
+                widget: {
+                  src: 'the-url',
+                  fieldTypes: [
+                    {type: 'Symbol'},
+                    {type: 'Array', items: {type: 'Link', linkType: 'Entry'}}
+                  ]
+                }
+              }
             },
             context
           );


### PR DESCRIPTION
## Summary

**note** this PR is based on https://github.com/contentful/widget-sdk/pull/31

This PR changes the payload sent from the CLI to the API to match the changes in the widget schema. The changes made to the schema are:
- Properties have to be scoped under a root `widget` object
- Field types have to be defined like this:
  - Simple fields: `{type: 'Symbol'}`
  - Links to Assets or Entries: `{type: 'Link', linkType: 'Asset'}`
  - Collections `{type: Array, items: {type: 'Link', linkType: 'Asset'}}`

Field types can be specified on the CLI just by their name and the tool will generate the right payload. For example:

```
contentful-widget create ... --field-types Symbol Assets
```
