### PR TITLE
Fixes window.updateHeight shrinking case

### DIFF
--- a/lib/api/window.js
+++ b/lib/api/window.js
@@ -1,19 +1,31 @@
 export default function createWindow (channel) {
-  let observer = new MutationObserver(() => updateHeight())
+  var autoUpdateHeight = () => updateHeight()
+  let observer = new MutationObserver(autoUpdateHeight)
   let oldHeight = null
+  let isAutoResizing = false
 
   return {startAutoResizer, stopAutoResizer, updateHeight}
 
   function startAutoResizer () {
     updateHeight()
+    if (isAutoResizing) {
+      return
+    }
+    isAutoResizing = true
     observer.observe(window.document.body, {
       attributes: true, childList: true,
       subtree: true, characterData: true
     })
+    window.addEventListener('resize', autoUpdateHeight)
   }
 
   function stopAutoResizer () {
+    if (!isAutoResizing) {
+      return
+    }
+    isAutoResizing = false
     observer.disconnect()
+    window.removeEventListener('resize', autoUpdateHeight)
   }
 
   function updateHeight (height) {


### PR DESCRIPTION
Fixes the case that `api.window.updateHeight()` is called after the
widget's content has been shrinking. Previously the iframe's height
remained the same.

Also brings some additional refinements to `api.window`:
- Solves `1px` issue on `api.window.updateHeight()`
- Auto resizer now listens to browser resize
- Correctly caches height, so no unnecessary resizing requests are sent to the iframe parent
