### PR TITLE
Move dev deps to devdeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,18 +27,18 @@
     "url": "git+https://github.com/contentful/ui-extensions-sdk.git"
   },
   "dependencies": {
+    "object-assign": "^4.1.0",
+    "yaku": "^0.18.2"
+  },
+  "devDependencies": {
+    "kss": "^2.3.1",
+    "nib": "^1.1.0",
+    "stylus": "^0.54.5",
+    "webpack": "^2.6.1",
     "babel-loader": "^6.4.1",
     "babel-core": "^6.25.0",
     "babel-preset-es2015": "^6.0.15",
     "core-js": "^2.4.0",
-    "kss": "^2.3.1",
-    "nib": "^1.1.0",
-    "object-assign": "^4.1.0",
-    "stylus": "^0.54.5",
-    "webpack": "^2.6.1",
-    "yaku": "^0.18.2"
-  },
-  "devDependencies": {
     "babel-plugin-rewire": "1.1.0",
     "eslint": "^3.7.1",
     "eslint-config-standard": "^6.2.0",


### PR DESCRIPTION
We should move dependencies like `webpack`, stylus to `devDEpendencies`.
En users should not get these when installing the library