### PR TITLE
Switch to unpkg CDN

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,6 +2,8 @@
 
 ### API documentation and changelog
 
+We use semantic versioning.
+
 A commit that changes the public API of the SDK must come with a changelog entry
 and an updated to the API documentation.
 
@@ -23,24 +25,25 @@ can build the styleguide with `make styleguide` which will create HTML files in
 
 ### Updating GH Pages distribution
 
-We use [Github Pages][] to distribute the compiled Javascript code, stylesheets, and
-the styleguide from the `./docs` folder.
+We use [Github Pages][] to distribute the styleguide from the `./docs` folder.
 
-If you make any changes to the code or stylesheets run `make build-pages` to
-update the `./docs` directory.
+If you make any changes to the stylesheets run `make build-pages` to
+update the `./docs` directory and add it to your commit.
+
+For backwards compatibility we also distribute the code and styles for `v2.1.0`
+from Github Pages. These are not updated automatically anymore since we use
+[`unpkg.com`][unpkg].
 
 [Github Pages]: https://help.github.com/categories/github-pages-basics/
+[unpkg]: https://unpkg.com
 
 ### Releasing a new version of the SDK
 
 1. Add new release to changelog by renaming “Upcoming” to “v1.2.3”.
-2. Update API documentation for added methods to include the version they were
+1. Update API documentation for added methods to include the version they were
    added in (e.g. _“Since 1.2.3”_)
-3. Update the version in `package.json`.
-4. [Update GH Pages distribution](#updating-gh-pages-distribution)
-5. Update the [`files`][npm-files] property in `package.json` if necessary.
-5. Commit to master.
-6. Tag commit as `vX.Y.Z` and push tag to GitHub
-7. Publish new version of package on `npm`
-
-[npm-files]: https://docs.npmjs.com/files/package.json#files
+1. Update the version in `package.json`.
+1. Update the [`files`][npm-files] property in `package.json` if necessary.
+1. Commit to master.
+1. Tag commit as `vX.Y.Z` and push tag to GitHub
+1. Publish new version of package on `npm`

--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,4 @@ clean:
 	rm -rf dist/*
 
 build-pages: build-with-docs
-	cp -r dist/* docs
+	cp -r dist/styleguide docs

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ npm install -g contentful-extension-cli
 Including the compiled version of the extension client library is as simple as
 adding the following line to your application.
 
-```html
-<script src="https://contentful.github.io/ui-extensions-sdk/cf-extension-api.js"></script>
-```
+~~~html
+<script src="https://unpkg.com/contentful-ui-extensions-sdk@2"></script>
+~~~
 
 It also provide a set of examples you can check out to get a deeper understanding of the SDK capabilities.
 
@@ -102,7 +102,7 @@ Contentful's styles.
 You can include this CSS in your extension code as follows:
 
 ```html
-<link rel="stylesheet" type="text/css" href="https://contentful.github.io/ui-extensions-sdk/cf-extension.css">
+<link rel="stylesheet" type="text/css" href="https://unpkg.com/contentful-ui-extensions-sdk@2/dist/cf-extension.css">
 ```
 
 Futher information about styling your extension can be found in the

--- a/docs/ui-extensions-sdk-frontend.md
+++ b/docs/ui-extensions-sdk-frontend.md
@@ -22,29 +22,18 @@ communicate with the Contentful Management App.
 You will need to include the `contentful-extension-sdk` library in your HTML5 app like
 so:
 ~~~html
-<script src="https://contentful.github.io/ui-extensions-sdk/cf-extension-api.js"></script>
+<script src="https://unpkg.com/contentful-ui-extensions-sdk@2"></script>
 ~~~
 
-From `v2.0.1` we also distribute tagged versions of the SDK.
-~~~
-https://contentful.github.io/ui-extensions-sdk/tagged/cf-extension-api-v2.js
-https://contentful.github.io/ui-extensions-sdk/tagged/cf-extension-api-v2.0.js
-https://contentful.github.io/ui-extensions-sdk/tagged/cf-extension-api-v2.0.1.js
-~~~
-The `v2` file will point to the lastest `v2.x` release and similar for `v2.0`.
-The `v2.0.1` file will always point to the correct release. Check out the
-[`./docs/tagged` directory](./tagged) to see a list of all releases.
-
-
-The Contentful UI Extensions SDK including the JavaScript API is also distributed as an
-[NPM package][package].
-
+The SDK is also distributed as an [NPM package][package].
 ~~~bash
 npm install --save contentful-ui-extensions-sdk
 ~~~
 
-Note that for production purposes you should not rely on the `github.io` hosted
-files. You should use a CDN or bundle the library node module.
+You can include it in your code base with
+~~~js
+var contentfulExtension = require('contentful-ui-extensions-sdk')
+~~~
 
 [package]: https://www.npmjs.com/package/contentful-ui-extensions-sdk
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,16 +1,9 @@
 var path = require('path')
 
-var pkg = require('./package.json')
-var tags = makeTags(pkg.version)
-
-var entry = {}
-entry['cf-extension-api'] = './lib/api/index.js'
-tags.forEach((tag) => {
-  entry[`tagged/cf-extension-api-v${tag}`] = './lib/api/index.js'
-})
-
 module.exports = {
-  entry: entry,
+  entry: {
+    'cf-extension-api': './lib/api/index.js'
+  },
   output: {
     path: path.join(__dirname, 'dist'),
     filename: '[name].js',


### PR DESCRIPTION
* Do not create distributions tagged with versions anymore
* Do not update the file distribution in `./docs`.
* We keep the old dist files on GH Pages for backwards compatibility
* Document using unpkg.com to get distributed files