### PR TITLE
Validations and error callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ the [“Keep a Changelog” format](http://keepachangelog.com/).
 ## Upcoming
 ### Added
 - `field.validations` property.
+- `field.onSchemaErrorsChanged` signal.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and
 the [“Keep a Changelog” format](http://keepachangelog.com/).
 
+## Upcoming
+### Added
+- `field.validations` property.
+
+### Fixed
+
+- Use `dist/cf-extension-api.js` file as the module's entry point
+
 ## 2.0.1 - 2016-07-13
 
 ### Fixed

--- a/docs/ui-extensions-sdk-frontend.md
+++ b/docs/ui-extensions-sdk-frontend.md
@@ -134,6 +134,13 @@ Holds the type of the field the extension is attached to.
 The field type can be one of the many described
 [in our api documentation](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/content-types).
 
+##### `extension.field.validations: Validation[]`
+A list of validations for this field that are defined in the content type. The
+[content type documentation](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/content-types/content-type/create/update-a-content-type)
+provides more information on the shape of validations.
+
+_In upcoming release_
+
 ## `extension.entry`
 This object allows you to read and update the value of any field of the current
 entry and to get the entry's metadata.

--- a/docs/ui-extensions-sdk-frontend.md
+++ b/docs/ui-extensions-sdk-frontend.md
@@ -121,6 +121,17 @@ A boolean indicating whether the field is disabled or not is passed to the callb
 
 The method returns a function that can be called to stop listerning to changes.
 
+##### `extension.field.onSchemaErrorsChanged(cb): function`
+Calls the callback immediately with the current validation errors and whenever
+the field is revalidated. The callback receives an array of error objects. An empty array indicates no errors.
+
+The errors are updated when the app validates an entry. This happens when
+loading an entry or when the user tries to publish it.
+
+The method returns a function that can be called to stop listerning to changes.
+
+_In upcoming release_
+
 ##### `extension.field.id: string`
 The ID of a field is defined in an entry’s content type. Yields `"title"` in the
 example.

--- a/lib/api/channel.js
+++ b/lib/api/channel.js
@@ -1,16 +1,34 @@
 import Promise from 'yaku'
 import { Signal } from './signal'
 
-export default class Channel {
+export default function connect (targetWindow, onConnect) {
+  waitForConnect(targetWindow, (params) => {
+    const channel = new Channel(params.id, targetWindow)
+    onConnect(channel, params)
+  })
+}
 
+
+function waitForConnect (targetWindow, onConnect) {
+  window.addEventListener('message', listener)
+
+  function listener (event) {
+    const message = event.data
+    if (message.method === 'connect') {
+      window.removeEventListener('message', listener)
+      onConnect(...message.params)
+    }
+  }
+}
+
+
+class Channel {
   constructor (sourceId, targetWindow) {
-    this.sourceId = sourceId
-    this.targetWindow = targetWindow // contentful webapp window
-    this._messageCount = 0
     this._messageHandlers = {}
     this._responseHandlers = {}
 
-    // window refers to iframe contentWindow
+    this._send = createSender(sourceId, targetWindow)
+
     window.addEventListener('message', (event) => {
       this._handleMessage(event.data)
     })
@@ -51,17 +69,21 @@ export default class Channel {
       if ('result' in message) {
         responseHandler.resolve(message.result)
       } else if ('error' in message) {
+        // TODO We should wrap this in an Error instance
         responseHandler.reject(message.error)
       }
       delete this._responseHandlers[id]
     }
   }
+}
 
-  _send (method, params) {
-    const messageId = this._messageCount++
+function createSender (sourceId, targetWindow) {
+  let messageCount = 0
+  return function send (method, params) {
+    const messageId = messageCount++
 
-    this.targetWindow.postMessage({
-      source: this.sourceId,
+    targetWindow.postMessage({
+      source: sourceId,
       id: messageId,
       method,
       params
@@ -69,5 +91,4 @@ export default class Channel {
 
     return messageId
   }
-
 }

--- a/lib/api/channel.js
+++ b/lib/api/channel.js
@@ -2,9 +2,9 @@ import Promise from 'yaku'
 import { Signal } from './signal'
 
 export default function connect (targetWindow, onConnect) {
-  waitForConnect(targetWindow, (params) => {
+  waitForConnect(targetWindow, (params, messageQueue) => {
     const channel = new Channel(params.id, targetWindow)
-    onConnect(channel, params)
+    onConnect(channel, params, messageQueue)
   })
 }
 

--- a/lib/api/field-locale.js
+++ b/lib/api/field-locale.js
@@ -10,6 +10,7 @@ export default class FieldLocale {
     this._value = fieldInfo.value
     this._valueSignal = new MemoizedSignal(fieldInfo.value)
     this._isDisabledSignal = new MemoizedSignal(undefined)
+    this._schemaErrorsChangedSignal = new MemoizedSignal(undefined)
     this._channel = channel
 
     channel.addHandler('valueChanged', (id, locale, value) => {
@@ -23,6 +24,10 @@ export default class FieldLocale {
 
     channel.addHandler('isDisabledChanged', (isDisabled) => {
       this._isDisabledSignal.dispatch(isDisabled)
+    })
+
+    channel.addHandler('schemaErrorsChanged', (errors) => {
+      this._schemaErrorsChangedSignal.dispatch(errors)
     })
   }
 
@@ -50,6 +55,10 @@ export default class FieldLocale {
 
   onIsDisabledChanged (handler) {
     return this._isDisabledSignal.attach(handler)
+  }
+
+  onSchemaErrorsChanged (handler) {
+    return this._schemaErrorsChangedSignal.attach(handler)
   }
 
 }

--- a/lib/api/field-locale.js
+++ b/lib/api/field-locale.js
@@ -9,7 +9,7 @@ export default class FieldLocale {
     this.validations = fieldInfo.validations
     this._value = fieldInfo.value
     this._valueSignal = new MemoizedSignal(fieldInfo.value)
-    this._isDisabledSignal = new MemoizedSignal(fieldInfo.isDisabled)
+    this._isDisabledSignal = new MemoizedSignal(undefined)
     this._channel = channel
 
     channel.addHandler('valueChanged', (id, locale, value) => {

--- a/lib/api/field-locale.js
+++ b/lib/api/field-locale.js
@@ -2,13 +2,14 @@ import { MemoizedSignal } from './signal'
 
 export default class FieldLocale {
 
-  constructor (channel, {id, locale, value, type, isDisabled}) {
-    this.id = id
-    this.locale = locale
-    this.type = type
-    this._value = value
-    this._valueSignal = new MemoizedSignal(value)
-    this._isDisabledSignal = new MemoizedSignal(isDisabled)
+  constructor (channel, fieldInfo) {
+    this.id = fieldInfo.id
+    this.locale = fieldInfo.locale
+    this.type = fieldInfo.type
+    this.validations = fieldInfo.validations
+    this._value = fieldInfo.value
+    this._valueSignal = new MemoizedSignal(fieldInfo.value)
+    this._isDisabledSignal = new MemoizedSignal(fieldInfo.isDisabled)
     this._channel = channel
 
     channel.addHandler('valueChanged', (id, locale, value) => {
@@ -20,7 +21,7 @@ export default class FieldLocale {
       }
     })
 
-    channel.addHandler('isDisabledChanged', isDisabled => {
+    channel.addHandler('isDisabledChanged', (isDisabled) => {
       this._isDisabledSignal.dispatch(isDisabled)
     })
   }

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,10 +1,10 @@
-import initializeApi from './initialize'
+import createInitializer from './initialize'
 import FieldLocale from './field-locale'
 import createWindow from './window'
 import createEntry from './entry'
 import createSpace from './space'
 
-export var init = initializeApi(createWidgetAPI)
+export var init = createInitializer(createWidgetAPI)
 
 function createWidgetAPI (channel, {entry, locales, field, fieldInfo, contentType}) {
   return {

--- a/lib/api/initialize.js
+++ b/lib/api/initialize.js
@@ -5,9 +5,13 @@ export default function createInitializer (apiCreator) {
   const channelDeferred = createDeferred()
   channelDeferred.then(addFocusHandlers)
 
-  connect(window.parent, (channel, params) => {
+  connect(window.parent, (channel, params, messageQueue) => {
     channelDeferred.resolve(channel)
-    apiDeferred.resolve(apiCreator(channel, params))
+    const api = apiCreator(channel, params)
+    messageQueue.forEach((m) => {
+      channel._handleMessage(m)
+    })
+    apiDeferred.resolve(api)
   })
 
   return function init (initCb) {

--- a/lib/api/initialize.js
+++ b/lib/api/initialize.js
@@ -1,33 +1,41 @@
-import Channel from './channel'
-import { Signal } from './signal'
+import connect from './channel'
 
-export default function initializeApi (apiCreator) {
-  const channel = new Channel(null, window.parent)
-  let apiInitCallbacks = new Signal()
-  let createdApi
+export default function createInitializer (apiCreator) {
+  const apiDeferred = createDeferred()
+  const channelDeferred = createDeferred()
+  channelDeferred.then(addFocusHandlers)
 
-  const removeHandler = channel.addHandler('connect', (params) => {
-    removeHandler()
-    channel.sourceId = params.id
-
-    createdApi = apiCreator(channel, params)
-
-    apiInitCallbacks.dispatch(createdApi)
-    apiInitCallbacks = null
+  connect(window.parent, (channel, params) => {
+    channelDeferred.resolve(channel)
+    apiDeferred.resolve(apiCreator(channel, params))
   })
 
   return function init (initCb) {
-    document.addEventListener('focus', setActive(true), true)
-    document.addEventListener('blur', setActive(false), true)
+    apiDeferred.then(initCb)
+  }
+}
 
-    if (createdApi) {
-      initCb(createdApi)
-    } else {
-      apiInitCallbacks.attach(initCb)
-    }
+function addFocusHandlers (channel) {
+  document.addEventListener('focus', () => channel.send('setActive', true), true)
+  document.addEventListener('blur', () => channel.send('setActive', false), true)
+}
 
-    function setActive (isActive) {
-      return () => channel.send('setActive', isActive)
+function createDeferred () {
+  let isResolved = false
+  let resolvedValue
+  let callbacks = []
+  return {
+    resolve: function (value) {
+      isResolved = true
+      resolvedValue = value
+      callbacks.forEach((cb) => cb(value))
+    },
+    then: function (cb) {
+      if (isResolved) {
+        cb(resolvedValue)
+      } else {
+        callbacks.push(cb)
+      }
     }
   }
 }

--- a/lib/api/initialize.js
+++ b/lib/api/initialize.js
@@ -27,7 +27,7 @@ export default function initializeApi (apiCreator) {
     }
 
     function setActive (isActive) {
-      return () => channel.call('setActive', isActive)
+      return () => channel.send('setActive', isActive)
     }
   }
 }

--- a/test/unit/field-locale.spec.js
+++ b/test/unit/field-locale.spec.js
@@ -12,7 +12,6 @@ describe('FieldLocale', () => {
     locale: 'en-US',
     value: 'Hello',
     type: 'Symbol',
-    isDisabled: true,
     validations: 'VALIDATIONS'
   }
   let channelStub
@@ -80,8 +79,6 @@ describe('FieldLocale', () => {
   })
 
   describe('.onIsDisabledChanged(handler)', () => {
-    testChangeMethod('onIsDisabledChanged', info.isDisabled)
-
     it('calls handler when method is received', () => {
       const cb = sinon.spy()
 
@@ -94,14 +91,23 @@ describe('FieldLocale', () => {
   })
 
   describe('.onValueChanged(handler)', () => {
-    testChangeMethod('onValueChanged', info.value)
-
     const newValue = 'some new, unused value'
     let valueChangedHandler
     beforeEach(() => {
       valueChangedHandler = function (...args) {
         channelStub.receiveMethod('valueChanged', args)
       }
+    })
+
+    describeAttachHandlerMember('default behaviour', () => {
+      return field.onValueChanged(noop)
+    })
+
+    it('calls handler immediately on attach with initial value of field', () => {
+      const spy = sinon.spy()
+      field.onValueChanged(spy)
+      sinon.assert.calledOnce(spy)
+      sinon.assert.calledWithExactly(spy, info.value)
     })
 
     describe('New value equals current value', () => {
@@ -165,20 +171,6 @@ describe('FieldLocale', () => {
     it('returns the promise returned by internal channel.call()', () => {
       channelStub.call.withArgs(method).returns('PROMISE')
       expect(field[method]('val')).to.equal('PROMISE')
-    })
-  }
-
-  function testChangeMethod (methodName, initialValue) {
-    describeAttachHandlerMember('default behaviour', () => {
-      return field[methodName](noop)
-    })
-
-    it('calls handler immediately on attach with initial value of field', () => {
-      const spy = sinon.spy()
-
-      field[methodName](spy)
-      sinon.assert.calledOnce(spy)
-      sinon.assert.calledWithExactly(spy, initialValue)
     })
   }
 })

--- a/test/unit/field-locale.spec.js
+++ b/test/unit/field-locale.spec.js
@@ -1,194 +1,184 @@
 import FieldLocale from '../../lib/api/field-locale'
+import cloneDeep from 'lodash/cloneDeep'
 import {
   noop,
   describeAttachHandlerMember
 } from '../helpers'
 
 describe('FieldLocale', () => {
+  const defaultLocale = 'en-US'
+  const info = {
+    id: 'some-field',
+    locale: 'en-US',
+    value: 'Hello',
+    type: 'Symbol',
+    isDisabled: true,
+    validations: 'VALIDATIONS'
+  }
   let channelStub
+  let field
+
   beforeEach(() => {
     channelStub = {
-      addHandler: sinon.stub(),
-      call: sinon.stub()
+      _handlers: {},
+      addHandler: function (method, cb) {
+        this._handlers[method] = cb
+      },
+      call: sinon.stub(),
+      receiveMethod: function (method, params) {
+        this._handlers[method](...params)
+      }
     }
+
+    const infoCopy = cloneDeep(info)
+    field = new FieldLocale(channelStub, infoCopy)
   })
 
-  describe('instance', () => {
-    const defaultLocale = 'en-US'
-    const info = {
-      id: 'some-field',
-      locale: 'en-US',
-      value: 'Hello',
-      type: 'Symbol',
-      isDisabled: true,
-      validations: 'VALIDATIONS'
-    }
-    let field
+  describe('.id', () => {
+    it('is equal to info.id', () => {
+      expect(field.id).to.equal(info.id)
+    })
+  })
+
+  describe('.type', () => {
+    it('is equal to info.type', () => {
+      expect(field.type).to.equal(info.type)
+    })
+  })
+
+  describe('.locale', () => {
+    it('is set to the same value as given to first constructor arg\'s .locale', () => {
+      expect(field.locale).to.equal(info.locale)
+    })
+  })
+
+  describe('.validations', () => {
+    it('is equal to info.validations', () => {
+      expect(field.validations).to.equal(info.validations)
+    })
+  })
+
+  describe('.getValue()', () => {
+    it('returns the field\'s value', () => {
+      expect(field.getValue()).to.equal(info.value)
+    })
+  })
+
+  describe('.setValue(value)', () => {
+    testValueMethods('setValue', 'new-value')
+  })
+
+  describe('.removeValue()', () => {
+    testValueMethods('removeValue')
+  })
+
+  describe('.setInvalid()', () => {
+    it('invokes channel.call("setInvalid", ...)', () => {
+      field.setInvalid(true)
+      sinon.assert.calledWithExactly(channelStub.call, 'setInvalid', true, info.locale)
+    })
+  })
+
+  describe('.onIsDisabledChanged(handler)', () => {
+    testChangeMethod('onIsDisabledChanged', info.isDisabled)
+
+    it('calls handler when method is received', () => {
+      const cb = sinon.spy()
+
+      field.onIsDisabledChanged(cb)
+      cb.reset()
+      channelStub.receiveMethod('isDisabledChanged', ['ISDISABLED'])
+      sinon.assert.calledOnce(cb)
+      sinon.assert.calledWithExactly(cb, 'ISDISABLED')
+    })
+  })
+
+  describe('.onValueChanged(handler)', () => {
+    testChangeMethod('onValueChanged', info.value)
+
+    const newValue = 'some new, unused value'
+    let valueChangedHandler
     beforeEach(() => {
-      const infoCopy = JSON.parse(JSON.stringify(info))
-      field = new FieldLocale(channelStub, infoCopy)
+      valueChangedHandler = function (...args) {
+        channelStub.receiveMethod('valueChanged', args)
+      }
     })
 
-    it('is a FieldLocale instance', () => {
-      expect(field).to.be.instanceof(FieldLocale)
-    })
-
-    describe('.id', () => {
-      it('is equal to info.id', () => {
-        expect(field.id).to.equal(info.id)
-      })
-    })
-
-    describe('.type', () => {
-      it('is equal to info.type', () => {
-        expect(field.type).to.equal(info.type)
-      })
-    })
-
-
-    describe('.locale', () => {
-      it('is set to the same value as given to first constructor arg\'s .locale', () => {
-        expect(field.locale).to.equal(info.locale)
-      })
-    })
-
-    describe('.validations', () => {
-      it('is equal to info.validations', () => {
-        expect(field.validations).to.equal(info.validations)
-      })
-    })
-
-    describe('.getValue()', () => {
-      it('returns the field\'s value', () => {
-        expect(field.getValue()).to.equal(info.value)
-      })
-    })
-
-    describe('.setValue(value)', () => {
-      testValueMethods('setValue', 'new-value')
-    })
-
-    describe('.removeValue()', () => {
-      testValueMethods('removeValue')
-    })
-
-    describe('.setInvalid()', () => {
-      it('invokes channel.call("${setInvalid}", ...)', () => {
-        field.setInvalid(true)
-        sinon.assert.calledWithExactly(channelStub.call, 'setInvalid', true, info.locale)
-      })
-    })
-
-    describe('.onValueChanged(handler)', () => {
-      testChangeMethod('onValueChanged', info.value)
-    })
-
-    describe('.onIsDisabledChanged(handler)', () => {
-      testChangeMethod('onIsDisabledChanged', info.isDisabled)
-    })
-
-    describe('injected channel propagating "isDisabledChanged"', () => {
-      let isDisabledChangedHandler
-
-      beforeEach(() => {
-        isDisabledChangedHandler = channelStub.addHandler.args[1][1]
-      })
-
-      it('calls the handler with given value', () => {
+    describe('New value equals current value', () => {
+      it('does not dispatch new value', () => {
+        const oldValue = field.getValue()
         const cb = sinon.spy()
 
-        field.onIsDisabledChanged(cb)
+        field.onValueChanged(cb)
         sinon.assert.calledOnce(cb)
-        sinon.assert.calledWithExactly(cb, info.isDisabled)
-        isDisabledChangedHandler('ISDISABLED')
-        sinon.assert.calledTwice(cb)
-        sinon.assert.calledWithExactly(cb, 'ISDISABLED')
+        valueChangedHandler(field.id, defaultLocale, oldValue)
+        sinon.assert.calledOnce(cb)
       })
     })
 
-    describe('injected channel propagating "valueChanged"', () => {
-      const newValue = 'some new, unused value'
-      let valueChangedHandler
-      beforeEach(() => {
-        // The handler registered with channel.addHandler("valueChanged", handler)
-        valueChangedHandler = channelStub.addHandler.args[0][1]
-      })
+    describe('targeted at another field’s id', () => {
+      it('does not update the value', () => {
+        const oldValue = field.getValue()
+        valueChangedHandler(`${field.id}-other-id`, defaultLocale, newValue)
 
-      describe('New value equals current value', () => {
-        it('does not dispatch new value', () => {
-          const oldValue = field.getValue()
-          const cb = sinon.spy()
-
-          field.onValueChanged(cb)
-          sinon.assert.calledOnce(cb)
-          valueChangedHandler(field.id, defaultLocale, oldValue)
-          sinon.assert.calledOnce(cb)
-        })
-      })
-
-      describe('targeted at another field\'s id', () => {
-        it('does not update the value', () => {
-          const oldValue = field.getValue()
-          valueChangedHandler(`${field.id}-other-id`, defaultLocale, newValue)
-
-          expect(oldValue).to.equal(field.getValue())
-        })
-      })
-      describe('targeted at the field\'s id', () => {
-        describe('for specific locale', () => {
-          it('sets the locale\'s value to the given one', () => {
-            valueChangedHandler(field.id, defaultLocale, newValue)
-
-            expect(field.getValue()).to.equal(newValue)
-          })
-        })
-        describe('without locale provided', () => {
-          it('sets the locale\'s value to the given one', () => {
-            valueChangedHandler(field.id, undefined, newValue)
-
-            expect(field.getValue()).to.equal(newValue)
-          })
-        })
+        expect(oldValue).to.equal(field.getValue())
       })
     })
 
-    function testValueMethods (method, newValue) {
-      beforeEach(() => {
-        field[method](newValue)
-      })
+    describe('targeted at the field’s id', () => {
+      describe('for specific locale', () => {
+        it('sets the locale’s value to the given one', () => {
+          valueChangedHandler(field.id, defaultLocale, newValue)
 
-      it(`sets the value to ${newValue}`, () => {
-        expect(field.getValue()).to.equal(newValue)
+          expect(field.getValue()).to.equal(newValue)
+        })
       })
+      describe('without locale provided', () => {
+        it('sets the locale’s value to the given one', () => {
+          valueChangedHandler(field.id, undefined, newValue)
 
-      it('invokes channel.call("${method}", ...)', () => {
-        if (newValue === undefined) {
-          expect(channelStub.call).to.have.been.calledWithExactly(
-          method, field.id, info.locale)
-        } else {
-          expect(channelStub.call).to.have.been.calledWithExactly(
-          method, field.id, info.locale, newValue)
-        }
+          expect(field.getValue()).to.equal(newValue)
+        })
       })
-
-      it('returns the promise returned by internal channel.call()', () => {
-        channelStub.call.withArgs(method).returns('PROMISE')
-        expect(field[method]('val')).to.equal('PROMISE')
-      })
-    }
-
-    function testChangeMethod (methodName, initialValue) {
-      describeAttachHandlerMember('default behaviour', () => {
-        return field[methodName](noop)
-      })
-
-      it('calls handler immediately on attach with initial value of field', () => {
-        const spy = sinon.spy()
-
-        field[methodName](spy)
-        sinon.assert.calledOnce(spy)
-        sinon.assert.calledWithExactly(spy, initialValue)
-      })
-    }
+    })
   })
+
+  function testValueMethods (method, newValue) {
+    beforeEach(() => {
+      field[method](newValue)
+    })
+
+    it(`sets the value to ${newValue}`, () => {
+      expect(field.getValue()).to.equal(newValue)
+    })
+
+    it(`invokes channel.call("${method}", ...)`, () => {
+      if (newValue === undefined) {
+        expect(channelStub.call).to.have.been.calledWithExactly(
+        method, field.id, info.locale)
+      } else {
+        expect(channelStub.call).to.have.been.calledWithExactly(
+        method, field.id, info.locale, newValue)
+      }
+    })
+
+    it('returns the promise returned by internal channel.call()', () => {
+      channelStub.call.withArgs(method).returns('PROMISE')
+      expect(field[method]('val')).to.equal('PROMISE')
+    })
+  }
+
+  function testChangeMethod (methodName, initialValue) {
+    describeAttachHandlerMember('default behaviour', () => {
+      return field[methodName](noop)
+    })
+
+    it('calls handler immediately on attach with initial value of field', () => {
+      const spy = sinon.spy()
+
+      field[methodName](spy)
+      sinon.assert.calledOnce(spy)
+      sinon.assert.calledWithExactly(spy, initialValue)
+    })
+  }
 })

--- a/test/unit/field-locale.spec.js
+++ b/test/unit/field-locale.spec.js
@@ -20,7 +20,8 @@ describe('FieldLocale', () => {
       locale: 'en-US',
       value: 'Hello',
       type: 'Symbol',
-      isDisabled: true
+      isDisabled: true,
+      validations: 'VALIDATIONS'
     }
     let field
     beforeEach(() => {
@@ -48,6 +49,12 @@ describe('FieldLocale', () => {
     describe('.locale', () => {
       it('is set to the same value as given to first constructor arg\'s .locale', () => {
         expect(field.locale).to.equal(info.locale)
+      })
+    })
+
+    describe('.validations', () => {
+      it('is equal to info.validations', () => {
+        expect(field.validations).to.equal(info.validations)
       })
     })
 

--- a/test/unit/field-locale.spec.js
+++ b/test/unit/field-locale.spec.js
@@ -79,15 +79,11 @@ describe('FieldLocale', () => {
   })
 
   describe('.onIsDisabledChanged(handler)', () => {
-    it('calls handler when method is received', () => {
-      const cb = sinon.spy()
+    testChannelSignal('onIsDisabledChanged', 'isDisabledChanged')
+  })
 
-      field.onIsDisabledChanged(cb)
-      cb.reset()
-      channelStub.receiveMethod('isDisabledChanged', ['ISDISABLED'])
-      sinon.assert.calledOnce(cb)
-      sinon.assert.calledWithExactly(cb, 'ISDISABLED')
-    })
+  describe('.onSchemaErrorsChanged(handler)', () => {
+    testChannelSignal('onSchemaErrorsChanged', 'schemaErrorsChanged')
   })
 
   describe('.onValueChanged(handler)', () => {
@@ -171,6 +167,26 @@ describe('FieldLocale', () => {
     it('returns the promise returned by internal channel.call()', () => {
       channelStub.call.withArgs(method).returns('PROMISE')
       expect(field[method]('val')).to.equal('PROMISE')
+    })
+  }
+
+  function testChannelSignal (method, message) {
+    it('calls handler when method is received', () => {
+      const cb = sinon.spy()
+
+      field[method](cb)
+      cb.reset()
+      channelStub.receiveMethod(message, ['VALUE'])
+      sinon.assert.calledOnce(cb)
+      sinon.assert.calledWithExactly(cb, 'VALUE')
+    })
+
+    it('calls handler with last received message', () => {
+      channelStub.receiveMethod(message, ['VALUE'])
+      const cb = sinon.spy()
+      field[method](cb)
+      sinon.assert.calledOnce(cb)
+      sinon.assert.calledWithExactly(cb, 'VALUE')
     })
   }
 })

--- a/test/unit/initialize.spec.js
+++ b/test/unit/initialize.spec.js
@@ -59,6 +59,19 @@ describe('initializeApi(apiCreator)', function () {
     })
   })
 
+  it('calls handlers for queued messages', function () {
+    sendConnect(null, [{method: 'M', params: ['X', 'Y']}])
+    const handler = sinon.stub()
+    this.apiCreator = function (channel) {
+      channel.addHandler('M', handler)
+    }
+    return this.initialize()
+    .then(() => {
+      expect(handler).to.have.been.calledOnce
+      expect(handler).to.have.been.calledWithExactly('X', 'Y')
+    })
+  })
+
   it('adds focus handlers', function () {
     let send = sinon.spy()
     this.apiCreator = function (channel) {
@@ -78,11 +91,12 @@ describe('initializeApi(apiCreator)', function () {
     })
   })
 
-  function sendConnect (params) {
+  function sendConnect (params, messageQueue) {
     window.postMessage({
       method: 'connect',
       params: [
-        params || {id: 'foo'}
+        params || {id: 'foo'},
+        messageQueue || []
       ]
     }, '*')
   }


### PR DESCRIPTION
This PR adds the `fields.validations` property and the `fields.onSchemaErrorsChanged` signal.

In addition we refactored the communication channel and provided a mechanism of initializing signal values before passing control to the user.

_Review commit by commit_