### PR TITLE
Add docs for exteneded `user` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/) and the ["Keep a
 Changelog" format](http://keepachangelog.com/).
 
+## Upcoming 3.3.0
+
+## Added
+
+- Add `user.sys.id`, `user.email`, `user.spaceMembership.sys.id` to the data
+  exposed by `extension.user`.
+
 ## 3.2.0 - 2017-08-07
 
 ## Added

--- a/docs/ui-extensions-sdk-frontend.md
+++ b/docs/ui-extensions-sdk-frontend.md
@@ -280,9 +280,12 @@ following shape.
 
 ```javascript
 {
+  sys: { id: 'b33ts' },
   firstName: 'Dwight',
   lastName: 'Schrute',
+  email: 'dwight@dundermifflin.com',
   spaceMembership: {
+    sys: { id: 'abc123xyz' }
     admin: false,
     roles: [{
       name: 'Assistant to the regional manager',
@@ -296,7 +299,7 @@ The `spaceMembership` and `roles` objects have include a subset of the data from
 the corresponding resources in the Contentful Management API. You can find more
 information in the [CMA Reference Documentation][cma-docs].
 
-_Since v3.2.0_
+_Since v3.3.0_
 
 ## `extension.window`
 


### PR DESCRIPTION
We don’t need to change the SDK implementation since we just take the object we get from the web app. If that object includes more information then we expose it.

Closes #155