### PR TITLE
3.8.0

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -32,7 +32,7 @@ module.exports = function createAPI (channel, data, currentWindow) {
 }
 
 function makeSharedAPI (channel, data, currentWindow) {
-  const { user, parameters, locales } = data
+  const { user, parameters, locales, ids } = data
 
   return {
     location: {
@@ -54,7 +54,8 @@ function makeSharedAPI (channel, data, currentWindow) {
     notifier: {
       success: message => channel.send('notify', { type: 'success', message }),
       error: message => channel.send('notify', { type: 'error', message })
-    }
+    },
+    ids
   }
 }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -17,6 +17,7 @@ const LOCATION_TO_API_PRODUCERS = {
   [locations.LOCATION_ENTRY_FIELD]: DEFAULT_API_PRODUCERS,
   [locations.LOCATION_ENTRY_FIELD_SIDEBAR]: DEFAULT_API_PRODUCERS,
   [locations.LOCATION_ENTRY_SIDEBAR]: [makeSharedAPI, makeEntryAPI],
+  [locations.LOCATION_ENTRY_EDITOR]: [makeSharedAPI, makeEntryAPI],
   [locations.LOCATION_DIALOG]: [makeSharedAPI, makeDialogAPI]
 }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -12,15 +12,16 @@ const DEFAULT_API_PRODUCERS = [
   makeSharedAPI,
   makeEntryAPI,
   makeFieldAPI,
-  makeEditorAPI
+  makeEditorAPI,
+  makeWindowAPI
 ]
 
 const LOCATION_TO_API_PRODUCERS = {
   [locations.LOCATION_ENTRY_FIELD]: DEFAULT_API_PRODUCERS,
   [locations.LOCATION_ENTRY_FIELD_SIDEBAR]: DEFAULT_API_PRODUCERS,
-  [locations.LOCATION_ENTRY_SIDEBAR]: [makeSharedAPI, makeEntryAPI, makeEditorAPI],
+  [locations.LOCATION_ENTRY_SIDEBAR]: [makeSharedAPI, makeEntryAPI, makeEditorAPI, makeWindowAPI],
   [locations.LOCATION_ENTRY_EDITOR]: [makeSharedAPI, makeEntryAPI, makeEditorAPI],
-  [locations.LOCATION_DIALOG]: [makeSharedAPI, makeDialogAPI]
+  [locations.LOCATION_DIALOG]: [makeSharedAPI, makeDialogAPI, makeWindowAPI]
 }
 
 module.exports = function createAPI (channel, data, currentWindow) {
@@ -31,7 +32,7 @@ module.exports = function createAPI (channel, data, currentWindow) {
   }, {})
 }
 
