### PR TITLE
Adds "Translate All" example widget

### DIFF
--- a/examples/translate-all/README.md
+++ b/examples/translate-all/README.md
@@ -1,0 +1,39 @@
+# “Translate All Content” Sidebar Widget
+
+This widget translates text of all the entry's fields from the default locale to all
+other locales enabled in the space, using the
+[Yandex translation API](https://translate.yandex.com/developers).
+
+## Bootstrap example for local development
+
+In the directory containing this README, run
+```bash
+npm install
+```
+
+First set the access token on your environment, then create the widget on Contentful:
+```bash
+export CONTENTFUL_MANAGEMENT_ACCESS_TOKEN=<contentfulManagementApiToken>
+contentful-widget create --space-id <yourSpaceId>
+```
+
+Serve on `http://localhost:3000`:
+```bash
+gulp watch
+```
+This does automatically serve again on any change to the source files, so you only
+need to manually refresh your browser to see the changes.
+
+**Note:** Since the Contentful App is served through HTTPS while the widget code is
+loaded from your local machine through HTTP, you need to enable insecure content.
+See here how to do it in [Firefox][ff-mixed] and [Chrome][chrome-mixed].
+
+[ff-mixed]: https://support.mozilla.org/en-US/kb/mixed-content-blocking-firefox
+[chrome-mixed]: https://support.google.com/chrome/answer/1342714
+
+## Upload widget
+If you want to inline all dependencies and upload the widget entirely to Contentful:
+```bash
+gulp bundle
+contentful-widget update --srcdoc ./dist/index.min.html --space-id <yourSpaceId> --force
+```

--- a/examples/translate-all/README.md
+++ b/examples/translate-all/README.md
@@ -6,8 +6,15 @@ other locales enabled in the space, using the
 
 ## Bootstrap example for local development
 
-In the directory containing this README, run
+In the *widget-sdk* directory root, build the widget API with
 ```bash
+npm install
+make
+```
+
+Navigate to the *translate-all* directory containing this README and install
+```bash
+cd examples/translate-all
 npm install
 ```
 

--- a/examples/translate-all/gulpfile.js
+++ b/examples/translate-all/gulpfile.js
@@ -1,0 +1,117 @@
+var gulp = require('gulp')
+var del = require('del')
+var merge = require('utils-merge')
+var serve = require('gulp-serve')
+var rename = require('gulp-rename')
+var sourcemaps = require('gulp-sourcemaps')
+var inlinesource = require('gulp-inline-source')
+var duration = require('gulp-duration')
+var bundleTimer = duration('Javascript bundle time')
+var plumber = require('gulp-plumber')
+var stylus = require('gulp-stylus')
+var babelify = require('babelify')
+var watchify = require('watchify')
+var browserify = require('browserify')
+var source = require('vinyl-source-stream')
+var buffer = require('vinyl-buffer')
+
+var config = {
+  src: './src/',
+  mainJs: './index.js',
+  mainHtml: './index.html',
+  buildDir: './dist/',
+  dependencies: [
+    '../../dist/*.*',
+    // TODO: Sort out do-translate's issue with browserify.
+    './node_modules/do-translate/browser/do-translate.min.js'
+  ]
+}
+
+gulp.task('default', ['build'], function () {
+  gulp.start('serve')
+})
+
+// Serve dist folder on port 3000 for local development.
+gulp.task('serve', serve({
+  root: 'dist'
+}))
+
+// Serve and watch for changes so we don't have to run `gulp` after each change.
+gulp.task('watch', ['serve', 'stylus', 'copy-html', 'copy-deps'], function () {
+  gulp.watch('./src/index.html', ['copy-html'])
+  gulp.watch(config.dependencies, ['copy-deps'])
+
+  var bundler = watchifyBundler(newBundler(watchify.args))
+  bundler.on('update', bundle.bind(null, bundler))
+
+  return bundle(bundler)
+})
+
+gulp.task('build', ['stylus', 'copy-html', 'copy-deps'], function () {
+  return bundle(newBundler())
+})
+
+gulp.task('copy-html', function () {
+  return gulp.src(config.src + config.mainHtml)
+    .pipe(gulp.dest(config.buildDir))
+})
+
+gulp.task('copy-deps', function () {
+  return gulp.src(config.dependencies)
+    .pipe(gulp.dest(config.buildDir + 'lib'))
+})
+
+gulp.task('stylus', function () {
+  return gulp.src(config.src + '*.styl')
+    .pipe(plumber({
+      errorHandler: function (err) {
+        console.log(err)
+        this.emit('end')
+      }
+    }))
+    .pipe(stylus())
+    .pipe(plumber.stop())
+    .pipe(gulp.dest(config.buildDir))
+})
+
+// Bundles the whole widget into one file which can be uploaded to Contentful.
+gulp.task('bundle', ['build'], function () {
+  return gulp.src(config.buildDir + config.mainHtml)
+    .pipe(rename('index.min.html'))
+    .pipe(inlinesource())
+    .pipe(gulp.dest('./dist'))
+})
+
+gulp.task('clean', function () {
+  return del([
+    './dist'
+  ])
+})
+
+function bundle (bundler) {
+  return bundler.bundle()
+    .pipe(source(config.mainJs))
+    .pipe(buffer())
+    .pipe(sourcemaps.init({loadMaps: true}))
+    .pipe(sourcemaps.write('.'))
+    .pipe(gulp.dest(config.buildDir))
+    .pipe(bundleTimer)
+}
+
+function newBundler (args) {
+  args = merge({
+    debug: true,
+    basedir: config.src
+  }, args || {})
+
+  return browserify(config.mainJs, args)
+    .transform(babelify, {
+      presets: ['es2015']
+    })
+}
+
+function watchifyBundler (bundler) {
+  return bundler.plugin(watchify, {
+    ignoreWatch: ['**/node_modules/**']
+  })
+}

--- a/examples/translate-all/package.json
+++ b/examples/translate-all/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "contentful-widget-translate-all-content",
+  "version": "1.0.0",
+  "private": true,
+  "main": "translate-all.js",
+  "dependencies": {
+    "do-translate": "^1.0.2"
+  },
+  "devDependencies": {
+    "babel-polyfill": "^6.3.14",
+    "babel-preset-es2015": "^6.3.13",
+    "babelify": "^7.2.0",
+    "browserify": "^13.0.0",
+    "del": "^2.2.0",
+    "gulp": "^3.9.0",
+    "gulp-duration": "0.0.0",
+    "gulp-inline-source": "^2.1.0",
+    "gulp-plumber": "^1.0.1",
+    "gulp-rename": "^1.2.2",
+    "gulp-serve": "^1.2.0",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-stylus": "^2.1.1",
+    "utils-merge": "^1.0.0",
+    "watchify": "^3.7.0"
+  }
+}

