### PR TITLE
Adding `isReady` logic to SDK

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -78,6 +78,9 @@ module.exports = function createApp(channel) {
     },
     onConfigure(handler) {
       setHandler(HOOK_STAGE_PRE_INSTALL, handler)
+    },
+    isReady() {
+      return channel.call('callAppMethod', 'isReady')
     }
   }
 }

--- a/test/unit/api.spec.js
+++ b/test/unit/api.spec.js
@@ -103,7 +103,7 @@ describe('createAPI()', () => {
     const api = test(expected, locations.LOCATION_APP)
 
     expect(api.platformAlpha).to.have.all.keys(['app'])
-    const appMethods = ['isInstalled', 'getParameters', 'getCurrentState', 'onConfigure']
+    const appMethods = ['isInstalled', 'getParameters', 'getCurrentState', 'onConfigure', 'isReady']
     expect(api.platformAlpha.app).to.have.all.keys(appMethods)
   })
 })

--- a/test/unit/app.spec.js
+++ b/test/unit/app.spec.js
@@ -87,7 +87,7 @@ const describeAppHookMessageExchange = (description, method, stage) => {
   })
 }
 
-const APP_METHODS = ['isInstalled', 'getParameters', 'getCurrentState']
+const APP_METHODS = ['isInstalled', 'getParameters', 'getCurrentState', 'isReady']
 
 describe('createApp()', () => {
   describe('returned "app" object', () => {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -440,13 +440,15 @@ declare module 'contentful-ui-extensions-sdk' {
       /** Management methods for App status and installation **/
       app: {
         /** Returns true if an App is installed **/
-        isInstalled: () => boolean
+        isInstalled: () => Promise<boolean>
         /** Returns parameters of an App, null otherwise **/
-        getParameters: () => null | Object
+        getParameters: () => Promise<null | Object>
         /** Returns current state of an App, null otherwise **/
-        getCurrentState: () => null | Object
+        getCurrentState: () => Promise<null | Object>
         /** Registers a handler to be called to produce parameters and target state for an App **/
-        onConfigure: (handler: Function) => void
+        onConfigure: (handler: Function) => Promise<void>
+        /** Tells the web app that the app is loaded */
+        isReady: () => Promise<void>
       }
     }
   }


### PR DESCRIPTION
This adds a method to the SDK called `isReady` which allows apps to notify the web app that they are done loading and ready to be presented.