### PR TITLE
Fix app handler registration

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -109,11 +109,11 @@ function makeDialogAPI(channel) {
 }
 
 function makeAppAPI(channel) {
+  const app = createApp(channel)
+
   return {
-    app: createApp(channel),
+    app,
     // TODO: remove `platformAlpha` namespace.
-    platformAlpha: {
-      app: createApp(channel)
-    }
+    platformAlpha: { app }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-ui-extensions-sdk",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful-ui-extensions-sdk",
   "description": "SDK to develop custom UI Extension for the Contentful Web App",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "author": "Contentful GmbH",
   "license": "MIT",
   "main": "dist/cf-extension-api.js",


### PR DESCRIPTION
# Purpose of PR

We called `createApp` twice which is fine until... you realize channel handlers are registered twice in this case. It still works fine... most of the time. Depending on timing of messages the SDK may end up in a weird state.

Solution: create `app` namespace once and reuse the same reference.

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
