### PR TITLE
Adds unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ watch:
 lint:
 	eslint lib/ bin/ test/
 
+test: lint
+	xvfb-run karma start --single-run --browsers SlimerJS --reporters dots
+
 clean:
 	rm -rf dist/*
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,28 @@
+var webpackConfig = require('./webpack.config.js');
+webpackConfig.entry = {};
+webpackConfig.output = {};
+
+module.exports = function(config) {
+  config.set({
+    basePath: '',
+    frameworks: ['mocha', 'sinon-chai', 'chai', 'chai-as-promised'],
+    files: [
+      './test/unit/**/*.spec.js'
+    ],
+    exclude: [
+    ],
+    preprocessors: {
+      './lib/api/index.js': ['webpack'],
+      './test/unit/**/*.spec.js': ['webpack']
+    },
+    webpack: webpackConfig,
+    reporters: ['dots'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['SlimerJS'],
+    singleRun: true,
+    concurrency: Infinity
+  })
+}

--- a/lib/api/channel.js
+++ b/lib/api/channel.js
@@ -3,11 +3,12 @@ import Signal from './signal'
 
 export default class Channel {
 
-  constructor (sourceId) {
+  constructor (sourceId, targetWindow) {
     this.sourceId = sourceId
-    this.messageID = 0
-    this.messageHandlers = {}
-    this.responseHandlers = {}
+    this.targetWindow = targetWindow
+    this._messageCount = 0
+    this._messageHandlers = {}
+    this._responseHandlers = {}
 
     window.addEventListener('message', (event) => {
       this._handleMessage(event.data)
@@ -15,9 +16,9 @@ export default class Channel {
   }
 
   call (method, ...params) {
-    var messageID = this._send(method, params)
+    const messageId = this._send(method, params)
     return new Promise((resolve, reject) => {
-      this.responseHandlers[messageID] = {resolve, reject}
+      this._responseHandlers[messageId] = {resolve, reject}
     })
   }
 
@@ -26,49 +27,45 @@ export default class Channel {
   }
 
   addHandler (method, handler) {
-    if (!(method in this.messageHandlers)) {
-      this.messageHandlers[method] = new Signal();
+    if (!(method in this._messageHandlers)) {
+      this._messageHandlers[method] = new Signal()
     }
-    return this.messageHandlers[method].attach(handler)
+    return this._messageHandlers[method].attach(handler)
   }
 
   _handleMessage (message) {
     if (message.method) {
-      // console.log('received message', message)
-      let {method, params} = message
-      let handlers = this.messageHandlers[method]
+      const {method, params} = message
+      const handlers = this._messageHandlers[method]
       if (handlers) {
         handlers.dispatch(...params)
       }
     } else {
-      let {id, result, error} = message
-      let handler = this.responseHandlers[id]
-
-      if (!handler) {
+      const {id, result, error} = message
+      const responseHandler = this._responseHandlers[id]
+      if (!responseHandler) {
         return
       }
-
       if (result) {
-        handler.resolve(result)
+        responseHandler.resolve(result)
       } else if (error) {
-        handler.reject(error)
+        responseHandler.reject(error)
       }
-
-      delete this.responseHandlers[id]
+      delete this._responseHandlers[id]
     }
   }
 
   _send (method, params) {
-    var messageID = this.messageID++
+    const messageId = this._messageCount++
 
-    window.parent.postMessage({
+    this.targetWindow.postMessage({
       source: this.sourceId,
-      id: messageID,
+      id: messageId,
       method,
       params
     }, '*')
 
-    return messageID
+    return messageId
   }
 
 }

--- a/lib/api/field.js
+++ b/lib/api/field.js
@@ -14,12 +14,14 @@ export default class Field {
       this._valueSignals[locale] = new Signal()
     })
 
+    assertHasLocale(this, defaultLocale)
+
     channel.addHandler('valueChanged', (id, locale, value) => {
       if (id !== this.id) {
         return
       }
 
-      var locales = locale ? [locale] : this.locales
+      const locales = locale ? [locale] : this.locales
       locales.forEach((locale) => {
         this._values[locale] = value
         this._valueSignals[locale].dispatch(value)
@@ -34,12 +36,13 @@ export default class Field {
 
   setValue (value, locale) {
     locale = locale || this._defaultLocale
+    assertHasLocale(this, locale)
     this._values[locale] = value
     return this._channel.call('setValue', this.id, locale, value)
   }
 
   removeValue (locale) {
-    this.setValue(undefined, locale)
+    return this.setValue(undefined, locale)
   }
 
   onValueChanged (locale, handler) {
@@ -47,10 +50,23 @@ export default class Field {
       handler = locale
       locale = this._defaultLocale
     }
-    if (!(locale in this._valueSignals)) {
-      throw new Error(`Unknown locale "${locale}" for field "${this.id}"`)
-    }
+    assertHasLocale(this, locale)
     return this._valueSignals[locale].attach(handler)
   }
 
+}
+
+function assertHasLocale (instance, locale) {
+  if (!instance._valueSignals[locale]) {
+    throw new UnknownLocaleError(instance.id, locale)
+  }
+}
+
+export class UnknownLocaleError extends Error {
+  constructor (fieldId, locale) {
+    super()
+    this.message = `Unknown locale "${locale}" for field "${fieldId}"`
+    this.fieldId = fieldId
+    this.locale = locale
+  }
 }

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,47 +1,15 @@
+import setup from './setup'
 import Channel from './channel'
-
 import FieldLocale from './field-locale'
 import createWindow from './window'
 import createEntry from './entry'
 import createSpace from './space'
 
-window.contentfulWidget = setup()
+window.contentfulWidget = setup(createWidgetAPI)
 export default window.contentfulWidget
 
-function setup () {
-  let readyCallbacks = []
-  let widget = null
-
-  window.addEventListener('message', initializer)
-
-  return {init}
-
-  function initializer (event) {
-    let method = event.data.method
-    let params = event.data.params
-
-    if (method !== 'connect') {
-      return
-    }
-
-    widget = createWidgetAPI(params)
-    window.removeEventListener('message', initializer)
-
-    readyCallbacks.forEach((cb) => cb(widget))
-  }
-
-  function init (cb) {
-    if (widget) {
-      cb(widget)
-    } else {
-      readyCallbacks.push(cb)
-    }
-  }
-}
-
-
 function createWidgetAPI ({id, entry, locales, field, fieldInfo}) {
-  let channel = new Channel(id)
+  let channel = new Channel(id, window.parent)
 
   return {
     locales,

--- a/lib/api/setup.js
+++ b/lib/api/setup.js
@@ -1,0 +1,30 @@
+export default function setup (apiCreator) {
+  const readyCallbacks = []
+  let widgetApi = null
+
+  window.addEventListener('message', initializer)
+
+  return {init}
+
+  function initializer (event) {
+    const method = event.data.method
+    const params = event.data.params
+
+    if (method !== 'connect') {
+      return
+    }
+
+    widgetApi = apiCreator(params)
+    window.removeEventListener('message', initializer)
+
+    readyCallbacks.forEach((cb) => cb(widgetApi))
+  }
+
+  function init (cb) {
+    if (widgetApi) {
+      cb(widgetApi)
+    } else {
+      readyCallbacks.push(cb)
+    }
+  }
+}

--- a/lib/api/signal.js
+++ b/lib/api/signal.js
@@ -11,6 +11,9 @@ export default class Signal {
   }
 
   attach (listener) {
+    if (typeof listener !== 'function') {
+      throw new Error('listener function expected')
+    }
     var id = this._id++
     this._listeners[id] = listener
     var self = this

--- a/lib/api/window.js
+++ b/lib/api/window.js
@@ -1,13 +1,14 @@
 export default function createWindow (channel) {
-  var autoUpdateHeight = () => updateHeight()
+  let autoUpdateHeight = () => { self.updateHeight() }
   let observer = new MutationObserver(autoUpdateHeight)
   let oldHeight = null
   let isAutoResizing = false
 
-  return {startAutoResizer, stopAutoResizer, updateHeight}
+  let self = {startAutoResizer, stopAutoResizer, updateHeight}
+  return self
 
   function startAutoResizer () {
-    updateHeight()
+    self.updateHeight()
     if (isAutoResizing) {
       return
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "prepublish": "make build"
+    "prepublish": "make build",
+    "test": "make test"
   },
   "bugs": {
     "url": "https://github.com/contentful/widget-sdk/issues"
@@ -25,5 +26,14 @@
     "stylus": "^0.52.4",
     "webpack": "^1.12.2",
     "yaku": "^0.11.4"
+  },
+  "devDependencies": {
+    "karma": "^0.13.15",
+    "karma-mocha": "^0.2.1",
+    "karma-chai-plugins": "^0.6.1",
+    "karma-chrome-launcher": "^0.2.2",
+    "karma-safari-launcher": "^0.1.1",
+    "karma-slimerjs-launcher": "^0.2.0",
+    "karma-webpack": "^1.7.0"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,13 @@
+{
+  "rules": {
+    "no-new": 0
+  },
+  "env": {
+    "browser": true,
+    "mocha": true
+  },
+  "globals": {
+    "sinon": true,
+    "expect": true
+  }
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,15 @@
+export const noop = function () {}
+
+export function describeAttachHandlerMember (msg, attachHandlerFn) {
+  describe(msg, () => {
+    it('returns a function to detach the handler', () => {
+      expect(attachHandlerFn()).to.be.a('function')
+    })
+    describe(`returned function`, () => {
+      it(`can be executed without error`, () => {
+        let detachHandler = attachHandlerFn()
+        expect(detachHandler).to.not.throw()
+      })
+    })
+  })
+}

--- a/test/unit/channel.spec.js
+++ b/test/unit/channel.spec.js
@@ -1,0 +1,171 @@
+import Channel from '../../lib/api/channel'
+import Promise from 'yaku'
+import {noop, describeAttachHandlerMember} from '../helpers'
+
+describe(`Channel instance`, () => {
+  const sourceId = 42
+
+  let stubTargetWindow
+  let postMessageSpy
+  let channel
+  beforeEach(() => {
+    postMessageSpy = sinon.stub()
+    stubTargetWindow = {
+      postMessage: postMessageSpy
+    }
+    channel = new Channel(sourceId, stubTargetWindow)
+  })
+
+  it(`is a Channel instance`, () => {
+    expect(channel).to.be.instanceof(Channel)
+  })
+
+  describe(`.sourceId`, () => {
+    it(`is equal to id given to constructor`, () => {
+      expect(channel.sourceId).to.equal(sourceId)
+    })
+  })
+
+  describe(`.targetWindow`, () => {
+    it(`is equal to object given to constructor`, () => {
+      expect(channel.targetWindow).to.equal(stubTargetWindow)
+    })
+  })
+
+  describeAttachHandlerMember(`.addHandler(method, handler)`, () => {
+    return channel.addHandler('forSomePurpose', noop)
+  })
+
+  const messagingCases = {
+    'with multiple params': {
+      method: 'someMethod',
+      params: [42, 'foo', {}]
+    },
+    'with one params value': {
+      method: 'aMethod',
+      params: ['']
+    },
+    'without params': {
+      method: 'anothereMethod',
+      params: []
+    }
+  }
+
+  describe(`.send(method, ...params)`, () => {
+    for (let msg in messagingCases) {
+      describeSend(msg, messagingCases[msg])
+    }
+
+    describeSubsequentTargetWindowsPostMessageInvocations('send')
+  })
+
+  function describeSend (msg, {method, params}) {
+    describe(msg, () => {
+      describeTargetWindowsPostMessageInvocation('send', method, ...params)
+    })
+  }
+
+  describe(`.call(method, ...params)`, () => {
+    for (let msg in messagingCases) {
+      describeCall(msg, messagingCases[msg])
+    }
+
+    describeSubsequentTargetWindowsPostMessageInvocations('call')
+  })
+
+  function describeCall (msg, {method, params}) {
+    describe(msg, () => {
+      let promise
+      beforeEach(() => {
+        promise = channel.call(method, ...params)
+      })
+
+      describeTargetWindowsPostMessageInvocation('call', method, ...params)
+
+      it(`returns a Promise`, () => {
+        expect(promise).to.be.instanceof(Promise)
+      })
+
+      describe(`returned Promise`, () => {
+        it(`gets resolved once the call got answered with a result`, (done) => {
+          const result = 'foo bar'
+          answerLastCallWith({result})
+
+          expect(promise).to.eventually.equal(result)
+            .and.notify(done)
+        })
+        it(`gets rejected once the call got answered with an error`, (done) => {
+          const error = 'What a mess!'
+          answerLastCallWith({error})
+
+          expect(promise).to.be.rejectedWith(error)
+            .and.notify(done)
+        })
+      })
+
+      function answerLastCallWith (data) {
+        data.id = postMessageSpy.lastCall.args[0].id
+        window.postMessage(data, '*')
+      }
+    })
+  }
+
+  function describeTargetWindowsPostMessageInvocation (member, method, ...params) {
+    describe(`.${member}() call's invocation of targetWindow .postMessage()`, () => {
+      beforeEach(() => {
+        postMessageSpy.reset()
+        channel[member](method, ...params)
+      })
+
+      it(`is done once`, () => {
+        expect(postMessageSpy).to.have.callCount(1)
+      })
+
+      describe(`message data`, () => {
+        itHasMessageData(`.source set to channel's source ID`, 'source', sourceId)
+        itHasMessageData(`.id set to a number`, 'id', sinon.match.number)
+        itHasMessageData(`.method as given to .call()`, 'method', method)
+        itHasMessageData(`.params as given to .call()`, 'params', params)
+
+        function itHasMessageData (msg, field, value) {
+          it(`has ${msg}`, () => {
+            expect(postMessageSpy).to.have.been.calledWith(
+              sinon.match.has(field, value))
+          })
+        }
+      })
+    })
+  }
+
+  function describeSubsequentTargetWindowsPostMessageInvocations (member) {
+    const msg =
+      `subsequent .${member}() calls' invocation of target window's .postMessage()`
+
+    describe(msg, () => {
+      const expectedCallsCount = Object.keys(messagingCases).length
+      beforeEach(() => {
+        for (let msg in messagingCases) {
+          const {method, params} = messagingCases[msg]
+          channel[member](method, ...params)
+        }
+      })
+
+      it(`is done once for each .${member}()`, () => {
+        expect(postMessageSpy).to.have.callCount(expectedCallsCount)
+      })
+
+      describe(`message data`, () => {
+        it(`has .id set to a number incremented by each call`, () => {
+          const expectedIds = []
+          for (let i = 0; i < expectedCallsCount; i++) {
+            expectedIds.push(i)
+          }
+          let providedIds = postMessageSpy.args.map((callArgs) => {
+            return callArgs[0].id
+          })
+          expect(providedIds).to.deep.equal(expectedIds)
+        })
+      })
+    })
+  }
+})

--- a/test/unit/entry.spec.js
+++ b/test/unit/entry.spec.js
@@ -1,0 +1,71 @@
+import createEntry from '../../lib/api/entry'
+import Field from '../../lib/api/field'
+import {
+  noop,
+  describeAttachHandlerMember
+} from '../helpers'
+
+describe(`createEntry()`, () => {
+  describe(`returned "entry" object`, () => {
+    const entryData = {sys: {}}
+    const fieldInfo = [
+      {
+        id: 'field1',
+        locales: ['en-US'],
+        values: {}
+      }, {
+        id: 'field2',
+        locales: ['en-US'],
+        values: {}
+      }, {
+        id: 'field3',
+        locales: ['en-US'],
+        values: {}
+      }
+    ]
+
+    let channelStub
+    let entry
+    beforeEach(() => {
+      channelStub = {
+        addHandler: sinon.spy()
+      }
+      entry = createEntry(channelStub, entryData, fieldInfo, 'en-US')
+    })
+
+    it(`subscribed to injected Channel's "sysChanged"`, () => {
+      const spy = channelStub.addHandler
+      expect(spy).to.have.been.calledWithExactly('sysChanged', sinon.match.func)
+    })
+
+    describe(`.fields[id]`, () => {
+      it(`is a Field with its .id==id for each constructor given fieldInfo`, () => {
+        fieldInfo.forEach((info) => {
+          const field = entry.fields[info.id]
+          expect(field).to.be.instanceof(Field)
+          expect(field.id).to.equal(info.id)
+        })
+      })
+    })
+
+    describe(`.getSys()`, () => {
+      it(`returns entryData.sys given to constructor`, () => {
+        expect(entry.getSys()).to.equal(entryData.sys)
+      })
+    })
+
+    describeAttachHandlerMember(`.onSysChanged(handler)`, () => {
+      return entry.onSysChanged(noop)
+    })
+
+    describe(`injected channel propagating "sysChanged"`, () => {
+      it(`replaces current sys with the given one`, () => {
+        const newSys = {}
+        // The handler registered with channel.addHandler("sysChanged", handler)
+        const sysChangedHandler = channelStub.addHandler.args[0][1]
+        sysChangedHandler(newSys)
+        expect(entry.getSys()).to.equal(newSys)
+      })
+    })
+  })
+})

--- a/test/unit/field-locale.spec.js
+++ b/test/unit/field-locale.spec.js
@@ -1,0 +1,103 @@
+import FieldLocale from '../../lib/api/field-locale'
+import {
+  noop,
+  describeAttachHandlerMember
+} from '../helpers'
+
+describe('FieldLocale', () => {
+  let channelStub
+  beforeEach(() => {
+    channelStub = {
+      addHandler: sinon.stub(),
+      call: sinon.stub()
+    }
+  })
+
+  describe('instance', () => {
+    const defaultLocale = 'en-US'
+    const info = {
+      id: 'some-field',
+      locale: 'en-US',
+      value: 'Hello'
+    }
+    let field
+    beforeEach(() => {
+      const infoCopy = JSON.parse(JSON.stringify(info))
+      field = new FieldLocale(channelStub, infoCopy)
+    })
+
+    it(`is a FieldLocale instance`, () => {
+      expect(field).to.be.instanceof(FieldLocale)
+    })
+
+    describe('.id', () => {
+      it(`is equal to info.id`, () => {
+        expect(field.id).to.equal(info.id)
+      })
+    })
+
+    describe('.locale', () => {
+      it(`is set to the same value as given to first constructor arg's .locale`, () => {
+        expect(field.locale).to.equal(info.locale)
+      })
+    })
+
+    describe('.getValue()', () => {
+      it(`returns the field's value`, () => {
+        expect(field.getValue()).to.equal(info.value)
+      })
+    })
+
+    describe('.setValue(value)', () => {
+      const newValue = `new-value`
+
+      beforeEach(() => {
+        field.setValue(newValue)
+      })
+
+      it(`changes the value`, () => {
+        expect(field.getValue()).to.equal(newValue)
+      })
+      it(`invokes channel.call("setValue", ...)`, () => {
+        expect(channelStub.call).to.have.been.calledWithExactly(
+          'setValue', field.id, info.locale, newValue)
+      })
+      it(`returns the promise returned by internal channel.call()`, () => {
+        channelStub.call.withArgs('setValue').returns('PROMISE')
+        expect(field.setValue('val')).to.equal('PROMISE')
+      })
+    })
+
+    describeAttachHandlerMember(`.onValueChanged(handler)`, () => {
+      return field.onValueChanged(noop)
+    })
+
+    describe(`injected channel propagating "valueChanged"`, () => {
+      const newValue = 'some new, unused value'
+
+      let valueChangedHandler
+      beforeEach(() => {
+        // The handler registered with channel.addHandler("valueChanged", handler)
+        valueChangedHandler = channelStub.addHandler.args[0][1]
+      })
+
+      describe(`targeted at another field's id`, () => {
+        it(`does not update the value`, () => {
+          const oldValue = field.getValue()
+          valueChangedHandler(`${field.id}-other-id`, defaultLocale, newValue)
+
+          expect(oldValue).to.equal(field.getValue())
+        })
+      })
+      describe(`targeted at the field's id`, () => {
+        describe(`for specific locale`, () => {
+          it(`sets the locale's value to the given one`, () => {
+            valueChangedHandler(field.id, defaultLocale, newValue)
+
+            expect(field.getValue()).to.equal(newValue)
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/unit/field.spec.js
+++ b/test/unit/field.spec.js
@@ -1,0 +1,213 @@
+import Field, {UnknownLocaleError} from '../../lib/api/field'
+import {
+  noop,
+  describeAttachHandlerMember
+} from '../helpers'
+
+describe(`Field`, () => {
+  let channelStub
+  beforeEach(() => {
+    channelStub = {
+      addHandler: sinon.stub(),
+      call: sinon.stub()
+    }
+  })
+
+  describe(`construction error`, () => {
+    it(`gets thrown if defaultLocale is not included in info.locales`, () => {
+      expect(() => {
+        new Field(channelStub, {id: 'x', locales: ['de-DE'], values: {}}, 'en-US')
+      }).to.throw((new UnknownLocaleError('x', 'en-US')).message)
+    })
+  })
+
+  describe(`instance`, () => {
+    const defaultLocale = 'en-US'
+    const localeWithoutValue = 'locale-without-value'
+    const info = {
+      id: 'some-field',
+      locales: ['en-US', 'it-IT', 'de-DE', localeWithoutValue],
+      values: {
+        'en-US': 'Hello',
+        'it-IT': 'Ciao',
+        'de-DE': 'Hallo'
+      }
+    }
+    let field
+    beforeEach(() => {
+      const infoCopy = JSON.parse(JSON.stringify(info))
+      field = new Field(channelStub, infoCopy, defaultLocale)
+    })
+
+    it(`is a Field instance`, () => {
+      expect(field).to.be.instanceof(Field)
+    })
+
+    describe(`.id`, () => {
+      it(`is equal to info.id`, () => {
+        expect(field.id).to.equal(info.id)
+      })
+    })
+
+    describe(`.locales`, () => {
+      it(`is set to the same value as info.locales`, () => {
+        expect(field.locales).to.deep.equal(info.locales)
+      })
+    })
+
+    describe(`.getValue()`, () => {
+      it(`returns the default locale's value`, () => {
+        expect(field.getValue()).to.equal(info.values[defaultLocale])
+      })
+    })
+
+    describe(`.getValue(locale)`, () => {
+      describe(`with locale set to the default locale "${defaultLocale}"`, () => {
+        it(`returns the value for the given locale`, () => {
+          expect(field.getValue(defaultLocale)).to.equal(info.values[defaultLocale])
+        })
+      })
+
+      describe(`for locale set to a locale without value`, () => {
+        it(`should return undefined`, () => {
+          expect(field.getValue(localeWithoutValue)).to.equal(undefined)
+        })
+      })
+
+      describe(`for locale set to a unknown locale`, () => {
+        it(`should return undefined`, () => {
+          expect(field.getValue('unknown-locale')).to.equal(undefined)
+        })
+      })
+
+      info.locales.forEach((locale) => {
+        if (locale === defaultLocale) {
+          return
+        }
+        describe(`with locale set to "${locale}"`, () => {
+          it(`returns the value for the given locale`, () => {
+            expect(field.getValue(locale)).to.equal(info.values[locale])
+          })
+        })
+      })
+    })
+
+    describeSetValue(`.setValue(value)`, undefined, defaultLocale)
+
+    describe(`.setValue(value, locale)`, () => {
+      info.locales.forEach((locale) => {
+        describeSetValue(`with locale set to "${locale}"`, locale, locale)
+      })
+
+      it(`throws an error if locale is unknown to the field`, () => {
+        const locale = 'some-unknown-locale'
+        expect(() => {
+          field.setValue('value', locale)
+        }).to.throw((new UnknownLocaleError(field.id, locale)).message)
+      })
+    })
+
+    function describeSetValue (msg, locale, localeOrDefault) {
+      describe(msg, () => {
+        const newValue = `new-value-${localeOrDefault}`
+
+        beforeEach(() => {
+          field.setValue(newValue, locale)
+        })
+
+        it(`changes the locale's value`, () => {
+          expect(field.getValue(locale)).to.equal(newValue)
+        })
+        it(`invokes channel.call("setValue", ...)`, () => {
+          expect(channelStub.call).to.have.been.calledWithExactly(
+            'setValue', field.id, localeOrDefault, newValue)
+        })
+        it(`returns the promise returned by internal channel.call()`, () => {
+          channelStub.call.withArgs('setValue').returns('PROMISE')
+          expect(field.setValue('val')).to.equal('PROMISE')
+        })
+      })
+    }
+
+    describeRemoveValue(`.removeValue()`, undefined)
+
+    describe(`.removeValue(locale)`, () => {
+      info.locales.forEach((locale) => {
+        describeRemoveValue(`with locale set to "${locale}"`, locale)
+      })
+    })
+
+    function describeRemoveValue (msg, locale) {
+      describe(msg, () => {
+        const localeParam = locale ? `"${locale}"` : 'undefined'
+
+        it(`is just a call to .setValue(undefined, ${localeParam})`, () => {
+          const setValueSpy = sinon.spy(field, 'setValue')
+          field.removeValue(locale)
+
+          expect(setValueSpy)
+            .to.have.callCount(1).and
+            .to.have.been.calledWithExactly(undefined, locale)
+        })
+        it(`returns the same value as .setValue(undefined, ${localeParam})`, () => {
+          let setValueStub = sinon.stub(field, 'setValue')
+          setValueStub.returns('PROMISE')
+          expect(field.removeValue()).to.equal('PROMISE')
+        })
+        it(`makes .getValue(${localeParam}) return undefined`, () => {
+          field.removeValue(locale)
+          expect(field.getValue(locale)).to.equal(undefined)
+        })
+      })
+    }
+
+    describeAttachHandlerMember(`.onValueChanged(handler)`, () => {
+      return field.onValueChanged(noop)
+    })
+
+    describe(`.onValueChanged(locale, handler)`, () => {
+      info.locales.forEach((locale) => {
+        describeAttachHandlerMember(`with locale set to ${locale}`, () => {
+          return field.onValueChanged(locale, noop)
+        })
+      })
+    })
+
+    describe(`injected channel propagating "valueChanged"`, () => {
+      const newValue = 'some new, unused value'
+
+      let valueChangedHandler
+      beforeEach(() => {
+        // The handler registered with channel.addHandler("valueChanged", handler)
+        valueChangedHandler = channelStub.addHandler.args[0][1]
+      })
+
+      describe(`targeted at another field's id`, () => {
+        it(`does not update the value`, () => {
+          const oldValue = field.getValue()
+          valueChangedHandler(`${field.id}-other-id`, defaultLocale, newValue)
+
+          expect(oldValue).to.equal(field.getValue())
+        })
+      })
+      describe(`targeted at the field's id`, () => {
+        describe(`for specific locale`, () => {
+          it(`sets the locale's value to the given one`, () => {
+            valueChangedHandler(field.id, defaultLocale, newValue)
+
+            expect(field.getValue()).to.equal(newValue)
+          })
+        })
+        describe(`without locale provided`, () => {
+          it(`sets all locales' values to the given one`, () => {
+            valueChangedHandler(field.id, undefined, newValue)
+
+            info.locales.forEach((locale) => {
+              expect(field.getValue(locale)).to.equal(newValue)
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/unit/setup.spec.js
+++ b/test/unit/setup.spec.js
@@ -1,0 +1,63 @@
+import setup from '../../lib/api/setup'
+
+describe(`setup(apiCreator)`, () => {
+  let cfWidget
+  beforeEach(() => {
+    cfWidget = setup(function () { return {} })
+  })
+
+  describe(`returned "Contentful widget" object`, () => {
+    it(`has a .init()`, () => {
+      expect(cfWidget.init).to.be.a('function')
+    })
+
+    describe(`.init(callback)`, () => {
+      it(`is a function`, () => {
+        expect(cfWidget.init).to.be.a('function')
+      })
+
+      describe(`called before Widget API is ready`, () => {
+        it(`does not invoke callback`, () => {
+          const spy = sinon.spy()
+          cfWidget.init(spy)
+          expect(spy).to.have.callCount(0)
+        })
+      })
+
+      describe(`called after Widget API is ready`, () => {
+        it(`immediately invokes callback`, (done) => {
+          signalWidgetReady()
+          setTimeout(() => {
+            const spy = sinon.spy()
+            cfWidget.init(spy)
+            expect(spy).to.have.callCount(1)
+            done()
+          }, 0)
+        })
+      })
+
+      describe(`callback`, () => {
+        it(`gets invoked once ready state got signaled`, (done) => {
+          cfWidget.init(() => done())
+          signalWidgetReady()
+        })
+        it(`does not get called again if ready state is signaled again `, (done) => {
+          cfWidget.init(() => {
+            const spy = sinon.spy()
+            cfWidget.init(spy)
+            expect(spy).to.have.callCount(1)
+            done()
+          })
+          signalWidgetReady()
+        })
+      })
+    })
+  })
+
+  function signalWidgetReady () {
+    window.postMessage({
+      method: 'connect',
+      params: []
+    }, '*')
+  }
+})

--- a/test/unit/signal.spec.js
+++ b/test/unit/signal.spec.js
@@ -1,0 +1,107 @@
+import Signal from '../../lib/api/signal'
+import {noop} from '../helpers'
+
+describe(`Signal`, () => {
+  describe(`constructor`, () => {
+    it(`creates a Signal instance`, () => {
+      expect(new Signal()).to.be.instanceof(Signal)
+    })
+  })
+
+  describe(`instance`, () => {
+    let signal
+    beforeEach(() => {
+      signal = new Signal()
+    })
+
+    describe(`attach(listener)`, () => {
+      it(`returns a function`, () => {
+        expect(signal.attach(noop)).to.be.a('function')
+      })
+      it(`throws an error if listener is not a function`, () => {
+        ['foo', undefined, 42].forEach((value) => {
+          expect(() => { signal.attach(value) }).to.throw()
+        })
+      })
+    })
+
+    describe(`dispatch()`, () => {
+      it(`returns nothing and does not fail`, () => {
+        expect(signal.dispatch()).to.equal(undefined)
+      })
+
+      describe(`with previously attached listeners`, () => {
+        let spies
+        beforeEach(() => {
+          spies = {
+            one: sinon.spy(),
+            two: sinon.spy(),
+            three: sinon.spy()
+          }
+        })
+
+        function expectCallCount (obj) {
+          for (let name in obj) {
+            expect(spies[name]).to.have.callCount(obj[name])
+          }
+        }
+
+        it(`fires attached listeners in the same order they were attached`, () => {
+          signal.attach(spies.one)
+          signal.attach(spies.two)
+          signal.attach(spies.three)
+          signal.dispatch()
+
+          expectCallCount({one: 1, two: 1, three: 1})
+
+          sinon.assert.callOrder(spies.one, spies.two, spies.three)
+        })
+
+        it(`does not fire detached listeners`, () => {
+          signal.attach(spies.one)()
+          signal.attach(spies.two)
+          signal.dispatch()
+
+          expectCallCount({one: 0, two: 1})
+        })
+
+        it(`fires reattached listeners`, () => {
+          signal.attach(spies.one)()
+          signal.dispatch()
+
+          expectCallCount({one: 0})
+
+          signal.attach(spies.one)
+          signal.dispatch()
+
+          expectCallCount({one: 1})
+        })
+
+        it(`fires same listener attached twice two times`, () => {
+          const detachSpyOneA = signal.attach(spies.one)
+          signal.attach(spies.one)
+          signal.dispatch()
+
+          expectCallCount({one: 2})
+
+          detachSpyOneA()
+          signal.dispatch()
+
+          expectCallCount({one: 3})
+        })
+
+        it(`passes given arguments to the listeners`, () => {
+          const args = ['foo', 42, {}]
+          signal.attach(spies.one)
+          signal.dispatch(...args)
+
+          expect(spies.one).to.have.been.calledWithExactly(...args)
+
+          signal.dispatch()
+
+          expect(spies.one).to.have.been.calledWithExactly()
+        })
+      })
+    })
+  })
+})

--- a/test/unit/space.spec.js
+++ b/test/unit/space.spec.js
@@ -1,0 +1,69 @@
+const spaceMethods = [
+  'getContentType',
+  'getEntry',
+  'getAsset',
+
+  'getContentTypes',
+  'getEntries',
+  'getAssets',
+
+  'createContentType',
+  'createEntry',
+  'createAsset',
+
+  'updateContentType',
+  'updateEntry',
+  'updateAsset',
+
+  'deleteContentType',
+  'deleteEntry',
+  'deleteAsset',
+
+  'publishEntry',
+  'publishAsset',
+  'unpublishEntry',
+  'unpublishAsset',
+
+  'archiveEntry',
+  'archiveAsset',
+  'unarchiveEntry',
+  'unarchiveAsset',
+
+  'processAsset'
+]
+
+import createSpace from '../../lib/api/space'
+
+describe(`createSpace()`, () => {
+  describe(`returned "space" object`, () => {
+    spaceMethods.forEach(describeSpaceMethod)
+  })
+})
+
+function describeSpaceMethod (methodName) {
+  let space
+  let channelCallStub
+  beforeEach(() => {
+    channelCallStub = sinon.stub()
+    space = createSpace({
+      call: channelCallStub
+    })
+  })
+
+  describe(`.${methodName}()`, () => {
+    it(`is a function`, () => {
+      expect(space[methodName]).to.be.a('function')
+    })
+    it(`invokes channel.call('callSpaceMethod', '${methodName}', args)`, () => {
+      let args = ['foo', 42, {}]
+      space[methodName](...args)
+      expect(channelCallStub)
+        .to.have.callCount(1).and
+        .to.have.been.calledWithExactly('callSpaceMethod', methodName, args)
+    })
+    it(`returns the promise returned by internal channel.call()`, () => {
+      channelCallStub.withArgs('callSpaceMethod').returns('PROMISE')
+      expect(space[methodName]()).to.equal('PROMISE')
+    })
+  })
+}

--- a/test/unit/window.spec.js
+++ b/test/unit/window.spec.js
@@ -1,0 +1,116 @@
+import createWindow from '../../lib/api/window'
+
+describe(`createWindow()`, () => {
+  let sandbox
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+  })
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe(`returned "window" object`, () => {
+    let window
+    let channelSendSpy
+    beforeEach(() => {
+      channelSendSpy = sandbox.spy()
+      window = createWindow({
+        send: channelSendSpy
+      })
+    })
+
+    it(`has all expected member functions`, () => {
+      expect(window.startAutoResizer).to.be.a('function')
+      expect(window.stopAutoResizer).to.be.a('function')
+      expect(window.updateHeight).to.be.a('function')
+    })
+
+    describe(`.startAutoResizer()`, () => {
+      let updateHeightSpy
+      beforeEach(() => {
+        updateHeightSpy = sinon.stub(window, 'updateHeight')
+        window.startAutoResizer()
+      })
+
+      it(`calls .updateHeight() initially`, () => {
+        expect(updateHeightSpy.callCount).to.equal(1)
+      })
+      it(`calls .updateHeight() without arguments (auto mode)`, () => {
+        expect(updateHeightSpy).to.have.been.calledWithExactly()
+      })
+
+      describe(`after auto resizer got started`, () => {
+        it(`listens to DOM changes and invokes .updateHeigt()`, (done) => {
+          updateHeightSpy.restore()
+          updateHeightSpy = sandbox.stub(window, 'updateHeight', () => {
+            expect(updateHeightSpy).to.have.callCount(1)
+            done()
+          })
+          modifyDOM()
+        })
+        it(`listens to global "resize" event and invokes .updateHeight()`, () => {
+          fireViewportResize()
+          expect(updateHeightSpy).to.have.callCount(2)
+        })
+      })
+
+      describe(`followed by .stopAutoResizer()`, () => {
+        beforeEach(() => {
+          window.stopAutoResizer()
+          updateHeightSpy.reset()
+        })
+
+        it(`stops observing DOM and does not invoke updateHeight()`, (done) => {
+          setTimeout(() => {
+            expect(updateHeightSpy).to.have.callCount(0)
+            done()
+          }, 0)
+          modifyDOM()
+        })
+        it(`stops listening to "resize" event does not invoke .updateHeight()`, () => {
+          fireViewportResize()
+          expect(updateHeightSpy).to.have.callCount(0)
+        })
+      })
+    })
+
+    describe(`.stopAutoResizer()`, () => {
+      it(`returns nothing, does not fail`, () => {
+        expect(window.stopAutoResizer()).to.equal(undefined)
+      })
+    })
+
+    describe(`.updateHeight()`, () => {
+      it(`notifies the parent window`, () => {
+        window.updateHeight()
+        expect(channelSendSpy).to.have.callCount(1)
+      })
+    })
+
+    describe(`.updateHeight(number)`, () => {
+      beforeEach(() => {
+        window.updateHeight(42)
+      })
+
+      it(`notifies the parent window`, () => {
+        expect(channelSendSpy).to.have.callCount(1)
+      })
+
+      describe(`called a second time with the same number`, () => {
+        it(`does not notify the parent window a second time`, () => {
+          window.updateHeight(42)
+          expect(channelSendSpy).to.have.callCount(1)
+        })
+      })
+    })
+  })
+})
+
+function modifyDOM () {
+  const elem = window.document.createElement('p')
+  window.document.body.appendChild(elem)
+}
+
+function fireViewportResize () {
+  window.dispatchEvent(new Event('resize'))
+}


### PR DESCRIPTION
Unit tests and some related refactoring, mostly to increase testability as well as a few minor bug fixes.
Uses _Karma_, _Mocha_, _Chai_ and _Sinon_ for unit tests. Tests can be run via `npm test`.

**API Changes:**
- **[bugfix]** `Field#removeValue()` returns a promise as specified
- `Signal#attach(handler)` throws an error if handler is not a function
- New class `UnknownLocaleError` which gets thrown by `Field`
- `Channel` expects target `window` as constructor parameter
- `Channel.messageCount`
- Moved and exposed _index.js_'s `setup()` in _setup.js_
- Some minor cosmetic changes

None of these changes is really affecting the documented [Widget API](https://github.com/contentful/widget-sdk/blob/master/doc/widget-api-frontend.md)

See [TP #7409](https://contentful.tpondemand.com/entity/7409)
