### PR TITLE
Only pack necessary files for NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-gh-pages
-examples

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -38,6 +38,9 @@ update the `./docs` directory.
    added in (e.g. _“Since 1.2.3”_)
 3. Update the version in `package.json`.
 4. [Update GH Pages distribution](#updating-gh-pages-distribution)
+5. Update the [`files`][npm-files] property in `package.json` if necessary.
 5. Commit to master.
 6. Tag commit as `vX.Y.Z` and push tag to GitHub
 7. Publish new version of package on `npm`
+
+[npm-files]: https://docs.npmjs.com/files/package.json#files

--- a/package.json
+++ b/package.json
@@ -9,6 +9,15 @@
   "bugs": {
     "url": "https://github.com/contentful/ui-extensions-sdk/issues"
   },
+  "files": [
+    "dist/cf-extension-api.js",
+    "dist/cf-extension-api.js.map",
+    "dist/cf-extension.css",
+    "dist/cf-extension.css.map",
+    "docs/ui-extensions-api-backend.md",
+    "docs/ui-extensions-sdk-frontend.md",
+    "lib/**/*.js"
+  ],
   "description": "SDK to develop custom widgets on Contentful",
   "homepage": "https://github.com/contentful/ui-extensions-sdk#readme",
   "license": "MIT",


### PR DESCRIPTION
Keeps the package size small and prevents leaking unwanted files when publishing.