### PR TITLE
Makes `Field#getValue()` reject unknown locales

### DIFF
--- a/doc/widget-api-frontend.md
+++ b/doc/widget-api-frontend.md
@@ -107,7 +107,8 @@ In addition to [`widget.field`](#widgetfield), a widget can also control the
 values of all other fields in the current entry in a similar way. The main
 difference here is that all operations on an `entry.fields` field accept an
 optional `locale` argument which falls back to the space's default locale (see
-[`widget.locales`](#widgetlocales)).
+[`widget.locales`](#widgetlocales)). Providing an unknown locale throws an
+exception.
 
 * `field.id: string`
 * `field.locales: Array<string>`

--- a/lib/api/field.js
+++ b/lib/api/field.js
@@ -18,15 +18,11 @@ export default class Field {
   }
 
   getValue (locale) {
-    locale = locale || this._defaultLocale
-    const fieldLocale = this._fieldLocales[locale]
-    return fieldLocale ? fieldLocale.getValue() : undefined
+    return this._getFieldLocale(locale).getValue()
   }
 
   setValue (value, locale) {
-    locale = locale || this._defaultLocale
-    assertHasLocale(this, locale)
-    return this._fieldLocales[locale].setValue(value)
+    return this._getFieldLocale(locale).setValue(value)
   }
 
   removeValue (locale) {
@@ -36,17 +32,22 @@ export default class Field {
   onValueChanged (locale, handler) {
     if (!handler) {
       handler = locale
-      locale = this._defaultLocale
+      locale = undefined
     }
+    return this._getFieldLocale(locale).onValueChanged(handler)
+  }
+
+  _getFieldLocale (locale) {
+    locale = locale || this._defaultLocale
     assertHasLocale(this, locale)
-    return this._fieldLocales[locale].onValueChanged(handler)
+    return this._fieldLocales[locale]
   }
 
 }
 
-function assertHasLocale (instance, locale) {
-  if (!instance._fieldLocales[locale]) {
-    throw new UnknownLocaleError(instance.id, locale)
+function assertHasLocale (field, locale) {
+  if (!field._fieldLocales[locale]) {
+    throw new UnknownLocaleError(field.id, locale)
   }
 }
 

--- a/test/unit/field.spec.js
+++ b/test/unit/field.spec.js
@@ -69,16 +69,16 @@ describe(`Field`, () => {
         })
       })
 
-      describe(`for locale set to a locale without value`, () => {
-        it(`should return undefined`, () => {
+      describe(`with locale set to a locale without value`, () => {
+        it(`returns undefined`, () => {
           expect(field.getValue(localeWithoutValue)).to.equal(undefined)
         })
       })
 
-      describe(`for locale set to a unknown locale`, () => {
-        it(`should return undefined`, () => {
-          expect(field.getValue('unknown-locale')).to.equal(undefined)
-        })
+      it(`throws UnknownLocaleError when locale is unknown to the field`, () => {
+        expect(() => {
+          field.getValue(unknownLocale)
+        }).to.throw((new UnknownLocaleError(field.id, unknownLocale)).message)
       })
 
       info.locales.forEach((locale) => {
@@ -134,6 +134,12 @@ describe(`Field`, () => {
     describe(`.removeValue(locale)`, () => {
       info.locales.forEach((locale) => {
         describeRemoveValue(`with locale set to "${locale}"`, locale)
+      })
+
+      it(`throws an error if locale is unknown to the field`, () => {
+        expect(() => {
+          field.removeValue(unknownLocale)
+        }).to.throw((new UnknownLocaleError(field.id, unknownLocale)).message)
       })
     })
 


### PR DESCRIPTION
- Passing an unknown locale into `Field#getValue()` will result in
  a UnknownLocaleError. This prevents confusion as `getValue()` is
  already returning `undefined` for empty fields.
- Also adds `Field#hasLocale()`
