### PR TITLE
Moved some dependencies into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,19 +27,15 @@
     "url": "git+https://github.com/contentful/ui-extensions-sdk.git"
   },
   "dependencies": {
-    "babel-loader": "^6.4.1",
-    "babel-core": "^6.25.0",
-    "babel-preset-es2015": "^6.0.15",
     "core-js": "^2.4.0",
-    "kss": "^2.3.1",
-    "nib": "^1.1.0",
     "object-assign": "^4.1.0",
-    "stylus": "^0.54.5",
-    "webpack": "^2.6.1",
     "yaku": "^0.18.2"
   },
   "devDependencies": {
+    "babel-loader": "^6.4.1",
+    "babel-core": "^6.25.0",
     "babel-plugin-rewire": "1.1.0",
+    "babel-preset-es2015": "^6.0.15",
     "eslint": "^3.7.1",
     "eslint-config-standard": "^6.2.0",
     "eslint-plugin-promise": "^3.4.0",
@@ -50,8 +46,12 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.3",
+    "kss": "^2.3.1",
+    "nib": "^1.1.0",
     "lodash": "^4.13.1",
     "mocha": "^2.5.3",
-    "phantomjs-prebuilt": "^2.1.7"
+    "phantomjs-prebuilt": "^2.1.7",
+    "stylus": "^0.54.5",
+    "webpack": "^2.6.1"
   }
 }


### PR DESCRIPTION
Until now, many actual dev dependencies were located in `dependencies`. While this is also not ideal with regards to the downloaded package's size, in our case it even lead to conflicts since the (pretty old) `webpack` and `babel-loader` packages were "overwriting" newer versions from other dependencies (I don't yet understand why npm would do this, to be honest).