--- a/examples/translate-all/package.json
+++ b/examples/translate-all/package.json
@@ -21,6 +21,8 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-stylus": "^2.1.1",
     "utils-merge": "^1.0.0",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"
   }
 }

--- a/examples/translate-all/src/helpers.js
+++ b/examples/translate-all/src/helpers.js
@@ -1,0 +1,22 @@
+export function arrayLocalizableToTextLocalizables (
+  {locale, srcLocale, srcValue, localize}
+) {
+  const localizedValues = srcValue.slice()
+  return srcValue.map((value, i) => {
+    return {
+      locale,
+      srcLocale,
+      srcValue: value,
+      valueType: 'Text',
+      localize: (newValue) => {
+        console.log('srcValue was', srcValue, 'set', i, 'new value is', localizedValues)
+        localizedValues[i] = newValue
+        localize(localizedValues)
+      }
+    }
+  })
+}
+
+export function localeToLanguage (locale) {
+  return locale.match(/^[a-z]+/)[0]
+}

--- a/examples/translate-all/src/helpers.js
+++ b/examples/translate-all/src/helpers.js
@@ -9,7 +9,6 @@ export function arrayLocalizableToTextLocalizables (
       srcValue: value,
       valueType: 'Text',
       localize: (newValue) => {
-        console.log('srcValue was', srcValue, 'set', i, 'new value is', localizedValues)
         localizedValues[i] = newValue
         localize(localizedValues)
       }

--- a/examples/translate-all/src/index.html
+++ b/examples/translate-all/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Translate All Content</title>
+  <link rel="stylesheet" type="text/css" href="lib/cf-widget-api.css" inline>
+  <link rel="stylesheet" type="text/css" href="styles.css" inline>
+</head>
+<body>
+  <script src="lib/cf-widget-api.js" inline></script>
+  <script src="lib/do-translate.min.js" inline></script>
+  <script src="index.js" inline></script>
+
+  <button type="submit" class="cf-btn-primary" disabled>Translate all content</button>
+</body>
+</html>

--- a/examples/translate-all/src/index.html
+++ b/examples/translate-all/src/index.html
@@ -10,6 +10,14 @@
   <script src="lib/do-translate.min.js" inline></script>
   <script src="index.js" inline></script>
 
-  <button type="submit" class="cf-btn-primary" disabled>Translate all content</button>
+  <form>
+    <div class="cf-form-option">
+      <input type="checkbox" id="trall-copy-untranslatable">
+      <div class="cf-form-label">
+        <label for="trall-copy-untranslatable">Copy default locale's content if no translation can be made.</label>
+      </div>
+    </div>
+    <button type="button" id="trall-btn-translate" class="cf-btn-primary" disabled>Translate all content</button>
+  </form>
 </body>
 </html>

--- a/examples/translate-all/src/index.js
+++ b/examples/translate-all/src/index.js
@@ -1,0 +1,51 @@
+/**
+ * Custom sidebar widget to translate all content.
+ * Displays a “Translate all content” button in the sidebar.
+ */
+
+import 'babel-polyfill'
+
+import Localizer from './localizer'
+import NonLocalizedLocalizablesGenerator from './localizables-generator'
+
+window.contentfulWidget.init(initWidget)
+
+function initWidget (cfApi) {
+  cfApi.window.updateHeight()
+
+  const contentTypeId = cfApi.entry.getSys().contentType.sys.id
+  const translateButton = document.getElementsByTagName('button')[0]
+  const translator = new Localizer()
+  let localesGenerator
+
+  cfApi.space.getContentType(contentTypeId).then(function (contentType) {
+    const fieldTypes = getFieldTypesMapFromContentType(contentType)
+    localesGenerator =
+      new NonLocalizedLocalizablesGenerator(
+        cfApi.entry, fieldTypes, cfApi.locales.default)
+
+    translateButton.disabled = false
+  })
+
+  translateButton.addEventListener('click', () => {
+    translateButton.classList.add('cf-is-loading')
+    translateButton.disabled = true
+
+    translator.localize(localesGenerator.generateLocalizables())
+      .then(releaseButton)
+      .catch(releaseButton)
+
+    function releaseButton () {
+      translateButton.classList.remove('cf-is-loading')
+      translateButton.disabled = false
+    }
+  })
+}
+
+function getFieldTypesMapFromContentType (contentType) {
+  const fieldTypes = {}
+  contentType.fields.forEach((fieldDefinition) => {
+    fieldTypes[fieldDefinition.id] = fieldDefinition.type
+  })
+  return fieldTypes
+}

--- a/examples/translate-all/src/index.js
+++ b/examples/translate-all/src/index.js
@@ -27,12 +27,10 @@ function initWidget (cfApi) {
   })
 
   translateButton.addEventListener('click', () => {
-    const localizer = newLocalizer()
-
     translateButton.classList.add('cf-is-loading')
     translateButton.disabled = true
 
-    localizer.localize(localesGenerator.generateLocalizables())
+    newLocalizer().localize(localesGenerator.generateLocalizables())
       .then(releaseButton)
       .catch(releaseButton)
 

--- a/examples/translate-all/src/index.js
+++ b/examples/translate-all/src/index.js
@@ -3,19 +3,18 @@
  * Displays a “Translate all content” button in the sidebar.
  */
 
-import 'babel-polyfill'
-
 import Localizer from './localizer'
 import NonLocalizedLocalizablesGenerator from './localizables-generator'
+
+const $ = document.querySelector.bind(document)
 
 window.contentfulWidget.init(initWidget)
 
 function initWidget (cfApi) {
-  cfApi.window.updateHeight()
+  cfApi.window.startAutoResizer()
 
   const contentTypeId = cfApi.entry.getSys().contentType.sys.id
-  const translateButton = document.getElementsByTagName('button')[0]
-  const translator = new Localizer()
+  const translateButton = $('#trall-btn-translate')
   let localesGenerator
 
   cfApi.space.getContentType(contentTypeId).then(function (contentType) {
@@ -28,10 +27,12 @@ function initWidget (cfApi) {
   })
 
   translateButton.addEventListener('click', () => {
+    const localizer = newLocalizer()
+
     translateButton.classList.add('cf-is-loading')
     translateButton.disabled = true
 
-    translator.localize(localesGenerator.generateLocalizables())
+    localizer.localize(localesGenerator.generateLocalizables())
       .then(releaseButton)
       .catch(releaseButton)
 
@@ -40,6 +41,11 @@ function initWidget (cfApi) {
       translateButton.disabled = false
     }
   })
+
+  function newLocalizer () {
+    const copyUntranslatableLocales = $('#trall-copy-untranslatable').checked
+    return new Localizer({copyUntranslatableLocales})
+  }
 }
 
 function getFieldTypesMapFromContentType (contentType) {

--- a/examples/translate-all/src/index.js
+++ b/examples/translate-all/src/index.js
@@ -31,8 +31,7 @@ function initWidget (cfApi) {
     translateButton.disabled = true
 
     newLocalizer().localize(localesGenerator.generateLocalizables())
-      .then(releaseButton)
-      .catch(releaseButton)
+      .then(releaseButton, releaseButton)
 
     function releaseButton () {
       translateButton.classList.remove('cf-is-loading')

--- a/examples/translate-all/src/localizables-generator.js
+++ b/examples/translate-all/src/localizables-generator.js
@@ -25,7 +25,7 @@ export default class NonLocalizedLocalizablesGenerator {
 
     for (let locale of field.locales) {
       const value = field.getValue(locale)
-      if (value === undefined && value !== srcValue) {
+      if (value === undefined) {
         yield {
           locale,
           srcLocale,

--- a/examples/translate-all/src/localizables-generator.js
+++ b/examples/translate-all/src/localizables-generator.js
@@ -1,0 +1,37 @@
+export default class NonLocalizedLocalizablesGenerator {
+  constructor (entry, fieldTypes, defaultLocale) {
+    this.entry = entry
+    this.fieldTypes = fieldTypes
+    this.defaultLocale = defaultLocale
+  }
+
+  * generateLocalizables () {
+    const fields = this.entry.fields
+    for (let fieldId in fields) {
+      const field = fields[fieldId]
+      yield* this._generateLocalizablesOfField(field, fieldId)
+    }
+  }
+
+  * _generateLocalizablesOfField (field, fieldId) {
+    const srcLocale = this.defaultLocale
+    const srcValue = field.getValue()
+    if (srcValue === undefined) {
+      return
+    }
+    const valueType = this.fieldTypes[fieldId]
+
+    for (let locale of field.locales) {
+      const value = field.getValue(locale)
+      if (value === undefined && value !== srcValue) {
+        yield {
+          locale,
+          srcLocale,
+          srcValue,
+          valueType,
+          localize: (value) => field.setValue(value, locale)
+        }
+      }
+    }
+  }
+}

--- a/examples/translate-all/src/localizables-generator.js
+++ b/examples/translate-all/src/localizables-generator.js
@@ -1,3 +1,5 @@
+import 'babel-polyfill'
+
 export default class NonLocalizedLocalizablesGenerator {
   constructor (entry, fieldTypes, defaultLocale) {
     this.entry = entry

--- a/examples/translate-all/src/localizables-generator.js
+++ b/examples/translate-all/src/localizables-generator.js
@@ -25,11 +25,11 @@ export default class NonLocalizedLocalizablesGenerator {
 
     for (let locale of field.locales) {
       const value = field.getValue(locale)
-      if (value === undefined) {
+      // TODO: Remove one of those once we made up our mind what to return.
+      if (value === undefined || value === null) {
         yield {
           locale,
           srcLocale,
-          srcValue,
           valueType,
           localize: (value) => field.setValue(value, locale)
         }

--- a/examples/translate-all/src/localizer.js
+++ b/examples/translate-all/src/localizer.js
@@ -1,7 +1,9 @@
 import yandexTranslator from './yandex-translator'
 
 export default class Localizer {
-  constructor () {}
+  constructor (options) {
+    this._options = options
+  }
 
   localize (localizables) {
     const promises = []
@@ -21,7 +23,7 @@ export default class Localizer {
     ) {
       return this._translateLocale(localizable)
     }
-    return this._copyLocale(localizable)
+    return this._handleUntranslatable(localizable)
   }
 
   _translateLocale (localizable) {
@@ -35,9 +37,17 @@ export default class Localizer {
           localize(result)
           return result
         } else {
-          return this._copyLocale(localizable)
+          return this._handleUntranslatable(localizable)
         }
       })
+  }
+
+  _handleUntranslatable (localizable) {
+    if (this._options.copyUntranslatableLocales) {
+      return this._copyLocale(localizable)
+    } else {
+      return Promise.resolve()
+    }
   }
 
   _copyLocale ({srcValue, localize}) {

--- a/examples/translate-all/src/localizer.js
+++ b/examples/translate-all/src/localizer.js
@@ -1,0 +1,51 @@
+import yandexTranslator from './yandex-translator'
+
+export default class Localizer {
+  constructor () {}
+
+  localize (localizables) {
+    const promises = []
+    for (let localizable of localizables) {
+      const p = this._handleLocalizable(localizable)
+      promises.push(p)
+    }
+    return Promise.all(promises)
+  }
+
+  _handleLocalizable (localizable) {
+    const {srcValue, valueType} = localizable
+    if (
+      // TODO: Handle "Array" as well.
+      ['Symbol', 'Text'].indexOf(valueType) > -1 &&
+      typeof srcValue === 'string'
+    ) {
+      return this._translateLocale(localizable)
+    }
+    return this._copyLocale(localizable)
+  }
+
+  _translateLocale (localizable) {
+    const {locale, srcLocale, srcValue, localize} = localizable
+    const sourceLang = localeToLanguage(srcLocale)
+    const targetLang = localeToLanguage(locale)
+    return yandexTranslator
+      .lookup(srcValue, targetLang, sourceLang)
+      .then((result) => {
+        if (typeof result === 'string') {
+          localize(result)
+          return result
+        } else {
+          return this._copyLocale(localizable)
+        }
+      })
+  }
+
+  _copyLocale ({srcValue, localize}) {
+    localize(srcValue)
+    return Promise.resolve(srcValue)
+  }
+}
+
+function localeToLanguage (locale) {
+  return locale.match(/^[a-z]+/)[0]
+}

--- a/examples/translate-all/src/localizer.js
+++ b/examples/translate-all/src/localizer.js
@@ -1,4 +1,5 @@
 import yandexTranslator from './yandex-translator'
+import {arrayLocalizableToTextLocalizables, localeToLanguage} from './helpers.js'
 
 export default class Localizer {
   constructor (options) {
@@ -17,13 +18,18 @@ export default class Localizer {
   _handleLocalizable (localizable) {
     const {srcValue, valueType} = localizable
     if (
-      // TODO: Handle "Array" as well.
       ['Symbol', 'Text'].indexOf(valueType) > -1 &&
       typeof srcValue === 'string'
     ) {
       return this._translateLocale(localizable)
+    } else if (
+      valueType === 'Array' && Array.isArray(srcValue)
+    ) {
+      const textLocalizables = arrayLocalizableToTextLocalizables(localizable)
+      return this.localize(textLocalizables)
+    } else {
+      return this._handleUntranslatable(localizable)
     }
-    return this._handleUntranslatable(localizable)
   }
 
   _translateLocale (localizable) {
@@ -54,8 +60,4 @@ export default class Localizer {
     localize(srcValue)
     return Promise.resolve(srcValue)
   }
-}
-
-function localeToLanguage (locale) {
-  return locale.match(/^[a-z]+/)[0]
 }

--- a/examples/translate-all/src/styles.styl
+++ b/examples/translate-all/src/styles.styl
@@ -1,2 +1,5 @@
-button
+body
+  padding-top: 4px; // Account for checkbox label's negative margin.
+
+#trall-btn-translate
   width: 100%

--- a/examples/translate-all/src/styles.styl
+++ b/examples/translate-all/src/styles.styl
@@ -1,0 +1,2 @@
+button
+  width: 100%

--- a/examples/translate-all/src/yandex-translator.js
+++ b/examples/translate-all/src/yandex-translator.js
@@ -1,0 +1,10 @@
+// Hardcoded secrets for now!
+
+const YANDEX_API_KEY =
+  'trnsl.1.1.20151015T080754Z.fac48f0d13a96c3a.c0c58058288c42ba40de8aec2b36d9d86c3adb1d'
+const YANDEX_API_URI = 'https://translate.yandex.net/api/v1.5/tr.json/'
+
+const yandexTranslator =
+  new doTranslate.Translator('yandex', YANDEX_API_KEY, YANDEX_API_URI)
+
+export default yandexTranslator

--- a/examples/translate-all/widget.json
+++ b/examples/translate-all/widget.json
@@ -1,0 +1,7 @@
+{
+  "id": "translateAllContent",
+  "name": "Translate All Content",
+  "src": "http://localhost:3000/",
+  "sidebar": true,
+  "fieldTypes": ["Symbol", "Text"]
+}

--- a/examples/translate-all/widget.json
+++ b/examples/translate-all/widget.json
@@ -3,5 +3,5 @@
   "name": "Translate All Content",
   "src": "http://localhost:3000/",
   "sidebar": true,
-  "fieldTypes": ["Symbol", "Text"]
+  "fieldTypes": ["Symbol", "Text", "Object"]
 }


### PR DESCRIPTION
This widget translates text of all the entry's fields from the default
locale to all other locales enabled in the space. It uses the Yandex
Translation API.

[TP # 7703](https://contentful.tpondemand.com/entity/7703)