### PR TITLE
Generates useful stacktraces for tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,6 +6,7 @@ assert.equal(webpackBabelLoaderConfig.loader, 'babel')
 
 webpackConfig.entry = {}
 webpackConfig.output = {}
+webpackConfig.devtool = 'inline-source-map' // Gives us correct stack traces.
 webpackBabelLoaderConfig.query.plugins.push('babel-plugin-rewire')
 
 module.exports = function (config) {
@@ -18,8 +19,8 @@ module.exports = function (config) {
     exclude: [
     ],
     preprocessors: {
-      './lib/api/index.js': ['webpack'],
-      './test/unit/**/*.spec.js': ['webpack']
+      './lib/api/index.js': ['webpack', 'sourcemap'],
+      './test/unit/**/*.spec.js': ['webpack', 'sourcemap'],
     },
     webpack: webpackConfig,
     reporters: ['dots'],

--- a/package.json
+++ b/package.json
@@ -29,16 +29,17 @@
     "yaku": "^0.11.4"
   },
   "devDependencies": {
+    "babel-plugin-rewire": "1.0.0-beta-3",
     "eslint": "^1.10.3",
     "eslint-config-standard": "^4.4.0",
     "eslint-plugin-standard": "^1.3.1",
-    "babel-plugin-rewire": "1.0.0-beta-3",
     "karma": "^0.13.15",
-    "karma-mocha": "^0.2.1",
     "karma-chai-plugins": "^0.6.1",
     "karma-chrome-launcher": "^0.2.2",
+    "karma-mocha": "^0.2.1",
     "karma-safari-launcher": "^0.1.1",
     "karma-slimerjs-launcher": "^0.2.0",
+    "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0"
   }
 }


### PR DESCRIPTION
Stacktraces were unusable so far as they related to the final,
bablified sources. This fixes the issue so that stack traces
will show line numbers in relation to the original source files.
