### PR TITLE
Expose field "required" and "items" properties

### DIFF
--- a/lib/field-locale.js
+++ b/lib/field-locale.js
@@ -1,11 +1,16 @@
 const { MemoizedSignal } = require('./signal')
 
+const INFO_PROPS = ['id', 'locale', 'type', 'required', 'validations', 'items']
+
 module.exports = class FieldLocale {
   constructor (channel, fieldInfo) {
-    this.id = fieldInfo.id
-    this.locale = fieldInfo.locale
-    this.type = fieldInfo.type
-    this.validations = fieldInfo.validations
+    INFO_PROPS.forEach(prop => {
+      const value = fieldInfo[prop]
+      if (typeof value !== 'undefined') {
+        this[prop] = fieldInfo[prop]
+      }
+    })
+
     this._value = fieldInfo.value
     this._valueSignal = new MemoizedSignal(this._value)
     this._isDisabledSignal = new MemoizedSignal(undefined)

--- a/lib/field.js
+++ b/lib/field.js
@@ -1,19 +1,27 @@
 const FieldLocale = require('./field-locale')
 
+const INFO_PROPS = ['id', 'locales', 'type', 'required', 'validations', 'items']
+
 module.exports = class Field {
   constructor (channel, info, defaultLocale) {
-    this.id = info.id
-    this.locales = info.locales
-    this.type = info.type
-    this.validations = info.validations
-    this._defaultLocale = defaultLocale
-    this._fieldLocales = {}
-
-    this.locales.forEach((locale) => {
-      const value = info.values[locale]
-      this._fieldLocales[locale] =
-        new FieldLocale(channel, { id: this.id, locale, value })
+    INFO_PROPS.forEach(prop => {
+      const value = info[prop]
+      if (typeof value !== 'undefined') {
+        this[prop] = info[prop]
+      }
     })
+
+    this._defaultLocale = defaultLocale
+
+    this._fieldLocales = info.locales.reduce((acc, locale) => {
+      const fieldLocale = new FieldLocale(channel, {
+        id: info.id,
+        locale,
+        value: info.values[locale]
+      })
+
+      return { ...acc, [locale]: fieldLocale }
+    }, {})
 
     assertHasLocale(this, defaultLocale)
   }

--- a/test/unit/field-locale.spec.js
+++ b/test/unit/field-locale.spec.js
@@ -6,8 +6,14 @@ describe('FieldLocale', () => {
   const info = {
     id: 'some-field',
     locale: 'en-US',
-    type: 'Symbol',
-    validations: 'VALIDATIONS'
+    type: 'Array',
+    required: false,
+    validations: 'VALIDATIONS',
+    items: {
+      type: 'Link',
+      linkType: 'Entry',
+      validations: 'VALIDATIONS OF ITEMS'
+    }
   }
   let channelStub
   let field
@@ -24,7 +30,8 @@ describe('FieldLocale', () => {
       }
     }
 
-    field = new FieldLocale(channelStub, info)
+    const infoCopy = JSON.parse(JSON.stringify(info))
+    field = new FieldLocale(channelStub, infoCopy)
   })
 
   describe('.id', () => {
@@ -45,9 +52,28 @@ describe('FieldLocale', () => {
     })
   })
 
+  describe('.required', () => {
+    it('is equal to info.required', () => {
+      expect(field.required).to.equal(info.required)
+    })
+  })
+
   describe('.validations', () => {
     it('is equal to info.validations', () => {
       expect(field.validations).to.equal(info.validations)
+    })
+  })
+
+  describe(`.items`, () => {
+    it(`is set to the same value as info.items`, () => {
+      expect(field.items).to.deep.equal(info.items)
+    })
+
+    it('is skipped on the object if not defined in info', () => {
+      const noItemsInfo = JSON.parse(JSON.stringify(info))
+      delete noItemsInfo.items
+      const noItemsField = new FieldLocale(channelStub, noItemsInfo)
+      expect(noItemsField.items).to.equal(undefined)
     })
   })
 

--- a/test/unit/field.spec.js
+++ b/test/unit/field.spec.js
@@ -31,9 +31,16 @@ describe(`Field`, () => {
         'it-IT': 'Ciao',
         'de-DE': 'Hallo'
       },
-      type: 'Symbol',
-      validations: 'VALIDATIONS'
+      type: 'Array',
+      required: true,
+      validations: 'VALIDATIONS',
+      items: {
+        type: 'Link',
+        linkType: 'Entry',
+        validations: 'VALIDATIONS OF ITEMS'
+      }
     }
+
     let field
     beforeEach(() => {
       const infoCopy = JSON.parse(JSON.stringify(info))
@@ -62,9 +69,28 @@ describe(`Field`, () => {
       })
     })
 
+    describe(`.required`, () => {
+      it(`is set to the same value as info.required`, () => {
+        expect(field.required).to.equal(info.required)
+      })
+    })
+
     describe(`.validations`, () => {
       it(`is set to the same value as info.validations`, () => {
         expect(field.validations).to.equal(info.validations)
+      })
+    })
+
+    describe(`.items`, () => {
+      it(`is set to the same value as info.items`, () => {
+        expect(field.items).to.deep.equal(info.items)
+      })
+
+      it('is skipped on the object if not defined in info', () => {
+        const noItemsInfo = JSON.parse(JSON.stringify(info))
+        delete noItemsInfo.items
+        const noItemsField = new Field(channelStub, noItemsInfo, defaultLocale)
+        expect(noItemsField.items).to.equal(undefined)
       })
     })
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -21,6 +21,12 @@ declare module 'contentful-ui-extensions-sdk' {
     spaceMembership: SpaceMembership;
   }
 
+  interface Items {
+    type: string;
+    linkType?: string;
+    validations?: Object[];
+  }
+
     /* Field API */
 
   interface FieldAPI  {
@@ -30,8 +36,12 @@ declare module 'contentful-ui-extensions-sdk' {
     locale: string;
     /** Holds the type of the field the extension is attached to. */
     type: string;
+    /** Indicates if a value for this field is required **/
+    required: boolean;
     /** A list of validations for this field that are defined in the content type. */
     validations: Object[];
+    /** Defines the shape of array items **/
+    items?: Items;
 
     /** Gets the current value of the field and locale. */
     getValue: () => any;
@@ -65,8 +75,12 @@ declare module 'contentful-ui-extensions-sdk' {
     locales: string[];
      /** Holds the type of the field. */
     type: string;
+    /** Indicates if a value for this field is required **/
+    required: boolean;
     /** A list of validations for this field that are defined in the content type. */
     validations: Object[];
+    /** Defines the shape of array items **/
+    items?: Items;
 
     /** Gets the current value of the field and locale. */
     getValue: (locale?: string) => any;
@@ -101,7 +115,7 @@ declare module 'contentful-ui-extensions-sdk' {
     type: string;
     validations: Object[];
     linkType?: string;
-    items?: Object;
+    items?: Items;
   }
 
   interface Link {


### PR DESCRIPTION
# Purpose of PR

Expose `required` and `items`(`.type .linkType .validations`) on both `Field` and `FieldLocale instances`

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
