### PR TITLE
Prepare for extension locations

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,63 @@
+const Field = require('./field')
+const FieldLocale = require('./field-locale')
+const createWindow = require('./window')
+const createEntry = require('./entry')
+const createSpace = require('./space')
+const createDialogs = require('./dialogs')
+const createNavigator = require('./navigator')
+
+const DEFAULT_API_PRODUCERS = [
+  makeSharedAPI,
+  makeEntryAPI,
+  makeFieldAPI
+]
+
+const LOCATION_TO_API_PRODUCERS = {
+  'entry-field': DEFAULT_API_PRODUCERS,
+  'entry-sidebar': [makeSharedAPI, makeEntryAPI]
+}
+
+module.exports = function createAPI (channel, data, currentWindow) {
+  const producers = LOCATION_TO_API_PRODUCERS[data.location] || DEFAULT_API_PRODUCERS
+
+  return producers.reduce((api, produce) => {
+    return { ...api, ...produce(channel, data, currentWindow) }
+  }, {})
+}
+
+function makeSharedAPI (channel, data, currentWindow) {
+  const { user, parameters, locales } = data
+
+  return {
+    user,
+    parameters,
+    locales: {
+      available: locales.available,
+      default: locales.default,
+      names: locales.names
+    },
+    space: createSpace(channel),
+    window: createWindow(currentWindow, channel),
+    dialogs: createDialogs(channel),
+    navigator: createNavigator(channel),
+    notifier: {
+      success: message => channel.send('notify', { type: 'success', message }),
+      error: message => channel.send('notify', { type: 'error', message })
+    }
+  }
+}
+
+function makeEntryAPI (channel, { locales, contentType, entry, fieldInfo }) {
+  const createEntryField = info => new Field(channel, info, locales.default)
+
+  return {
+    contentType,
+    entry: createEntry(channel, entry, fieldInfo, createEntryField)
+  }
+}
+
+function makeFieldAPI (channel, { field }) {
+  return {
+    field: new FieldLocale(channel, field)
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,40 +1,4 @@
 const createInitializer = require('./initialize')
-const Field = require('./field')
-const FieldLocale = require('./field-locale')
-const createWindow = require('./window')
-const createEntry = require('./entry')
-const createSpace = require('./space')
-const createDialogs = require('./dialogs')
-const createNavigator = require('./navigator')
+const createAPI = require('./api')
 
-const currentWindow = window
-
-const init = createInitializer(currentWindow, createExtensionAPI)
-
-module.exports = { init }
-
-function createExtensionAPI (channel, data) {
-  const { user, parameters, entry, locales, field, fieldInfo, contentType } = data
-  const createEntryField = info => new Field(channel, info, locales.default)
-
-  return {
-    user,
-    parameters,
-    contentType,
-    locales: {
-      available: locales.available,
-      default: locales.default,
-      names: locales.names
-    },
-    field: new FieldLocale(channel, field),
-    entry: createEntry(channel, entry, fieldInfo, createEntryField),
-    space: createSpace(channel),
-    window: createWindow(currentWindow, channel),
-    dialogs: createDialogs(channel),
-    navigator: createNavigator(channel),
-    notifier: {
-      success: message => channel.send('notify', { type: 'success', message }),
-      error: message => channel.send('notify', { type: 'error', message })
-    }
-  }
-}
+module.exports = { init: createInitializer(window, createAPI) }

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -14,7 +14,7 @@ module.exports = function createInitializer (currentWindow, apiCreator) {
 
   connect(currentWindow, (channel, params, messageQueue) => {
     channelDeferred.resolve(channel)
-    const api = apiCreator(channel, params)
+    const api = apiCreator(channel, params, currentWindow)
     messageQueue.forEach((m) => {
       channel._handleMessage(m)
     })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,9 +12,21 @@ const { expect } = chai
 module.exports = {
   sinon,
   makeDOM: () => new JSDOM('<!DOCTYPE html>'),
+  mockMutationObserver,
   expect,
   describeAttachHandlerMember,
   describeChannelCallingMethod
+}
+
+function mockMutationObserver (dom, registerMutationTrigger) {
+  const MutationObserverMock = function (cb) { registerMutationTrigger(cb) }
+  MutationObserverMock.prototype.observe = () => {}
+  MutationObserverMock.prototype.disconnect = () => { registerMutationTrigger(() => {}) }
+
+  Object.defineProperty(dom.window, 'MutationObserver', {
+    writable: false,
+    value: MutationObserverMock
+  })
 }
 
 function describeAttachHandlerMember (msg, attachHandlerFn) {

--- a/test/unit/api.spec.js
+++ b/test/unit/api.spec.js
@@ -1,0 +1,75 @@
+const { makeDOM, mockMutationObserver, expect } = require('../helpers')
+
+const createAPI = require('../../lib/api')
+
+function test (expected, location) {
+  const channel = { addHandler: () => {} }
+
+  const data = {
+    location,
+    user: 'USER',
+    parameters: 'PARAMS',
+    locales: {
+      available: 'AVAIL',
+      default: 'DEFAULT',
+      names: 'NAMES'
+    },
+    contentType: 'CONTENT TYPE',
+    entry: { sys: 'EID' },
+    fieldInfo: [],
+    field: { id: 'fid' }
+  }
+
+  const dom = makeDOM()
+  mockMutationObserver(dom, () => {})
+
+  const api = createAPI(channel, data, dom.window)
+
+  // Test location-specific API.
+  expect(api).to.have.all.keys(expected)
+
+  // Test simple but nested properties of the shared API.
+  expect(api.locales).to.have.all.keys(['available', 'default', 'names'])
+  expect(api.notifier).to.have.all.keys(['success', 'error'])
+}
+
+describe('createAPI()', () => {
+  it('returns correct shape of the default API (entry-field)', () => {
+    const expected = [
+      'user',
+      'parameters',
+      'locales',
+      'contentType',
+      'entry',
+      'field',
+      'space',
+      'dialogs',
+      'navigator',
+      'window',
+      'notifier'
+    ]
+
+    // No location, `entry-field` is the default.
+    test(expected)
+
+    // `entry-field` provided explicitly.
+    test(expected, 'entry-field')
+  })
+
+  it('returns correct shape of the sidebar API (entry-sidebar)', () => {
+    const expected = [
+      'user',
+      'parameters',
+      'locales',
+      'contentType',
+      'entry',
+      'space',
+      'dialogs',
+      'navigator',
+      'window',
+      'notifier'
+    ]
+
+    test(expected, 'entry-sidebar')
+  })
+})

--- a/test/unit/window.spec.js
+++ b/test/unit/window.spec.js
@@ -1,4 +1,4 @@
-const { sinon, makeDOM, expect } = require('../helpers')
+const { sinon, makeDOM, mockMutationObserver, expect } = require('../helpers')
 
 const createWindow = require('../../lib/window')
 
@@ -9,16 +9,10 @@ describe(`createWindow()`, () => {
     let modifyDOM
     let channelSendSpy
     beforeEach(() => {
-      const MutationObserverMock = function (cb) { modifyDOM = cb }
-      MutationObserverMock.prototype.observe = () => {}
-      MutationObserverMock.prototype.disconnect = () => { modifyDOM = () => {} }
-
       dom = makeDOM()
-      Object.defineProperty(dom.window, 'MutationObserver', {
-        writable: false,
-        value: MutationObserverMock
+      mockMutationObserver(dom, cb => {
+        modifyDOM = cb
       })
-
       channelSendSpy = sinon.spy()
       window = createWindow(dom.window, { send: channelSendSpy })
     })


### PR DESCRIPTION
Allows to define how the Extension API is built.

Will allow to have different API depending on the location of an extension.

Backwards compatible, if the Web App don't initialize connection with the `location` parameter the default of `entry-field` is used.

This PR includes definition of the API for `entry-sidebar` location (basically: not including the `field` object)