### PR TITLE
Fix typo in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ install the dependencies:
 
 ```bash
 git clone git@github.com:contentful/widget-sdk.git
-cd widget-wdk
+cd widget-sdk
 npm install
 ```
 


### PR DESCRIPTION
Fixing a typo - `widget-wdk` should be `widget-sdk`
