### PR TITLE
Refactores Field to share code with FieldLocale

### DIFF
--- a/lib/api/field-locale.js
+++ b/lib/api/field-locale.js
@@ -5,13 +5,12 @@ export default class FieldLocale {
   constructor (channel, {id, locale, value}) {
     this.id = id
     this.locale = locale
-
     this._value = value
     this._valueSignal = new Signal()
     this._channel = channel
 
     channel.addHandler('valueChanged', (id, locale, value) => {
-      if (id === this.id && locale === this.locale) {
+      if (id === this.id && (!locale || locale === this.locale)) {
         this._value = value
         this._valueSignal.dispatch(value)
       }

--- a/lib/api/field.js
+++ b/lib/api/field.js
@@ -1,4 +1,4 @@
-import Signal from './signal'
+import FieldLocale from './field-locale'
 
 export default class Field {
 
@@ -6,39 +6,27 @@ export default class Field {
     this.id = info.id
     this.locales = info.locales
     this._defaultLocale = defaultLocale
-    this._valueSignals = {}
-    this._values = info.values
-    this._channel = channel
+    this._fieldLocales = {}
 
     this.locales.forEach((locale) => {
-      this._valueSignals[locale] = new Signal()
+      const value = info.values[locale]
+      this._fieldLocales[locale] =
+        new FieldLocale(channel, {id: this.id, locale, value})
     })
 
     assertHasLocale(this, defaultLocale)
-
-    channel.addHandler('valueChanged', (id, locale, value) => {
-      if (id !== this.id) {
-        return
-      }
-
-      const locales = locale ? [locale] : this.locales
-      locales.forEach((locale) => {
-        this._values[locale] = value
-        this._valueSignals[locale].dispatch(value)
-      })
-    })
   }
 
   getValue (locale) {
     locale = locale || this._defaultLocale
-    return this._values[locale]
+    const fieldLocale = this._fieldLocales[locale]
+    return fieldLocale ? fieldLocale.getValue() : undefined
   }
 
   setValue (value, locale) {
     locale = locale || this._defaultLocale
     assertHasLocale(this, locale)
-    this._values[locale] = value
-    return this._channel.call('setValue', this.id, locale, value)
+    return this._fieldLocales[locale].setValue(value)
   }
 
   removeValue (locale) {
@@ -51,13 +39,13 @@ export default class Field {
       locale = this._defaultLocale
     }
     assertHasLocale(this, locale)
-    return this._valueSignals[locale].attach(handler)
+    return this._fieldLocales[locale].onValueChanged(handler)
   }
 
 }
 
 function assertHasLocale (instance, locale) {
-  if (!instance._valueSignals[locale]) {
+  if (!instance._fieldLocales[locale]) {
     throw new UnknownLocaleError(instance.id, locale)
   }
 }

--- a/test/unit/field-locale.spec.js
+++ b/test/unit/field-locale.spec.js
@@ -97,6 +97,13 @@ describe('FieldLocale', () => {
             expect(field.getValue()).to.equal(newValue)
           })
         })
+        describe(`without locale provided`, () => {
+          it(`sets the locale's value to the given one`, () => {
+            valueChangedHandler(field.id, undefined, newValue)
+
+            expect(field.getValue()).to.equal(newValue)
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
Since a Field basically consists of multiple locales and their values, it
makes perfect sense to use FieldLocale instances internally. This allows us
to simplifiy Field by having all Channel related logic in FieldLocale only.
