### PR TITLE
Simple dialogs (alert, confirm, prompt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/) and the ["Keep a
 Changelog" format](http://keepachangelog.com/).
 
+## 3.4.2 - 2019-01-15
+
+- Expose methods to open simple dialog windows: `dialogs.openAlert()`,
+  `dialogs.openConfirm()`, `dialogs.openPrompt()`.
+
 ## 3.4.1 - 2018-07-02
 
 - Reintroduced outline to all interactive elements for improved accessibility

--- a/docs/ui-extensions-sdk-frontend.md
+++ b/docs/ui-extensions-sdk-frontend.md
@@ -332,6 +332,84 @@ Stops resizing the iframe automatically.
 
 This object provides methods for opening UI dialogs:
 
+### `dialogs.openAlert(options)`
+
+Opens a simple alert window. It can be only closed. The method returns
+a promise always resolving to `true` once the dialog is closed.
+
+`options` is an object configuring the dialog. The available `options` are:
+
+- `title` (string, __required__): title of the dialog.
+- `message` (string, __required__): message of the dialog.
+- `confirmLabel` (string, optional): label of the confirmation button.
+  Defaults to `"Confirm"`.
+- `shouldCloseOnEscapePress` (boolean, optional): indicates if the Escape key
+  should close the dialog. Defaults to `true`.
+- `shouldCloseOnOverlayClick` (boolean, optional): indicates if clicking the
+  dialog overlay should close the dialog. Defaults to `true`.
+
+```javascript
+dialogs.openAlert({
+  title: 'My alert',
+  message: 'My message to you'
+}).then(result => {
+  // `result` is always `true`, can be skipped
+});
+```
+
+_Since v3.4.2_
+
+### `dialogs.openConfirm(options)`
+
+Opens a confirmation window. A user can either confirm or cancel the dialog.
+The method returns a promise resolving to either `true` (for confirmations)
+or `false` (for cancellations). Clicking the dialog overlay or pressing the
+Escape key (if enabled) will cancel the dialog.
+
+`options` is an object configuring the dialog. The available `options` are
+all the options of `dialogs.openAlert(options)` and additionally there is:
+
+- `cancelLabel` (string, optional): label of the cancellation button.
+  Defaults to `"Cancel"`.
+
+```javascript
+dialogs.openAlert({
+  title: 'My question',
+  message: 'What is your answer?',
+  confirmLabel: 'Yes!',
+  cancelLabel: 'No...'
+}).then(result => {
+  // `result` is either `true` or `false`
+});
+```
+
+_Since v3.4.2_
+
+### `dialogs.openPrompt(options)`
+
+Opens a prompt window. A user can either provide a string input or cancel
+the dialog. The method returns a promise resolving the provided string
+(when confirmed) or `false` (when cancelled). Clicking the dialog overlay
+or pressing the Escape key (if enabled) will cancel the dialog.
+
+`options` is an object configuring the dialog. The available `options` are
+all the options of `dialogs.openConfirm(options)` and additionally there is:
+
+- `defaultValue` (string, optional): the default value of the text input.
+  Defaults to an empty string.
+
+```javascript
+dialogs.openPrompt({
+  title: 'My question',
+  message: 'Please tell me more...',
+  defaultValue: 'hello world'
+}).then(result => {
+  // `result` is either a string or `false`
+});
+```
+
+_Since v3.4.2_
+
 ### `dialogs.selectSingleEntry(options)`
 
 Opens a dialog for selecting a single entry. It returns a promise resolved with

--- a/docs/ui-extensions-sdk-frontend.md
+++ b/docs/ui-extensions-sdk-frontend.md
@@ -334,7 +334,7 @@ This object provides methods for opening UI dialogs:
 
 ### `dialogs.openAlert(options)`
 
-Opens a simple alert window. It can be only closed. The method returns
+Opens a simple alert window (which can only be closed). The method returns
 a promise always resolving to `true` once the dialog is closed.
 
 `options` is an object configuring the dialog. The available `options` are:
@@ -343,10 +343,10 @@ a promise always resolving to `true` once the dialog is closed.
 - `message` (string, __required__): message of the dialog.
 - `confirmLabel` (string, optional): label of the confirmation button.
   Defaults to `"Confirm"`.
-- `shouldCloseOnEscapePress` (boolean, optional): indicates if the Escape key
-  should close the dialog. Defaults to `true`.
+- `shouldCloseOnEscapePress` (boolean, optional): indicates if pressing
+  the Escape key closes the dialog. Defaults to `true`.
 - `shouldCloseOnOverlayClick` (boolean, optional): indicates if clicking the
-  dialog overlay should close the dialog. Defaults to `true`.
+  dialog overlay closes the dialog. Defaults to `true`.
 
 ```javascript
 dialogs.openAlert({
@@ -367,7 +367,7 @@ or `false` (for cancellations). Clicking the dialog overlay or pressing the
 Escape key (if enabled) will cancel the dialog.
 
 `options` is an object configuring the dialog. The available `options` are
-all the options of `dialogs.openAlert(options)` and additionally there is:
+the options of `dialogs.openAlert(options)` and additionally:
 
 - `cancelLabel` (string, optional): label of the cancellation button.
   Defaults to `"Cancel"`.
@@ -393,7 +393,7 @@ the dialog. The method returns a promise resolving the provided string
 or pressing the Escape key (if enabled) will cancel the dialog.
 
 `options` is an object configuring the dialog. The available `options` are
-all the options of `dialogs.openConfirm(options)` and additionally there is:
+the options of `dialogs.openConfirm(options)` and additionally:
 
 - `defaultValue` (string, optional): the default value of the text input.
   Defaults to an empty string.

--- a/lib/api/dialogs.js
+++ b/lib/api/dialogs.js
@@ -2,13 +2,20 @@ import objectAssign from 'object-assign'
 
 export default function createDialogs (channel) {
   return {
-    selectSingleEntry: call.bind(null, 'Entry', false),
-    selectSingleAsset: call.bind(null, 'Asset', false),
-    selectMultipleEntries: call.bind(null, 'Entry', true),
-    selectMultipleAssets: call.bind(null, 'Asset', true)
+    openAlert: openSimpleDialog.bind(null, 'alert'),
+    openConfirm: openSimpleDialog.bind(null, 'confirm'),
+    openPrompt: openSimpleDialog.bind(null, 'prompt'),
+    selectSingleEntry: openEntitySelector.bind(null, 'Entry', false),
+    selectSingleAsset: openEntitySelector.bind(null, 'Asset', false),
+    selectMultipleEntries: openEntitySelector.bind(null, 'Entry', true),
+    selectMultipleAssets: openEntitySelector.bind(null, 'Asset', true)
   }
 
-  function call (entityType, multiple, options) {
+  function openSimpleDialog (type, options) {
+    return channel.call('openDialog', type, options)
+  }
+
+  function openEntitySelector (entityType, multiple, options) {
     options = objectAssign({}, options, {entityType, multiple})
 
     return channel.call('openDialog', 'entitySelector', options)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful-ui-extensions-sdk",
   "author": "Contentful GmbH",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "scripts": {
     "prepublish": "make build",
     "test": "make test"

--- a/test/unit/dialogs.spec.js
+++ b/test/unit/dialogs.spec.js
@@ -1,7 +1,13 @@
 import createDialogs from '../../lib/api/dialogs'
 import { describeChannelCallingMethod } from '../helpers'
 
-const methods = [
+const SIMPLE_DIALOGS = [
+  ['openAlert', 'alert'],
+  ['openConfirm', 'confirm'],
+  ['openPrompt', 'prompt']
+]
+
+const ENTITY_SELECTOR_DIALOGS = [
   ['selectSingleEntry', 'Entry', false],
   ['selectSingleAsset', 'Asset', false],
   ['selectMultipleEntries', 'Entry', true],
@@ -10,14 +16,23 @@ const methods = [
 
 describe('createDialogs()', () => {
   describe('returned "dialogs" object', () => {
-    methods.forEach(([method, entityType, multiple]) => {
-      const callOptions = {test: true, entityType, multiple}
+    SIMPLE_DIALOGS.forEach(([method, type]) => {
       describeChannelCallingMethod({
         creator: createDialogs,
         methodName: method,
         channelMethod: 'openDialog',
         args: [{test: true}],
-        expectedCallArgs: ['entitySelector', callOptions]
+        expectedCallArgs: [type, {test: true}]
+      })
+    })
+
+    ENTITY_SELECTOR_DIALOGS.forEach(([method, entityType, multiple]) => {
+      describeChannelCallingMethod({
+        creator: createDialogs,
+        methodName: method,
+        channelMethod: 'openDialog',
+        args: [{test: true}],
+        expectedCallArgs: ['entitySelector', {test: true, entityType, multiple}]
       })
     })
   })


### PR DESCRIPTION
`alert`, `confirm`, `prompt` for UI Extensions, following the visual style of the Contentful Web App.