### PR TITLE
api.window.startAutoResizer to resize initially

### DIFF
--- a/lib/api/window.js
+++ b/lib/api/window.js
@@ -5,6 +5,7 @@ export default function createWindow (channel) {
   return {startAutoResizer, stopAutoResizer, updateHeight}
 
   function startAutoResizer () {
+    updateHeight()
     observer.observe(window.document.body, {
       attributes: true, childList: true,
       subtree: true, characterData: true


### PR DESCRIPTION
When starting the auto resizer, this will update the widget's height
initially.