-function makeSharedAPI (channel, data, currentWindow) {
+function makeSharedAPI (channel, data) {
   const { user, parameters, locales, ids } = data
 
   return {
@@ -48,7 +49,6 @@ function makeSharedAPI (channel, data, currentWindow) {
       names: locales.names
     },
     space: createSpace(channel),
-    window: createWindow(currentWindow, channel),
     dialogs: createDialogs(channel),
     navigator: createNavigator(channel),
     notifier: {
@@ -59,10 +59,16 @@ function makeSharedAPI (channel, data, currentWindow) {
   }
 }
 
-function makeEditorAPI (channel, data) {
-  const { editor } = data
+function makeWindowAPI (channel, _data, currentWindow) {
   return {
-    editor: createEditor(channel, editor.editorInterface)
+    window: createWindow(currentWindow, channel)
+  }
+}
+
+function makeEditorAPI (channel, data) {
+  const { editorInterface } = data
+  return {
+    editor: createEditor(channel, editorInterface)
   }
 }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -4,20 +4,22 @@ const createWindow = require('./window')
 const createEntry = require('./entry')
 const createSpace = require('./space')
 const createDialogs = require('./dialogs')
+const createEditor = require('./editor')
 const createNavigator = require('./navigator')
 const locations = require('./locations')
 
 const DEFAULT_API_PRODUCERS = [
   makeSharedAPI,
   makeEntryAPI,
-  makeFieldAPI
+  makeFieldAPI,
+  makeEditorAPI
 ]
 
 const LOCATION_TO_API_PRODUCERS = {
   [locations.LOCATION_ENTRY_FIELD]: DEFAULT_API_PRODUCERS,
   [locations.LOCATION_ENTRY_FIELD_SIDEBAR]: DEFAULT_API_PRODUCERS,
-  [locations.LOCATION_ENTRY_SIDEBAR]: [makeSharedAPI, makeEntryAPI],
-  [locations.LOCATION_ENTRY_EDITOR]: [makeSharedAPI, makeEntryAPI],
+  [locations.LOCATION_ENTRY_SIDEBAR]: [makeSharedAPI, makeEntryAPI, makeEditorAPI],
+  [locations.LOCATION_ENTRY_EDITOR]: [makeSharedAPI, makeEntryAPI, makeEditorAPI],
   [locations.LOCATION_DIALOG]: [makeSharedAPI, makeDialogAPI]
 }
 
@@ -53,6 +55,13 @@ function makeSharedAPI (channel, data, currentWindow) {
       success: message => channel.send('notify', { type: 'success', message }),
       error: message => channel.send('notify', { type: 'error', message })
     }
+  }
+}
+
+function makeEditorAPI (channel, data) {
+  const { editor } = data
+  return {
+    editor: createEditor(channel, editor.editorInterface)
   }
 }
 

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -1,0 +1,5 @@
+module.exports = function createEditor (channel, editorInterface) {
+  return {
+    editorInterface
+  }
+}

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -1,21 +1,11 @@
 const { MemoizedSignal } = require('./signal')
 
 module.exports = function createEditor (channel, editorInterface) {
-  const _activeLocalesSygnal = new MemoizedSignal(undefined)
-  const _focusedLocaleSygnal = new MemoizedSignal(undefined)
-  const _localeModeSygnal = new MemoizedSignal(undefined)
+  const _localeSettingsSygnal = new MemoizedSignal(undefined)
   const _showDisabledFieldsSygnal = new MemoizedSignal(undefined)
 
-  channel.addHandler('activeLocalesChanged', (activeLocales) => {
-    _activeLocalesSygnal.dispatch(activeLocales)
-  })
-
-  channel.addHandler('focusedLocaleChanged', (focusedLocale) => {
-    _focusedLocaleSygnal.dispatch(focusedLocale)
-  })
-
-  channel.addHandler('localeModeChanged', (localeMode) => {
-    _localeModeSygnal.dispatch(localeMode)
+  channel.addHandler('localeSettingsChanged', (settings) => {
+    _localeSettingsSygnal.dispatch(settings)
   })
 
   channel.addHandler('showDisabledFieldsChanged', (showDisabledFields) => {
@@ -24,14 +14,8 @@ module.exports = function createEditor (channel, editorInterface) {
 
   return {
     editorInterface,
-    onActiveLocalesChanged: (handler) => {
-      return _activeLocalesSygnal.attach(handler)
-    },
-    onFocusedLocaleChanged: (handler) => {
-      return _focusedLocaleSygnal.attach(handler)
-    },
-    onLocaleModeChanged: (handler) => {
-      return _localeModeSygnal.attach(handler)
+    onLocaleSettingsChanged: (handler) => {
+      return _localeSettingsSygnal.attach(handler)
     },
     onShowDisabledFieldsChanged: (handler) => {
       return _showDisabledFieldsSygnal.attach(handler)

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -4,6 +4,7 @@ module.exports = function createEditor (channel, editorInterface) {
   const _activeLocalesSygnal = new MemoizedSignal(undefined)
   const _focusedLocaleSygnal = new MemoizedSignal(undefined)
   const _localeModeSygnal = new MemoizedSignal(undefined)
+  const _showDisabledFieldsSygnal = new MemoizedSignal(undefined)
 
   channel.addHandler('activeLocalesChanged', (activeLocales) => {
     _activeLocalesSygnal.dispatch(activeLocales)
@@ -17,6 +18,10 @@ module.exports = function createEditor (channel, editorInterface) {
     _localeModeSygnal.dispatch(localeMode)
   })
 
+  channel.addHandler('showDisabledFieldsChanged', (showDisabledFields) => {
+    _showDisabledFieldsSygnal.dispatch(showDisabledFields)
+  })
+
   return {
     editorInterface,
     onActiveLocalesChanged: (handler) => {
@@ -27,6 +32,9 @@ module.exports = function createEditor (channel, editorInterface) {
     },
     onLocaleModeChanged: (handler) => {
       return _localeModeSygnal.attach(handler)
+    },
+    onShowDisabledFieldsChanged: (handler) => {
+      return _showDisabledFieldsSygnal.attach(handler)
     }
   }
 }

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -1,5 +1,32 @@
+const { MemoizedSignal } = require('./signal')
+
 module.exports = function createEditor (channel, editorInterface) {
+  const _activeLocalesSygnal = new MemoizedSignal(undefined)
+  const _focusedLocaleSygnal = new MemoizedSignal(undefined)
+  const _localeModeSygnal = new MemoizedSignal(undefined)
+
+  channel.addHandler('activeLocalesChanged', (activeLocales) => {
+    _activeLocalesSygnal.dispatch(activeLocales)
+  })
+
+  channel.addHandler('focusedLocaleChanged', (focusedLocale) => {
+    _focusedLocaleSygnal.dispatch(focusedLocale)
+  })
+
+  channel.addHandler('localeModeChanged', (localeMode) => {
+    _localeModeSygnal.dispatch(localeMode)
+  })
+
   return {
-    editorInterface
+    editorInterface,
+    onActiveLocalesChanged: (handler) => {
+      return _activeLocalesSygnal.attach(handler)
+    },
+    onFocusedLocaleChanged: (handler) => {
+      return _focusedLocaleSygnal.attach(handler)
+    },
+    onLocaleModeChanged: (handler) => {
+      return _localeModeSygnal.attach(handler)
+    }
   }
 }

--- a/lib/field-locale.js
+++ b/lib/field-locale.js
@@ -1,11 +1,16 @@
 const { MemoizedSignal } = require('./signal')
 
+const INFO_PROPS = ['id', 'locale', 'type', 'required', 'validations', 'items']
+
 module.exports = class FieldLocale {
   constructor (channel, fieldInfo) {
-    this.id = fieldInfo.id
-    this.locale = fieldInfo.locale
-    this.type = fieldInfo.type
-    this.validations = fieldInfo.validations
+    INFO_PROPS.forEach(prop => {
+      const value = fieldInfo[prop]
+      if (typeof value !== 'undefined') {
+        this[prop] = fieldInfo[prop]
+      }
+    })
+
     this._value = fieldInfo.value
     this._valueSignal = new MemoizedSignal(this._value)
     this._isDisabledSignal = new MemoizedSignal(undefined)

--- a/lib/field.js
+++ b/lib/field.js
@@ -1,19 +1,27 @@
 const FieldLocale = require('./field-locale')
 
+const INFO_PROPS = ['id', 'locales', 'type', 'required', 'validations', 'items']
+
 module.exports = class Field {
   constructor (channel, info, defaultLocale) {
-    this.id = info.id
-    this.locales = info.locales
-    this.type = info.type
-    this.validations = info.validations
-    this._defaultLocale = defaultLocale
-    this._fieldLocales = {}
-
-    this.locales.forEach((locale) => {
-      const value = info.values[locale]
-      this._fieldLocales[locale] =
-        new FieldLocale(channel, { id: this.id, locale, value })
+    INFO_PROPS.forEach(prop => {
+      const value = info[prop]
+      if (typeof value !== 'undefined') {
+        this[prop] = info[prop]
+      }
     })
+
+    this._defaultLocale = defaultLocale
+
+    this._fieldLocales = info.locales.reduce((acc, locale) => {
+      const fieldLocale = new FieldLocale(channel, {
+        id: info.id,
+        locale,
+        value: info.values[locale]
+      })
+
+      return { ...acc, [locale]: fieldLocale }
+    }, {})
 
     assertHasLocale(this, defaultLocale)
   }

--- a/lib/locations.js
+++ b/lib/locations.js
@@ -2,5 +2,6 @@ module.exports = {
   LOCATION_ENTRY_FIELD: 'entry-field',
   LOCATION_ENTRY_FIELD_SIDEBAR: 'entry-field-sidebar',
   LOCATION_ENTRY_SIDEBAR: 'entry-sidebar',
-  LOCATION_DIALOG: 'dialog'
+  LOCATION_DIALOG: 'dialog',
+  LOCATION_ENTRY_EDITOR: 'entry-editor'
 }

--- a/lib/space.js
+++ b/lib/space.js
@@ -36,7 +36,9 @@ const spaceMethods = [
   'processAsset',
   'waitUntilAssetProcessed',
 
-  'getUsers'
+  'getUsers',
+
+  'getEditorInterface'
 ]
 
 module.exports = function createSpace (channel) {

--- a/lib/space.js
+++ b/lib/space.js
@@ -3,6 +3,7 @@ const spaceMethods = [
   'getEntry',
   'getEntrySnapshots',
   'getAsset',
+  'getEditorInterface',
 
   'getPublishedEntries',
   'getPublishedAssets',
@@ -36,9 +37,7 @@ const spaceMethods = [
   'processAsset',
   'waitUntilAssetProcessed',
 
-  'getUsers',
-
-  'getEditorInterface'
+  'getUsers'
 ]
 
 module.exports = function createSpace (channel) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-ui-extensions-sdk",
-  "version": "3.7.2",
+  "version": "3.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful-ui-extensions-sdk",
   "description": "SDK to develop custom UI Extension for the Contentful Web App",
-  "version": "3.7.2",
+  "version": "3.8.0",
   "author": "Contentful GmbH",
   "license": "MIT",
   "main": "dist/cf-extension-api.js",

--- a/test/unit/api.spec.js
+++ b/test/unit/api.spec.js
@@ -32,7 +32,14 @@ function test (expected, location, expectedLocation) {
     contentType: 'CONTENT TYPE',
     entry: { sys: 'EID' },
     fieldInfo: [],
-    field: { id: 'fid' }
+    field: { id: 'fid' },
+    editor: {
+      editorInterface: {
+        controls: [],
+        sidebar: [],
+        sys: {}
+      }
+    }
   }
 
   const dom = makeDOM()
@@ -55,7 +62,7 @@ function test (expected, location, expectedLocation) {
 
 describe('createAPI()', () => {
   it('returns correct shape of the default API (entry-field and entry-field-sidebar)', () => {
-    const expected = ['contentType', 'entry', 'field']
+    const expected = ['contentType', 'entry', 'field', 'editor']
 
     // No location, `entry-field` is the default.
     test(expected, undefined, locations.LOCATION_ENTRY_FIELD)
@@ -68,13 +75,13 @@ describe('createAPI()', () => {
   })
 
   it('returns correct shape of the sidebar API (entry-sidebar)', () => {
-    const expected = ['contentType', 'entry']
+    const expected = ['contentType', 'entry', 'editor']
 
     test(expected, locations.LOCATION_ENTRY_SIDEBAR)
   })
 
   it('returns correct shape of the entry editor API', () => {
-    const expected = ['contentType', 'entry']
+    const expected = ['contentType', 'entry', 'editor']
 
     test(expected, locations.LOCATION_ENTRY_EDITOR)
   })

--- a/test/unit/api.spec.js
+++ b/test/unit/api.spec.js
@@ -73,6 +73,12 @@ describe('createAPI()', () => {
     test(expected, locations.LOCATION_ENTRY_SIDEBAR)
   })
 
+  it('returns correct shape of the entry editor API', () => {
+    const expected = ['contentType', 'entry']
+
+    test(expected, locations.LOCATION_ENTRY_EDITOR)
+  })
+
   it('returns correct shape of the dialog API (dialog)', () => {
     const expected = ['close']
 

--- a/test/unit/api.spec.js
+++ b/test/unit/api.spec.js
@@ -11,7 +11,6 @@ const sharedExpected = [
   'space',
   'dialogs',
   'navigator',
-  'window',
   'notifier',
   'ids'
 ]
@@ -63,7 +62,7 @@ function test (expected, location, expectedLocation) {
 
 describe('createAPI()', () => {
   it('returns correct shape of the default API (entry-field and entry-field-sidebar)', () => {
-    const expected = ['contentType', 'entry', 'field', 'editor']
+    const expected = ['contentType', 'entry', 'field', 'editor', 'window']
 
     // No location, `entry-field` is the default.
     test(expected, undefined, locations.LOCATION_ENTRY_FIELD)
@@ -76,19 +75,19 @@ describe('createAPI()', () => {
   })
 
   it('returns correct shape of the sidebar API (entry-sidebar)', () => {
-    const expected = ['contentType', 'entry', 'editor']
+    const expected = ['contentType', 'entry', 'editor', 'window']
 
     test(expected, locations.LOCATION_ENTRY_SIDEBAR)
   })
 
-  it('returns correct shape of the entry editor API', () => {
+  it('returns correct shape of the entry editor API (entry-editor)', () => {
     const expected = ['contentType', 'entry', 'editor']
 
     test(expected, locations.LOCATION_ENTRY_EDITOR)
   })
 
   it('returns correct shape of the dialog API (dialog)', () => {
-    const expected = ['close']
+    const expected = ['close', 'window']
 
     test(expected, locations.LOCATION_DIALOG)
   })

--- a/test/unit/api.spec.js
+++ b/test/unit/api.spec.js
@@ -12,7 +12,8 @@ const sharedExpected = [
   'dialogs',
   'navigator',
   'window',
-  'notifier'
+  'notifier',
+  'ids'
 ]
 
 function test (expected, location, expectedLocation) {

--- a/test/unit/editor.spec.js
+++ b/test/unit/editor.spec.js
@@ -1,0 +1,32 @@
+const { describeAttachHandlerMember, sinon, expect } = require('../helpers')
+
+const createEditor = require('../../lib/editor')
+
+describe('createEditor()', () => {
+  const channelStub = {
+    addHandler: sinon.spy()
+  }
+
+  const editorInterfaceMock = {
+    sidebar: [],
+    controls: []
+  }
+
+  const editor = createEditor(channelStub, editorInterfaceMock)
+
+  it('should return editorInterface', () => {
+    expect(editor.editorInterface).to.equal(editorInterfaceMock)
+  })
+
+  describe('.onLocaleSettingsChanged(handler)', () => {
+    describeAttachHandlerMember('default behaviour', () => {
+      return editor.onLocaleSettingsChanged(() => {})
+    })
+  })
+
+  describe('.onShowDisabledFieldsChanged(handler)', () => {
+    describeAttachHandlerMember('default behaviour', () => {
+      return editor.onShowDisabledFieldsChanged(() => {})
+    })
+  })
+})

--- a/test/unit/field-locale.spec.js
+++ b/test/unit/field-locale.spec.js
@@ -6,8 +6,14 @@ describe('FieldLocale', () => {
   const info = {
     id: 'some-field',
     locale: 'en-US',
-    type: 'Symbol',
-    validations: 'VALIDATIONS'
+    type: 'Array',
+    required: false,
+    validations: 'VALIDATIONS',
+    items: {
+      type: 'Link',
+      linkType: 'Entry',
+      validations: 'VALIDATIONS OF ITEMS'
+    }
   }
   let channelStub
   let field
@@ -24,7 +30,8 @@ describe('FieldLocale', () => {
       }
     }
 
-    field = new FieldLocale(channelStub, info)
+    const infoCopy = JSON.parse(JSON.stringify(info))
+    field = new FieldLocale(channelStub, infoCopy)
   })
 
   describe('.id', () => {
@@ -45,9 +52,28 @@ describe('FieldLocale', () => {
     })
   })
 
+  describe('.required', () => {
+    it('is equal to info.required', () => {
+      expect(field.required).to.equal(info.required)
+    })
+  })
+
   describe('.validations', () => {
     it('is equal to info.validations', () => {
       expect(field.validations).to.equal(info.validations)
+    })
+  })
+
+  describe(`.items`, () => {
+    it(`is set to the same value as info.items`, () => {
+      expect(field.items).to.deep.equal(info.items)
+    })
+
+    it('is skipped on the object if not defined in info', () => {
+      const noItemsInfo = JSON.parse(JSON.stringify(info))
+      delete noItemsInfo.items
+      const noItemsField = new FieldLocale(channelStub, noItemsInfo)
+      expect(noItemsField.items).to.equal(undefined)
     })
   })
 

--- a/test/unit/field.spec.js
+++ b/test/unit/field.spec.js
@@ -31,9 +31,16 @@ describe(`Field`, () => {
         'it-IT': 'Ciao',
         'de-DE': 'Hallo'
       },
-      type: 'Symbol',
-      validations: 'VALIDATIONS'
+      type: 'Array',
+      required: true,
+      validations: 'VALIDATIONS',
+      items: {
+        type: 'Link',
+        linkType: 'Entry',
+        validations: 'VALIDATIONS OF ITEMS'
+      }
     }
+
     let field
     beforeEach(() => {
       const infoCopy = JSON.parse(JSON.stringify(info))
@@ -62,9 +69,28 @@ describe(`Field`, () => {
       })
     })
 
+    describe(`.required`, () => {
+      it(`is set to the same value as info.required`, () => {
+        expect(field.required).to.equal(info.required)
+      })
+    })
+
     describe(`.validations`, () => {
       it(`is set to the same value as info.validations`, () => {
         expect(field.validations).to.equal(info.validations)
+      })
+    })
+
+    describe(`.items`, () => {
+      it(`is set to the same value as info.items`, () => {
+        expect(field.items).to.deep.equal(info.items)
+      })
+
+      it('is skipped on the object if not defined in info', () => {
+        const noItemsInfo = JSON.parse(JSON.stringify(info))
+        delete noItemsInfo.items
+        const noItemsField = new Field(channelStub, noItemsInfo, defaultLocale)
+        expect(noItemsField.items).to.equal(undefined)
       })
     })
 

--- a/test/unit/space.spec.js
+++ b/test/unit/space.spec.js
@@ -7,6 +7,7 @@ const spaceMethods = [
   'getEntry',
   'getEntrySnapshots',
   'getAsset',
+  'getEditorInterface',
 
   'getPublishedEntries',
   'getPublishedAssets',
@@ -40,9 +41,7 @@ const spaceMethods = [
   'processAsset',
   'waitUntilAssetProcessed',
 
-  'getUsers',
-
-  'getEditorInterface'
+  'getUsers'
 ]
 
 describe('createSpace()', () => {

--- a/test/unit/space.spec.js
+++ b/test/unit/space.spec.js
@@ -40,7 +40,9 @@ const spaceMethods = [
   'processAsset',
   'waitUntilAssetProcessed',
 
-  'getUsers'
+  'getUsers',
+
+  'getEditorInterface'
 ]
 
 describe('createSpace()', () => {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -132,22 +132,22 @@ declare module 'contentful-ui-extensions-sdk' {
 
   interface EditorInterface {
     sys: Object;
-    controls: Array<{
+    controls?: Array<{
       fieldId: string;
-      widgetId: string;
-      widgetNamespace: string;
-      settings: Object;
+      widgetId?: string;
+      widgetNamespace?: string;
+      settings?: Object;
     }>;
     sidebar?: Array<{
       widgetId: string;
       widgetNamespace: string;
-      settings: Object;
+      settings?: Object;
       disabled?: boolean;
     }>;
     editor?: {
       widgetId: string;
       widgetNamespace: string;
-      settings: Object;
+      settings?: Object;
     }
   }
 
@@ -346,10 +346,8 @@ declare module 'contentful-ui-extensions-sdk' {
   interface SharedEditorSDK {
     editor: {
       editorInterface: EditorInterface,
-      onActiveLocalesChanged: (callback: (value: Array<Object>) => any) => Function,
-      onFocusedLocaleChanged: (callback: (value: Object) => any) => Function,
-      onLocaleModeChanged: (callback: (value: 'single' | 'multi') => any) => Function,
-      onShowDisabledFieldsChanged: (callback: (value: boolean) => any) => Function
+      onLocaleSettingsChanged: (callback: (value: { mode: 'multi' | 'single', focused?: string, active?: Array<string>} ) => any) => Function;
+      onShowDisabledFieldsChanged: (callback: (value: boolean) => any) => Function;
     }
   }
 
@@ -364,8 +362,6 @@ declare module 'contentful-ui-extensions-sdk' {
     user: User;
     /** Information about the current locales */
     locales: LocalesAPI;
-    /** Methods to update the size of the iframe the extension is contained within.  */
-    window: WindowAPI;
     /** Methods for opening UI dialogs: */
     dialogs: DialogsAPI;
     /** Methods for navigating between entities stored in a Contentful space. */
@@ -380,29 +376,35 @@ declare module 'contentful-ui-extensions-sdk' {
 
   export type EditorExtensionSDK = BaseExtensionSDK & SharedEditorSDK & {
     /** A set of IDs actual for the extension */
-    ids: Pick<IdsAPI, 'entry' | 'contentType' | 'environment' | 'space' | 'extension' | 'user'>
+    ids: Pick<IdsAPI, 'entry' | 'contentType' | 'environment' | 'space' | 'extension' | 'user'>;
   };
 
   export type SidebarExtensionSDK = BaseExtensionSDK & SharedEditorSDK & {
     /** A set of IDs actual for the extension */
-    ids: Pick<IdsAPI, 'entry' | 'contentType' | 'environment' | 'space' | 'extension' | 'user'>
+    ids: Pick<IdsAPI, 'entry' | 'contentType' | 'environment' | 'space' | 'extension' | 'user'>;
+    /** Methods to update the size of the iframe the extension is contained within.  */
+    window: WindowAPI;
   };
 
   export type FieldExtensionSDK = BaseExtensionSDK & SharedEditorSDK & {
     /** A set of IDs actual for the extension */
-    ids: IdsAPI
+    ids: IdsAPI;
     /** Gives you access to the value and metadata of the field the extension is attached to. */
-    field: FieldAPI
+    field: FieldAPI;
+    /** Methods to update the size of the iframe the extension is contained within.  */
+    window: WindowAPI;
   }
 
   export type DialogExtensionSDK = BaseExtensionSDK & {
     /** A set of IDs actual for the extension */
-    ids: Pick<IdsAPI, 'environment' | 'space' | 'extension' | 'user'>
+    ids: Pick<IdsAPI, 'environment' | 'space' | 'extension' | 'user'>;
     /** Closes the dialog and resolves openExtension promise with data */
     close: (data: any) => void
+    /** Methods to update the size of the iframe the extension is contained within.  */
+    window: WindowAPI;
   }
 
-  export const init: (initCallback: (sdk: BaseExtensionSDK | FieldExtensionSDK | SidebarExtensionSDK | DialogExtensionSDK | EditorExtensionSDK) => any) => void;
+  export const init: (initCallback: (sdk: FieldExtensionSDK | SidebarExtensionSDK | DialogExtensionSDK | EditorExtensionSDK) => any) => void;
 
   export const locations: {
     LOCATION_ENTRY_FIELD: string;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -333,6 +333,8 @@ declare module 'contentful-ui-extensions-sdk' {
 
   export type SidebarExtensionSDK = BaseExtensionSDK;
 
+  export type EntryEditorSDK = BaseExtensionSDK;
+
   export type FieldExtensionSDK = BaseExtensionSDK & {
     /** Gives you access to the value and metadata of the field the extension is attached to. */
     field: FieldAPI
@@ -350,6 +352,7 @@ declare module 'contentful-ui-extensions-sdk' {
     LOCATION_ENTRY_FIELD_SIDEBAR: string;
     LOCATION_ENTRY_SIDEBAR: string;
     LOCATION_DIALOG: string;
+    LOCATION_ENTRY_EDITOR: string;
   }
 
 }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -331,6 +331,16 @@ declare module 'contentful-ui-extensions-sdk' {
     invocation?: Object;
   }
 
+  /* IDs */
+
+  interface IdsAPI {
+    extension: string;
+    space: string;
+    environment: string;
+    field: string;
+    entry: string;
+  }
+
   interface SharedEditorSDK {
     editor: {
       editorInterface: EditorInterface,
@@ -362,21 +372,30 @@ declare module 'contentful-ui-extensions-sdk' {
     notifier: NotifierAPI;
     /** Exposes extension configuration parameters */
     parameters: ParametersAPI;
+    /** Exposes method to identify extension's location */
     location: LocationAPI;
   }
 
-  export type EditorExtensionSDK = BaseExtensionSDK & SharedEditorSDK;
+  export type EditorExtensionSDK = BaseExtensionSDK & SharedEditorSDK & {
+    /** A set of IDs actual for the extension */
+    ids: Pick<IdsAPI, 'entry' | 'environment' | 'space' | 'extension'>
+  };
 
-  export type SidebarExtensionSDK = BaseExtensionSDK & SharedEditorSDK;
-
-  export type EntryEditorSDK = BaseExtensionSDK & SharedEditorSDK;
+  export type SidebarExtensionSDK = BaseExtensionSDK & SharedEditorSDK & {
+    /** A set of IDs actual for the extension */
+    ids: Pick<IdsAPI, 'entry' | 'environment' | 'space' | 'extension'>
+  };
 
   export type FieldExtensionSDK = BaseExtensionSDK & SharedEditorSDK & {
+    /** A set of IDs actual for the extension */
+    ids: IdsAPI
     /** Gives you access to the value and metadata of the field the extension is attached to. */
     field: FieldAPI
   }
 
   export type DialogExtensionSDK = BaseExtensionSDK & {
+    /** A set of IDs actual for the extension */
+    ids: Pick<IdsAPI, 'environment' | 'space' | 'extension'>
     /** Closes the dialog and resolves openExtension promise with data */
     close: (data: any) => void
   }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -336,7 +336,8 @@ declare module 'contentful-ui-extensions-sdk' {
       editorInterface: EditorInterface,
       onActiveLocalesChanged: (callback: (value: Array<Object>) => any) => Function,
       onFocusedLocaleChanged: (callback: (value: Object) => any) => Function,
-      onLocaleModeChanged: (callback: (value: 'single' | 'multi') => any) => Function
+      onLocaleModeChanged: (callback: (value: 'single' | 'multi') => any) => Function,
+      onShowDisabledFieldsChanged: (callback: (value: boolean) => any) => Function
     }
   }
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -334,6 +334,7 @@ declare module 'contentful-ui-extensions-sdk' {
   /* IDs */
 
   interface IdsAPI {
+    user: string;
     extension: string;
     space: string;
     environment: string;
@@ -379,12 +380,12 @@ declare module 'contentful-ui-extensions-sdk' {
 
   export type EditorExtensionSDK = BaseExtensionSDK & SharedEditorSDK & {
     /** A set of IDs actual for the extension */
-    ids: Pick<IdsAPI, 'entry' | 'contentType' | 'environment' | 'space' | 'extension'>
+    ids: Pick<IdsAPI, 'entry' | 'contentType' | 'environment' | 'space' | 'extension' | 'user'>
   };
 
   export type SidebarExtensionSDK = BaseExtensionSDK & SharedEditorSDK & {
     /** A set of IDs actual for the extension */
-    ids: Pick<IdsAPI, 'entry' | 'contentType' | 'environment' | 'space' | 'extension'>
+    ids: Pick<IdsAPI, 'entry' | 'contentType' | 'environment' | 'space' | 'extension' | 'user'>
   };
 
   export type FieldExtensionSDK = BaseExtensionSDK & SharedEditorSDK & {
@@ -396,7 +397,7 @@ declare module 'contentful-ui-extensions-sdk' {
 
   export type DialogExtensionSDK = BaseExtensionSDK & {
     /** A set of IDs actual for the extension */
-    ids: Pick<IdsAPI, 'environment' | 'space' | 'extension'>
+    ids: Pick<IdsAPI, 'environment' | 'space' | 'extension' | 'user'>
     /** Closes the dialog and resolves openExtension promise with data */
     close: (data: any) => void
   }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -130,6 +130,27 @@ declare module 'contentful-ui-extensions-sdk' {
     description: string;
   }
 
+  interface EditorInterface {
+    sys: Object;
+    controls: Array<{
+      fieldId: string;
+      widgetId: string;
+      widgetNamespace: string;
+      settings: Object;
+    }>;
+    sidebar?: Array<{
+      widgetId: string;
+      widgetNamespace: string;
+      settings: Object;
+      disabled?: boolean;
+    }>;
+    editor?: {
+      widgetId: string;
+      widgetNamespace: string;
+      settings: Object;
+    }
+  }
+
   /* Space API */
 
   interface SearchQuery {
@@ -184,21 +205,7 @@ declare module 'contentful-ui-extensions-sdk' {
     getUsers: () => Promise<CollectionReponse<Object>>,
 
     /** Returns editor interface for a given content type */
-    getEditorInterface: (contentTypeId: string) => Promise<{
-      sys: Object;
-      controls: Array<{
-        fieldId: string;
-        widgetId: string;
-        widgetNamespace: string;
-        settings: Object;
-      }>;
-      sidebar?: Array<{
-        widgetId: string;
-        widgetNamespace: string;
-        settings: Object;
-        disabled?: boolean;
-      }>
-    }>
+    getEditorInterface: (contentTypeId: string) => Promise<EditorInterface>
   }
 
   /* Locales API */
@@ -324,6 +331,12 @@ declare module 'contentful-ui-extensions-sdk' {
     invocation?: Object;
   }
 
+  interface SharedEditorSDK {
+    editor: {
+      editorInterface: EditorInterface
+    }
+  }
+
   export interface BaseExtensionSDK {
     /** Allows to read and update the value of any field of the current entry and to get the entry's metadata */
     entry: EntryAPI;
@@ -348,11 +361,13 @@ declare module 'contentful-ui-extensions-sdk' {
     location: LocationAPI;
   }
 
-  export type SidebarExtensionSDK = BaseExtensionSDK;
+  export type EditorExtensionSDK = BaseExtensionSDK & SharedEditorSDK;
 
-  export type EntryEditorSDK = BaseExtensionSDK;
+  export type SidebarExtensionSDK = BaseExtensionSDK & SharedEditorSDK;
 
-  export type FieldExtensionSDK = BaseExtensionSDK & {
+  export type EntryEditorSDK = BaseExtensionSDK & SharedEditorSDK;
+
+  export type FieldExtensionSDK = BaseExtensionSDK & SharedEditorSDK & {
     /** Gives you access to the value and metadata of the field the extension is attached to. */
     field: FieldAPI
   }
@@ -362,7 +377,7 @@ declare module 'contentful-ui-extensions-sdk' {
     close: (data: any) => void
   }
 
-  export const init: (initCallback: (sdk: BaseExtensionSDK | FieldExtensionSDK | SidebarExtensionSDK | DialogExtensionSDK) => any) => void;
+  export const init: (initCallback: (sdk: BaseExtensionSDK | FieldExtensionSDK | SidebarExtensionSDK | DialogExtensionSDK | EditorExtensionSDK) => any) => void;
 
   export const locations: {
     LOCATION_ENTRY_FIELD: string;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -333,7 +333,10 @@ declare module 'contentful-ui-extensions-sdk' {
 
   interface SharedEditorSDK {
     editor: {
-      editorInterface: EditorInterface
+      editorInterface: EditorInterface,
+      onActiveLocalesChanged: (callback: (value: Array<Object>) => any) => Function,
+      onFocusedLocaleChanged: (callback: (value: Object) => any) => Function,
+      onLocaleModeChanged: (callback: (value: 'single' | 'multi') => any) => Function
     }
   }
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -181,7 +181,24 @@ declare module 'contentful-ui-extensions-sdk' {
     waitUntilAssetProcessed: (assetId: string, locale: string) => void;
 
     /** Returns all users who belong to the space. */
-    getUsers: () => Promise<CollectionReponse<Object>>
+    getUsers: () => Promise<CollectionReponse<Object>>,
+
+    /** Returns editor interface for a given content type */
+    getEditorInterface: (contentTypeId: string) => Promise<{
+      sys: Object;
+      controls: Array<{
+        fieldId: string;
+        widgetId: string;
+        widgetNamespace: string;
+        settings: Object;
+      }>;
+      sidebar?: Array<{
+        widgetId: string;
+        widgetNamespace: string;
+        settings: Object;
+        disabled?: boolean;
+      }>
+    }>
   }
 
   /* Locales API */

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -21,6 +21,12 @@ declare module 'contentful-ui-extensions-sdk' {
     spaceMembership: SpaceMembership;
   }
 
+  interface Items {
+    type: string;
+    linkType?: string;
+    validations?: Object[];
+  }
+
     /* Field API */
 
   interface FieldAPI  {
@@ -30,8 +36,12 @@ declare module 'contentful-ui-extensions-sdk' {
     locale: string;
     /** Holds the type of the field the extension is attached to. */
     type: string;
+    /** Indicates if a value for this field is required **/
+    required: boolean;
     /** A list of validations for this field that are defined in the content type. */
     validations: Object[];
+    /** Defines the shape of array items **/
+    items?: Items;
 
     /** Gets the current value of the field and locale. */
     getValue: () => any;
@@ -65,8 +75,12 @@ declare module 'contentful-ui-extensions-sdk' {
     locales: string[];
      /** Holds the type of the field. */
     type: string;
+    /** Indicates if a value for this field is required **/
+    required: boolean;
     /** A list of validations for this field that are defined in the content type. */
     validations: Object[];
+    /** Defines the shape of array items **/
+    items?: Items;
 
     /** Gets the current value of the field and locale. */
     getValue: (locale?: string) => any;
@@ -101,7 +115,7 @@ declare module 'contentful-ui-extensions-sdk' {
     type: string;
     validations: Object[];
     linkType?: string;
-    items?: Object;
+    items?: Items;
   }
 
   interface Link {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -339,6 +339,7 @@ declare module 'contentful-ui-extensions-sdk' {
     environment: string;
     field: string;
     entry: string;
+    contentType: string;
   }
 
   interface SharedEditorSDK {
@@ -378,12 +379,12 @@ declare module 'contentful-ui-extensions-sdk' {
 
   export type EditorExtensionSDK = BaseExtensionSDK & SharedEditorSDK & {
     /** A set of IDs actual for the extension */
-    ids: Pick<IdsAPI, 'entry' | 'environment' | 'space' | 'extension'>
+    ids: Pick<IdsAPI, 'entry' | 'contentType' | 'environment' | 'space' | 'extension'>
   };
 
   export type SidebarExtensionSDK = BaseExtensionSDK & SharedEditorSDK & {
     /** A set of IDs actual for the extension */
-    ids: Pick<IdsAPI, 'entry' | 'environment' | 'space' | 'extension'>
+    ids: Pick<IdsAPI, 'entry' | 'contentType' | 'environment' | 'space' | 'extension'>
   };
 
   export type FieldExtensionSDK = BaseExtensionSDK & SharedEditorSDK & {


### PR DESCRIPTION
# Purpose of PR

- [x] Add a new location (`LOCATION_ENTRY_EDITOR`) with entry API but no field API
- [x] Expose `space.getEditorInterface`. Fixes https://github.com/contentful/ui-extensions-sdk/issues/198
- [x] Add method to listen:
  - [x] changes to locale mode (single vs multiple)
  - [x] changes of active locales
  - [x] changes of disabled field visibility
- [x] Add `extension.ids` with all important IDs (extension, space, environment etc...). Fixes https://github.com/contentful/ui-extensions-sdk/issues/206 https://github.com/contentful/ui-extensions-sdk/issues/201
- [x] Remove `window` from `LOCATION_ENTRY_EDITOR`
- [x] Add `user` to ids
- [x] Address PR comments

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
