### PR TITLE
Add "platformAlpha" namespace

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -6,6 +6,7 @@ const createSpace = require('./space')
 const createDialogs = require('./dialogs')
 const createEditor = require('./editor')
 const createNavigator = require('./navigator')
+const createApp = require('./app')
 const locations = require('./locations')
 
 const DEFAULT_API_PRODUCERS = [
@@ -22,7 +23,8 @@ const LOCATION_TO_API_PRODUCERS = {
   [locations.LOCATION_ENTRY_SIDEBAR]: [makeSharedAPI, makeEntryAPI, makeEditorAPI, makeWindowAPI],
   [locations.LOCATION_ENTRY_EDITOR]: [makeSharedAPI, makeEntryAPI, makeEditorAPI],
   [locations.LOCATION_DIALOG]: [makeSharedAPI, makeDialogAPI, makeWindowAPI],
-  [locations.LOCATION_PAGE]: [makeSharedAPI]
+  [locations.LOCATION_PAGE]: [makeSharedAPI],
+  [locations.LOCATION_APP]: [makeSharedAPI, makeAppAPI]
 }
 
 module.exports = function createAPI(channel, data, currentWindow) {
@@ -91,5 +93,13 @@ function makeFieldAPI(channel, { field }) {
 function makeDialogAPI(channel) {
   return {
     close: data => channel.send('closeDialog', data)
+  }
+}
+
+function makeAppAPI(channel) {
+  return {
+    platformAlpha: {
+      app: createApp(channel)
+    }
   }
 }

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,0 +1,69 @@
+const HOOK_STAGE_PRE_INSTALL = 'preInstall'
+const HOOK_STAGE_POST_INSTALL = 'postInstall'
+
+const isObject = o => typeof o === 'object' && o !== null && !Array.isArray(o)
+
+const runHandler = handler => {
+  handler = typeof handler === 'function' ? handler : () => {}
+
+  let resultMaybePromise
+  try {
+    resultMaybePromise = handler()
+  } catch (err) {
+    resultMaybePromise = false
+  }
+
+  const isPromise = resultMaybePromise && typeof resultMaybePromise.then === 'function'
+  const resultPromise = isPromise ? resultMaybePromise : Promise.resolve(resultMaybePromise)
+
+  return resultPromise.then(
+    result => {
+      if (result instanceof Error || result === false) {
+        return false
+      } else if (!isObject(result)) {
+        return {}
+      } else {
+        return result
+      }
+    },
+    () => false
+  )
+}
+
+module.exports = function createApp(channel) {
+  const handlers = {
+    [HOOK_STAGE_PRE_INSTALL]: null,
+    [HOOK_STAGE_POST_INSTALL]: null
+  }
+
+  const setHandler = (stage, handler) => {
+    if (handlers[stage]) {
+      throw new Error('Cannot register a handler twice.')
+    } else if (typeof handler !== 'function') {
+      throw new Error('Handler must be a function.')
+    } else {
+      handlers[stage] = handler
+    }
+  }
+
+  channel.addHandler('appHook', ({ stage, installationRequestId }) => {
+    return runHandler(handlers[stage]).then(result => {
+      channel.send('appHookResult', { stage, installationRequestId, result })
+    })
+  })
+
+  return {
+    isInstalled() {
+      return channel.call('callAppMethod', 'isInstalled')
+    },
+    getParameters() {
+      return channel.call('callAppMethod', 'getParameters')
+    },
+    onConfigure(handler) {
+      setHandler(HOOK_STAGE_PRE_INSTALL, handler)
+    },
+    onConfigurationCompleted(handler) {
+      setHandler(HOOK_STAGE_POST_INSTALL, handler)
+    }
+  }
+}

--- a/lib/app.js
+++ b/lib/app.js
@@ -78,9 +78,6 @@ module.exports = function createApp(channel) {
     },
     onConfigure(handler) {
       setHandler(HOOK_STAGE_PRE_INSTALL, handler)
-    },
-    onConfigurationCompleted(handler) {
-      setHandler(HOOK_STAGE_POST_INSTALL, handler)
     }
   }
 }

--- a/lib/app.js
+++ b/lib/app.js
@@ -2,32 +2,46 @@ const HOOK_STAGE_PRE_INSTALL = 'preInstall'
 const HOOK_STAGE_POST_INSTALL = 'postInstall'
 
 const isObject = o => typeof o === 'object' && o !== null && !Array.isArray(o)
+const isFunction = f => typeof f === 'function'
+const isPromise = p => isObject(p) && isFunction(p.then)
 
 const runHandler = handler => {
-  handler = typeof handler === 'function' ? handler : () => {}
-
-  let resultMaybePromise
-  try {
-    resultMaybePromise = handler()
-  } catch (err) {
-    resultMaybePromise = false
+  // Handler was not registered. Registering a handler is not
+  // required and we resolve with empty parameters in this case.
+  if (!isFunction(handler)) {
+    return Promise.resolve({})
   }
 
-  const isPromise = resultMaybePromise && typeof resultMaybePromise.then === 'function'
-  const resultPromise = isPromise ? resultMaybePromise : Promise.resolve(resultMaybePromise)
+  // If handler is synchronous it can throw and we need to
+  // catch it. We resolve with `false` in this case.
+  let maybeResultPromise
+  try {
+    maybeResultPromise = handler()
+  } catch (err) {
+    return Promise.resolve(false)
+  }
 
-  return resultPromise.then(
-    result => {
-      if (result instanceof Error || result === false) {
-        return false
-      } else if (!isObject(result)) {
-        return {}
-      } else {
-        return result
-      }
-    },
-    () => false
-  )
+  // If handler is synchronous, we wrap the result with a promise
+  // and deal only with Promises API below.
+  let resultPromise = maybeResultPromise
+  if (!isPromise(resultPromise)) {
+    resultPromise = Promise.resolve(resultPromise)
+  }
+
+  return resultPromise
+    .then(
+      result => {
+        if (result instanceof Error || result === false) {
+          return false
+        } else if (!isObject(result)) {
+          return {}
+        } else {
+          return result
+        }
+      },
+      () => false
+    )
+    .catch(() => false)
 }
 
 module.exports = function createApp(channel) {
@@ -39,7 +53,7 @@ module.exports = function createApp(channel) {
   const setHandler = (stage, handler) => {
     if (handlers[stage]) {
       throw new Error('Cannot register a handler twice.')
-    } else if (typeof handler !== 'function') {
+    } else if (!isFunction(handler)) {
       throw new Error('Handler must be a function.')
     } else {
       handlers[stage] = handler

--- a/lib/app.js
+++ b/lib/app.js
@@ -73,6 +73,9 @@ module.exports = function createApp(channel) {
     getParameters() {
       return channel.call('callAppMethod', 'getParameters')
     },
+    getCurrentState() {
+      return channel.call('callAppMethod', 'getCurrentState')
+    },
     onConfigure(handler) {
       setHandler(HOOK_STAGE_PRE_INSTALL, handler)
     },

--- a/lib/locations.js
+++ b/lib/locations.js
@@ -4,5 +4,6 @@ module.exports = {
   LOCATION_ENTRY_SIDEBAR: 'entry-sidebar',
   LOCATION_DIALOG: 'dialog',
   LOCATION_ENTRY_EDITOR: 'entry-editor',
-  LOCATION_PAGE: 'page'
+  LOCATION_PAGE: 'page',
+  LOCATION_APP: 'app'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-ui-extensions-sdk",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful-ui-extensions-sdk",
   "description": "SDK to develop custom UI Extension for the Contentful Web App",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "author": "Contentful GmbH",
   "license": "MIT",
   "main": "dist/cf-extension-api.js",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -58,7 +58,10 @@ function describeChannelCallingMethod(spec) {
 
     beforeEach(() => {
       channelCallStub = sinon.stub()
-      object = creator({ call: channelCallStub })
+      object = creator({
+        call: channelCallStub,
+        addHandler: sinon.spy()
+      })
     })
 
     it('is a function', () => {

--- a/test/unit/api.spec.js
+++ b/test/unit/api.spec.js
@@ -61,6 +61,8 @@ function test(expected, location, expectedLocation) {
   expect(Object.keys(api.location)).to.deep.equal(['is'])
   expect(api.location.is(expectedLocation)).to.equal(true)
   expect(api.location.is('wat?')).to.equal(false)
+
+  return api
 }
 
 describe('createAPI()', () => {
@@ -93,5 +95,15 @@ describe('createAPI()', () => {
     const expected = ['close', 'window']
 
     test(expected, locations.LOCATION_DIALOG)
+  })
+
+  it('returns correct shape of the app API (app)', () => {
+    const expected = ['platformAlpha']
+
+    const api = test(expected, locations.LOCATION_APP)
+
+    expect(api.platformAlpha).to.have.all.keys(['app'])
+    const appMethods = ['isInstalled', 'getParameters', 'onConfigure', 'onConfigurationCompleted']
+    expect(api.platformAlpha.app).to.have.all.keys(appMethods)
   })
 })

--- a/test/unit/api.spec.js
+++ b/test/unit/api.spec.js
@@ -103,7 +103,13 @@ describe('createAPI()', () => {
     const api = test(expected, locations.LOCATION_APP)
 
     expect(api.platformAlpha).to.have.all.keys(['app'])
-    const appMethods = ['isInstalled', 'getParameters', 'onConfigure', 'onConfigurationCompleted']
+    const appMethods = [
+      'isInstalled',
+      'getParameters',
+      'getCurrentState',
+      'onConfigure',
+      'onConfigurationCompleted'
+    ]
     expect(api.platformAlpha.app).to.have.all.keys(appMethods)
   })
 })

--- a/test/unit/api.spec.js
+++ b/test/unit/api.spec.js
@@ -103,13 +103,7 @@ describe('createAPI()', () => {
     const api = test(expected, locations.LOCATION_APP)
 
     expect(api.platformAlpha).to.have.all.keys(['app'])
-    const appMethods = [
-      'isInstalled',
-      'getParameters',
-      'getCurrentState',
-      'onConfigure',
-      'onConfigurationCompleted'
-    ]
+    const appMethods = ['isInstalled', 'getParameters', 'getCurrentState', 'onConfigure']
     expect(api.platformAlpha.app).to.have.all.keys(appMethods)
   })
 })

--- a/test/unit/app.spec.js
+++ b/test/unit/app.spec.js
@@ -1,0 +1,97 @@
+const { sinon, expect, describeChannelCallingMethod } = require('../helpers')
+
+const createApp = require('../../lib/app')
+
+const describeAppHookMessageExchange = (description, method, stage) => {
+  describe(description, () => {
+    let channelStub
+    let app
+
+    beforeEach(() => {
+      channelStub = { addHandler: sinon.spy(), send: sinon.spy() }
+      app = createApp(channelStub)
+    })
+
+    const test = async (handler, result) => {
+      expect(channelStub.addHandler).to.have.been.calledOnce // eslint-disable-line no-unused-expressions
+      const [channelMethod, sendMessage] = channelStub.addHandler.args[0]
+      expect(channelMethod).to.eql('appHook')
+
+      if (handler) {
+        app[method](handler)
+      }
+
+      const msg = { installationRequestId: 'xyz', stage }
+      const expected = { result, ...msg }
+
+      await sendMessage(msg)
+
+      expect(channelStub.send).to.have.been.calledWithExactly('appHookResult', expected)
+    }
+
+    it('does the exchange when handler is not defined', () => test(undefined, {}))
+
+    describe('the exchange when handler is a synchronous function', () => {
+      const scenarios = [
+        ['returns hash of empty parameters', () => ({}), {}],
+        ['returns hash of non-empty parameters', () => ({ test: true }), { test: true }],
+        ['returns false', () => false, false],
+        [
+          'returns false when an error is thrown',
+          () => {
+            throw new Error()
+          },
+          false
+        ],
+        ['returns empty hash of parameters if a non-object is returned', () => 1, {}]
+      ]
+
+      scenarios.forEach(([description, handler, result]) => {
+        it(description, () => test(handler, result))
+      })
+    })
+
+    describe('the exchange when handler is an async function', () => {
+      const scenarios = [
+        ['returns hash of empty parameters', async () => ({}), {}],
+        ['returns hash of non-empty parameters', async () => ({ test: true }), { test: true }],
+        ['returns false', async () => false, false],
+        [
+          'returns false when an error is thrown',
+          async () => {
+            throw new Error()
+          },
+          false
+        ],
+        ['returns false when a promise rejects', () => Promise.reject(new Error()), false],
+        ['returns empty hash of parameters if a non-object is returned', async () => 1, {}]
+      ]
+
+      scenarios.forEach(([description, handler, result]) => {
+        it(description, () => test(handler, result))
+      })
+    })
+  })
+}
+
+describe('createApp()', () => {
+  describe('returned "app" object', () => {
+    ;['isInstalled', 'getParameters'].forEach(appMethod => {
+      describeChannelCallingMethod({
+        creator: createApp,
+        methodName: appMethod,
+        channelMethod: 'callAppMethod',
+        args: [],
+        expectedCallArgs: [appMethod]
+      })
+    })
+
+    describeAppHookMessageExchange('.onConfigure(handler)', 'onConfigure', 'preInstall')
+
+    describeAppHookMessageExchange(
+      '.onConfigurationCompleted(handler)',
+      'onConfigurationCompleted',
+      'postInstall'
+    )
+  })
+})

--- a/test/unit/app.spec.js
+++ b/test/unit/app.spec.js
@@ -29,6 +29,19 @@ const describeAppHookMessageExchange = (description, method, stage) => {
       expect(channelStub.send).to.have.been.calledWithExactly('appHookResult', expected)
     }
 
+    it('requires the handler to be a function', () => {
+      expect(() => {
+        app[method]('yolo')
+      }).to.throw(/must be a function/)
+    })
+
+    it('only allows to register a handler once', () => {
+      app[method](() => {})
+      expect(() => {
+        app[method](() => {})
+      }).to.throw(/handler twice/)
+    })
+
     it('does the exchange when handler is not defined', () => test(undefined, {}))
 
     describe('the exchange when handler is a synchronous function', () => {

--- a/test/unit/app.spec.js
+++ b/test/unit/app.spec.js
@@ -102,11 +102,5 @@ describe('createApp()', () => {
     })
 
     describeAppHookMessageExchange('.onConfigure(handler)', 'onConfigure', 'preInstall')
-
-    describeAppHookMessageExchange(
-      '.onConfigurationCompleted(handler)',
-      'onConfigurationCompleted',
-      'postInstall'
-    )
   })
 })

--- a/test/unit/app.spec.js
+++ b/test/unit/app.spec.js
@@ -87,9 +87,11 @@ const describeAppHookMessageExchange = (description, method, stage) => {
   })
 }
 
+const APP_METHODS = ['isInstalled', 'getParameters', 'getCurrentState']
+
 describe('createApp()', () => {
   describe('returned "app" object', () => {
-    ;['isInstalled', 'getParameters'].forEach(appMethod => {
+    APP_METHODS.forEach(appMethod => {
       describeChannelCallingMethod({
         creator: createApp,
         methodName: appMethod,

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -443,10 +443,10 @@ declare module 'contentful-ui-extensions-sdk' {
         isInstalled: () => boolean
         /** Returns parameters of an App, null otherwise **/
         getParameters: () => null | Object
-        /** Registers a handler to be called to produce parameters for an App **/
+        /** Returns current state of an App, null otherwise **/
+        getCurrentState: () => null | Object
+        /** Registers a handler to be called to produce parameters and target state for an App **/
         onConfigure: (handler: Function) => void
-        /** Registers a handler to be called to do post configuration tasks **/
-        onConfigurationCompleted: (handler: Function) => void
       }
     }
   }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -432,7 +432,26 @@ declare module 'contentful-ui-extensions-sdk' {
     ids: Pick<IdsAPI, 'environment' | 'space' | 'extension' | 'user'>;
   }
 
-  export const init: (initCallback: (sdk: FieldExtensionSDK | SidebarExtensionSDK | DialogExtensionSDK | EditorExtensionSDK | PageExtensionSDK) => any) => void;
+  export type AppExtensionSDK = BaseExtensionSDK & {
+    /** A set of IDs actual for the extension */
+    ids: Pick<IdsAPI, 'environment' | 'space' | 'user'>;
+    /** Apps Platform __ALPHA__ methods: subject to change **/
+    platformAlpha: {
+      /** Management methods for App status and installation **/
+      app: {
+        /** Returns true if an App is installed **/
+        isInstalled: () => boolean
+        /** Returns parameters of an App, null otherwise **/
+        getParameters: () => null | Object
+        /** Registers a handler to be called to produce parameters for an App **/
+        onConfigure: (handler: Function) => void
+        /** Registers a handler to be called to do post configuration tasks **/
+        onConfigurationCompleted: (handler: Function) => void
+      }
+    }
+  }
+
+  export const init: (initCallback: (sdk: FieldExtensionSDK | SidebarExtensionSDK | DialogExtensionSDK | EditorExtensionSDK | PageExtensionSDK | AppExtensionSDK) => any) => void;
 
   export const locations: {
     LOCATION_ENTRY_FIELD: string;
@@ -441,6 +460,7 @@ declare module 'contentful-ui-extensions-sdk' {
     LOCATION_DIALOG: string;
     LOCATION_ENTRY_EDITOR: string;
     LOCATION_PAGE: string;
+    LOCATION_APP: string;
   }
 
 }


### PR DESCRIPTION
# Purpose of PR

adds a new `platformAlpha` namespace with the following API:

- `sdk.platformAlpha.app.isInstalled(): boolean`
- `sdk.platformAlpha.app.getParameters(): null | object`
- `sdk.platformAlpha.app.getCurrentState(): null | object`
- `sdk.platformAlpha.app.onConfigure(handler): void`

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
