### PR TITLE
Fix anchor link to first section

### DIFF
--- a/docs/ui-extensions-sdk-frontend.md
+++ b/docs/ui-extensions-sdk-frontend.md
@@ -5,7 +5,7 @@ with the Contentful Management App.
 
 ## Table of Contents
 
-- [Inclusion into your project](#inclusion-into-your-project)
+- [Inclusion in your project](#inclusion-in-your-project)
 - [Initialization](#initialization)
 - [`extension.contentType`](#extensioncontenttype)
 - [`extension.field`](#extensionfield)


### PR DESCRIPTION
The link to the first section in the ToC read `#inclusion-into-your-project` while the headline itself read `Inclusion in your project` resulting in the actual name `inclusion-in-your-project` which is why the link in the ToC didn't work. I fixed it by adjusting the link and text in the ToC.