### PR TITLE
Expose more info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/) and the ["Keep a
 Changelog" format](http://keepachangelog.com/).
 
+## 3.4.3 - 2019-01-17
+
+- Expose locale names: `locales.names`.
+- Expose field type and validations: `entry.fields[id].type`,
+  `entry.fields[id].validations`.
+
 ## 3.4.2 - 2019-01-15
 
 - Expose methods to open simple dialog windows: `dialogs.openAlert()`,

--- a/docs/ui-extensions-sdk-frontend.md
+++ b/docs/ui-extensions-sdk-frontend.md
@@ -206,6 +206,8 @@ locale. It defaults to the space the space's default locale (see
 exception.
 
 - `field.id: string`
+- `field.type: string`
+- `field.validations: Array<Validation>`
 - `field.locales: Array<string>`
 - `field.getValue(locale?): mixed`
 - `field.setValue(value, locale?): Promise<void>`
@@ -268,11 +270,27 @@ code, e.g. `"en_US"`.
 
 ### `locales.default: string`
 
-The default locale for the current space.
+The default locale code for the current space.
 
 ### `locales.available: Array<string>`
 
-A list of all locales available in the current space.
+A list of all locale codes available for editing in the current space.
+
+### `locales.names: Object`
+
+An object with keys of locale codes and values of corresponding human-readable
+locale names.
+
+```javascript
+{
+  available: ['en-US', 'pl'],
+  default: 'en-US',
+  names: {
+    'en-US': 'English (US)',
+    pl: 'Polski'
+  }
+}
+```
 
 ## `extension.user`
 

--- a/lib/api/field.js
+++ b/lib/api/field.js
@@ -5,6 +5,8 @@ export default class Field {
   constructor (channel, info, defaultLocale) {
     this.id = info.id
     this.locales = info.locales
+    this.type = info.type
+    this.validations = info.validations
     this._defaultLocale = defaultLocale
     this._fieldLocales = {}
 

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -14,12 +14,16 @@ function createWidgetAPI (
   return {
     user,
     parameters,
-    locales,
+    contentType,
+    locales: {
+      available: locales.available,
+      default: locales.default,
+      names: locales.names
+    },
     field: new FieldLocale(channel, field),
     entry: createEntry(channel, entry, fieldInfo, locales.default),
     space: createSpace(channel),
     window: createWindow(channel),
-    contentType: contentType,
     dialogs: createDialogs(channel)
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful-ui-extensions-sdk",
   "author": "Contentful GmbH",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "scripts": {
     "prepublish": "make build",
     "test": "make test"

--- a/test/unit/field.spec.js
+++ b/test/unit/field.spec.js
@@ -32,7 +32,9 @@ describe(`Field`, () => {
         'en-US': 'Hello',
         'it-IT': 'Ciao',
         'de-DE': 'Hallo'
-      }
+      },
+      type: 'Symbol',
+      validations: 'VALIDATIONS'
     }
     let field
     beforeEach(() => {
@@ -53,6 +55,18 @@ describe(`Field`, () => {
     describe(`.locales`, () => {
       it(`is set to the same value as info.locales`, () => {
         expect(field.locales).to.deep.equal(info.locales)
+      })
+    })
+
+    describe(`.type`, () => {
+      it(`is set to the same value as info.type`, () => {
+        expect(field.type).to.equal(info.type)
+      })
+    })
+
+    describe(`.validations`, () => {
+      it(`is set to the same value as info.validations`, () => {
+        expect(field.validations).to.equal(info.validations)
       })
     })
 


### PR DESCRIPTION
- Expose locale names: `locales.names`.
- Expose field type and validations: `entry.fields[id].type`,
  `entry.fields[id].validations`.