### PR TITLE
CLI: Do not require sidebar

### DIFF
--- a/lib/cli/command/update.js
+++ b/lib/cli/command/update.js
@@ -11,14 +11,7 @@ var formatError = error.format('update');
 module.exports = function (options, context) {
   return maybeReadDescriptor(options)
     .then(function (descriptor) {
-      let required = [
-        'id',
-        'fieldTypes',
-        'name',
-        {
-          or: ['src', 'srcdoc', 'sidebar']
-        }
-      ];
+      let required = ['id', 'fieldTypes', 'name', { or: ['src', 'srcdoc'] }];
 
       return maybeExtendOptions(options, descriptor, required);
     })


### PR DESCRIPTION
## Summary

**note** this PR is based on https://github.com/contentful/widget-sdk/pull/32

This PR fixes a tiny bug: we were requiring the `sidebar` property to be present even though that property is not required on the widget schema.
