### PR TITLE
Refactor tests

### DIFF
--- a/test/cypress/integration/dialog-extension.spec.js
+++ b/test/cypress/integration/dialog-extension.spec.js
@@ -3,7 +3,6 @@ import { entry } from '../utils/paths'
 import * as openPageExtensionTest from './reusable/open-page-extension-test'
 import { openEntryTest } from './reusable/open-entry-test'
 import { openAssetTest } from './reusable/open-asset-test'
-import { actionSelectors } from '../../constants'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openDialogExtension } from './reusable/open-dialog-extension-test'
 import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
@@ -38,14 +37,17 @@ context('Dialog extension', () => {
   })
 
   it('opens page extension using sdk.navigator.openPageExtension (with closing dialog)', () => {
-    openPageExtensionTest.clickToOpenPageExtension()
+    openPageExtensionTest.openPageExtension(iframeDialogSelector)
+    cy.getSdk(iframeDialogSelector).then(sdk => {
+      sdk.close()
+    })
     openPageExtensionTest.verifyPageExtensionUrl()
 
     cy.get('@extension').should('not.be.visible')
   })
 
   it('opens page extension using sdk.navigator.openPageExtension (without closing dialog)', () => {
-    openPageExtensionTest.clickToOpenPageExtension(actionSelectors.openPageExtensionNoClose)
+    openPageExtensionTest.openPageExtension(iframeDialogSelector)
     openPageExtensionTest.verifyPageExtensionUrl()
 
     cy.get('@extension').should('be.visible')
@@ -65,8 +67,8 @@ context('Dialog extension', () => {
 
   /* Reusable */
 
-  openEntryTest()
-  openAssetTest()
+  openEntryTest(iframeDialogSelector)
+  openAssetTest(iframeDialogSelector)
   openSdkUserDataTest(iframeDialogSelector)
   openSdkLocalesDataTest(iframeDialogSelector)
 })

--- a/test/cypress/integration/entry-editor-extension.spec.js
+++ b/test/cypress/integration/entry-editor-extension.spec.js
@@ -64,12 +64,12 @@ context('Entry editor extension', () => {
 
   /* Reusable tests */
 
-  openPageExtensionTest()
+  openPageExtensionTest(iframeSelector)
   openDialogExtensionTest(iframeSelector)
-  openEntryTest()
-  openEntrySlideInTest(post.id)
-  openAssetTest()
-  openAssetSlideInTest(post.id)
+  openEntryTest(iframeSelector)
+  openEntrySlideInTest(iframeSelector, post.id)
+  openAssetTest(iframeSelector)
+  openAssetSlideInTest(iframeSelector, post.id)
   openSdkUserDataTest(iframeSelector)
   openSdkLocalesDataTest(iframeSelector)
   openSdkEntryDataTest(iframeSelector)

--- a/test/cypress/integration/field-extension.spec.js
+++ b/test/cypress/integration/field-extension.spec.js
@@ -53,12 +53,12 @@ context('Field extension', () => {
 
   /* Reusable tests */
 
-  openPageExtensionTest()
+  openPageExtensionTest(iframeSelector)
   openDialogExtensionTest(iframeSelector)
-  openEntryTest()
-  openEntrySlideInTest(post.id)
-  openAssetTest()
-  openAssetSlideInTest(post.id)
+  openEntryTest(iframeSelector)
+  openEntrySlideInTest(iframeSelector, post.id)
+  openAssetTest(iframeSelector)
+  openAssetSlideInTest(iframeSelector, post.id)
   openSdkUserDataTest(iframeSelector)
   openSdkLocalesDataTest(iframeSelector)
   openSdkEntryDataTest(iframeSelector)

--- a/test/cypress/integration/page-extension.spec.js
+++ b/test/cypress/integration/page-extension.spec.js
@@ -46,8 +46,8 @@ context('Page extension', () => {
   /* Reusable tests */
 
   openDialogExtensionTest(iframeSelector)
-  openEntryTest()
-  openAssetTest()
+  openEntryTest(iframeSelector)
+  openAssetTest(iframeSelector)
   openSdkUserDataTest(iframeSelector)
   openSdkLocalesDataTest(iframeSelector)
 })

--- a/test/cypress/integration/reusable/open-asset-test.js
+++ b/test/cypress/integration/reusable/open-asset-test.js
@@ -1,11 +1,17 @@
 import { asset } from '../../utils/paths'
 import * as Constants from '../../../constants'
 
-export function clickToOpenAsset({ slideIn } = { slideIn: false }) {
-  cy.get('@extension').within(() => {
-    cy.getByTestId(
-      slideIn ? Constants.actionSelectors.openAssetSlideIn : Constants.actionSelectors.openAsset
-    ).click()
+export function openAssetExtension(iframeSelector) {
+  cy.getSdk(iframeSelector).then(sdk => {
+    sdk.navigator.openAsset(Constants.assets.testImage)
+  })
+}
+
+export function openAssetSlideInExtension(iframeSelector) {
+  cy.getSdk(iframeSelector).then(sdk => {
+    sdk.navigator.openAsset(Constants.assets.testImage, {
+      slideIn: true
+    })
   })
 }
 
@@ -20,18 +26,16 @@ export function verifyAssetSlideInUrl(assetId, previousEntryId) {
   )
 }
 
-export function openAssetTest() {
+export function openAssetTest(iframeSelector) {
   it('opens asset using sdk.navigator.openAsset', () => {
-    clickToOpenAsset()
+    openAssetExtension(iframeSelector)
     verifyAssetPageUrl(Constants.assets.testImage)
   })
 }
 
-export function openAssetSlideInTest(currentEntryId) {
+export function openAssetSlideInTest(iframeSelector, currentEntryId) {
   it('opens asset using sdk.navigator.openAsset (slideIn)', () => {
-    clickToOpenAsset({
-      slideIn: true
-    })
+    openAssetSlideInExtension(iframeSelector)
     verifyAssetSlideInUrl(Constants.assets.testImage, currentEntryId)
   })
 }

--- a/test/cypress/integration/reusable/open-entry-test.js
+++ b/test/cypress/integration/reusable/open-entry-test.js
@@ -1,11 +1,17 @@
 import { entry } from '../../utils/paths'
 import * as Constants from '../../../constants'
 
-export function clickToOpenEntry({ slideIn } = { slideIn: false }) {
-  cy.get('@extension').within(() => {
-    cy.getByTestId(
-      slideIn ? Constants.actionSelectors.openEntrySlideIn : Constants.actionSelectors.openEntry
-    ).click()
+export function openEntryExtension(iframeSelector) {
+  cy.getSdk(iframeSelector).then(sdk => {
+    sdk.navigator.openEntry(Constants.entries.testImageWrapper)
+  })
+}
+
+export function openEntrySlideInExtension(iframeSelector) {
+  cy.getSdk(iframeSelector).then(sdk => {
+    sdk.navigator.openEntry(Constants.entries.testImageWrapper, {
+      slideIn: true
+    })
   })
 }
 
@@ -20,18 +26,16 @@ export function verifyEntrySlideInUrl(entryId, previousEntryId) {
   )
 }
 
-export function openEntryTest() {
+export function openEntryTest(iframeSelector) {
   it('opens entry using sdk.navigator.openEntry', () => {
-    clickToOpenEntry()
+    openEntryExtension(iframeSelector)
     verifyEntryPageUrl(Constants.entries.testImageWrapper)
   })
 }
 
-export function openEntrySlideInTest(currentEntryId) {
+export function openEntrySlideInTest(iframeSelector, currentEntryId) {
   it('opens entry using sdk.navigator.openEntry (slideIn)', () => {
-    clickToOpenEntry({
-      slideIn: true
-    })
+    openEntrySlideInExtension(iframeSelector)
     verifyEntrySlideInUrl(Constants.entries.testImageWrapper, currentEntryId)
   })
 }

--- a/test/cypress/integration/reusable/open-page-extension-test.js
+++ b/test/cypress/integration/reusable/open-page-extension-test.js
@@ -1,9 +1,8 @@
 import { pageExtension } from '../../utils/paths'
-import { actionSelectors } from '../../../constants'
 
-export function clickToOpenPageExtension(testId = actionSelectors.openPageExtension) {
-  cy.get('@extension').within(() => {
-    cy.getByTestId(testId).click()
+export function openPageExtension(iframeSelector) {
+  cy.getSdk(iframeSelector).then(sdk => {
+    sdk.navigator.openPageExtension()
   })
 }
 
@@ -11,9 +10,9 @@ export function verifyPageExtensionUrl(extensionId = 'test-extension') {
   cy.url().should('eq', Cypress.config().baseUrl + pageExtension(extensionId))
 }
 
-export function openPageExtensionTest() {
+export function openPageExtensionTest(iframeSelector) {
   it('opens page extension using sdk.navigator.openPageExtension', () => {
-    clickToOpenPageExtension()
+    openPageExtension(iframeSelector)
     verifyPageExtensionUrl()
   })
 }

--- a/test/cypress/integration/sidebar-extension.spec.js
+++ b/test/cypress/integration/sidebar-extension.spec.js
@@ -58,12 +58,12 @@ context('Sidebar extension', () => {
 
   /* Reusable tests */
 
-  openPageExtensionTest()
+  openPageExtensionTest(iframeSelector)
   openDialogExtensionTest(iframeSelector)
-  openEntryTest()
-  openEntrySlideInTest(post.id)
-  openAssetTest()
-  openAssetSlideInTest(post.id)
+  openEntryTest(iframeSelector)
+  openEntrySlideInTest(iframeSelector, post.id)
+  openAssetTest(iframeSelector)
+  openAssetSlideInTest(iframeSelector, post.id)
   openSdkUserDataTest(iframeSelector)
   openSdkLocalesDataTest(iframeSelector)
   openSdkEntryDataTest(iframeSelector)


### PR DESCRIPTION
Next tests were refactored to call sdk methods directly and not through DOM-elements: 

- dialog-extension.spec.js

- entry-editor-extension.spec.js

- field-extension.spec.js

- page-extension.spec.js

- sidebar-extension.spec.js