### PR TITLE
Added sdk.notifier success and fail methods tests

### DIFF
--- a/test/cypress/integration/dialog-extension.spec.js
+++ b/test/cypress/integration/dialog-extension.spec.js
@@ -6,6 +6,10 @@ import { openAssetTest } from './reusable/open-asset-test'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openDialogExtension } from './reusable/open-dialog-extension-test'
 import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
+import {
+  openSuccessNotificationTest,
+  openErrorNotificationTest
+} from './reusable/open-notifications-test'
 
 const post = {
   id: '3MEimIRakHkmgmqvp1oIsM',
@@ -71,4 +75,6 @@ context('Dialog extension', () => {
   openAssetTest(iframeDialogSelector)
   openSdkUserDataTest(iframeDialogSelector)
   openSdkLocalesDataTest(iframeDialogSelector)
+  openSuccessNotificationTest(iframeDialogSelector)
+  openErrorNotificationTest(iframeDialogSelector)
 })

--- a/test/cypress/integration/entry-editor-extension.spec.js
+++ b/test/cypress/integration/entry-editor-extension.spec.js
@@ -7,6 +7,10 @@ import { openAssetSlideInTest, openAssetTest } from './reusable/open-asset-test'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
 import { openSdkEntryDataTest } from './reusable/open-sdk-entry-data-test'
+import {
+  openSuccessNotificationTest,
+  openErrorNotificationTest
+} from './reusable/open-notifications-test'
 
 const post = {
   id: '5mwUiJB2kThfAG9ZnRNuNQ',
@@ -73,4 +77,6 @@ context('Entry editor extension', () => {
   openSdkUserDataTest(iframeSelector)
   openSdkLocalesDataTest(iframeSelector)
   openSdkEntryDataTest(iframeSelector)
+  openSuccessNotificationTest(iframeSelector)
+  openErrorNotificationTest(iframeSelector)
 })

--- a/test/cypress/integration/field-extension.spec.js
+++ b/test/cypress/integration/field-extension.spec.js
@@ -7,6 +7,10 @@ import { openAssetSlideInTest, openAssetTest } from './reusable/open-asset-test'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
 import { openSdkEntryDataTest } from './reusable/open-sdk-entry-data-test'
+import {
+  openSuccessNotificationTest,
+  openErrorNotificationTest
+} from './reusable/open-notifications-test'
 
 const post = {
   id: '1MDrvtuLDk0PcxS5nCkugC',
@@ -62,4 +66,6 @@ context('Field extension', () => {
   openSdkUserDataTest(iframeSelector)
   openSdkLocalesDataTest(iframeSelector)
   openSdkEntryDataTest(iframeSelector)
+  openSuccessNotificationTest(iframeSelector)
+  openErrorNotificationTest(iframeSelector)
 })

--- a/test/cypress/integration/page-extension.spec.js
+++ b/test/cypress/integration/page-extension.spec.js
@@ -5,6 +5,10 @@ import { openEntryTest } from './reusable/open-entry-test'
 import { openAssetTest } from './reusable/open-asset-test'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
+import {
+  openSuccessNotificationTest,
+  openErrorNotificationTest
+} from './reusable/open-notifications-test'
 
 const iframeSelector = '[data-test-id="page-extension"] iframe'
 const idsData = require('./fixtures/ids-data.json')
@@ -50,4 +54,6 @@ context('Page extension', () => {
   openAssetTest(iframeSelector)
   openSdkUserDataTest(iframeSelector)
   openSdkLocalesDataTest(iframeSelector)
+  openSuccessNotificationTest(iframeSelector)
+  openErrorNotificationTest(iframeSelector)
 })

--- a/test/cypress/integration/reusable/open-notifications-test.js
+++ b/test/cypress/integration/reusable/open-notifications-test.js
@@ -1,0 +1,31 @@
+export function verifySuccessNotification(iframeSelector) {
+  const successMessage = 'Success message!'
+  cy.getSdk(iframeSelector).then(sdk => {
+    sdk.notifier.success(successMessage)
+  })
+  cy.getByTestId('cf-ui-notification')
+    .should('have.attr', 'data-intent', 'success')
+    .and('contain', successMessage)
+}
+
+export function verifyErrorNotification(iframeSelector) {
+  const errorMessage = 'Error message!'
+  cy.getSdk(iframeSelector).then(sdk => {
+    sdk.notifier.error(errorMessage)
+  })
+  cy.getByTestId('cf-ui-notification')
+    .should('have.attr', 'data-intent', 'error')
+    .and('contain', errorMessage)
+}
+
+export function openSuccessNotificationTest(iframeSelector) {
+  it('sdk.notifier.success method opens success notification', () => {
+    verifySuccessNotification(iframeSelector)
+  })
+}
+
+export function openErrorNotificationTest(iframeSelector) {
+  it('sdk.notifier.error method opens error notification', () => {
+    verifyErrorNotification(iframeSelector)
+  })
+}

--- a/test/cypress/integration/sidebar-extension.spec.js
+++ b/test/cypress/integration/sidebar-extension.spec.js
@@ -7,6 +7,10 @@ import { openAssetSlideInTest, openAssetTest } from './reusable/open-asset-test'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
 import { openSdkEntryDataTest } from './reusable/open-sdk-entry-data-test'
+import {
+  openSuccessNotificationTest,
+  openErrorNotificationTest
+} from './reusable/open-notifications-test'
 
 const post = {
   id: '3MEimIRakHkmgmqvp1oIsM',
@@ -67,4 +71,6 @@ context('Sidebar extension', () => {
   openSdkUserDataTest(iframeSelector)
   openSdkLocalesDataTest(iframeSelector)
   openSdkEntryDataTest(iframeSelector)
+  openSuccessNotificationTest(iframeSelector)
+  openErrorNotificationTest(iframeSelector)
 })


### PR DESCRIPTION
# Purpose of PR
Added tests, which verify, that notification messages are displayed, when methods sdk.notifier success and fail are called.