### PR TITLE
Making init() generic

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -455,7 +455,9 @@ declare module 'contentful-ui-extensions-sdk' {
     }
   }
 
-  export const init: (initCallback: (sdk: FieldExtensionSDK | SidebarExtensionSDK | DialogExtensionSDK | EditorExtensionSDK | PageExtensionSDK | AppExtensionSDK) => any) => void;
+  export type KnownSDK = FieldExtensionSDK | SidebarExtensionSDK | DialogExtensionSDK | EditorExtensionSDK | PageExtensionSDK | AppExtensionSDK;
+
+  export const init: <T extends KnownSDK = KnownSDK>(initCallback: (sdk: T) => any) => void;
 
   export const locations: {
     LOCATION_ENTRY_FIELD: string;


### PR DESCRIPTION
# Purpose of PR

SDK's `init` often forces you to use `as` assertion, even when you know it would only be, for example, `FieldExtensionSDK`.

```ts
init(sdk => {
  const initialValue = (sdk as FieldExtensionSDK).field.getValue()

  render(<App sdk={sdk as FieldExtensionSDK} initialValue={initialValue} />, root)
})
```

I want to use generic to express it would only be a specific type of SDK.

```ts
init<FieldExtensionSDK>(sdk => {
  const initialValue = sdk.field.getValue()

  render(<App sdk={sdk} initialValue={initialValue} />, root)
})

// Or even...
init<FieldExtensionSDK | SidebarExtensionSDK>(sdk => { ... })
```

<img width="630" alt="スクリーンショット 2019-11-08 10 23 04" src="https://user-images.githubusercontent.com/5250706/68441580-f0732900-0211-11ea-92b7-646160833d9a.png">


## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
