### PR TITLE
Add getEditorInterfaces method to space

### DIFF
--- a/lib/space.js
+++ b/lib/space.js
@@ -9,6 +9,7 @@ const spaceMethods = [
   'getPublishedAssets',
   'getContentTypes',
   'getEntries',
+  'getEditorInterfaces',
   'getAssets',
 
   'createContentType',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-ui-extensions-sdk",
-  "version": "3.9.4",
+  "version": "3.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful-ui-extensions-sdk",
   "description": "SDK to develop custom UI Extension for the Contentful Web App",
-  "version": "3.9.4",
+  "version": "3.10.0",
   "author": "Contentful GmbH",
   "license": "MIT",
   "main": "dist/cf-extension-api.js",

--- a/test/unit/space.spec.js
+++ b/test/unit/space.spec.js
@@ -13,6 +13,7 @@ const spaceMethods = [
   'getPublishedAssets',
   'getContentTypes',
   'getEntries',
+  'getEditorInterfaces',
   'getAssets',
 
   'createContentType',

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -220,6 +220,8 @@ declare module 'contentful-ui-extensions-sdk' {
 
     /** Returns editor interface for a given content type */
     getEditorInterface: (contentTypeId: string) => Promise<EditorInterface>
+    /** Returns editor interfaces for a given environment */
+    getEditorInterfaces: () => Promise<CollectionResponse<Object>>;
   }
 
   /* Locales API */


### PR DESCRIPTION
# Purpose of PR

Add a new `getEditorInterfaces` method to `space` to retrieve all editor interfaces for all content types within a given environment.

## PR Checklist

- [✓] Tests are added
- [✓] Tests are passing
- [✓] Typescript typings are added