### PR TITLE
Add entry field method overloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-ui-extensions-sdk",
-  "version": "3.10.9",
+  "version": "3.10.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful-ui-extensions-sdk",
   "description": "SDK to develop custom UI Extension for the Contentful Web App",
-  "version": "3.10.9",
+  "version": "3.10.10",
   "author": "Contentful GmbH",
   "license": "MIT",
   "main": "dist/cf-extension-api.js",

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -89,11 +89,6 @@ declare module 'contentful-ui-extensions-sdk' {
 
   /* Entry API */
 
-  type onValueChangedType = (callback: (value: any) => void) => Function
-  type onValueChangeWithLocaleType = (locale: string, callback: (value: any) => void) => Function
-  type onIsDisabledChangedType = (callback: Function) => Function
-  type onIsDisabledChangedWithLocaleType = (locale: string, callback: Function) => Function
-
   interface EntryFieldAPI {
     /** The ID of a field is defined in an entry's content type. */
     id: string
@@ -115,11 +110,15 @@ declare module 'contentful-ui-extensions-sdk' {
     /** Removes the value for the field and locale. */
     removeValue: (locale?: string) => Promise<void>
     /** Calls the callback every time the value of the field is changed by an external event or when setValue() is called. */
-    onValueChanged: onValueChangeWithLocaleType
-    onValueChanged: onValueChangedType
+    onValueChanged: {
+      (callback: (value: any) => void): Function
+      (locale: string, callback: (value: any) => void): Function
+    }
     /** Calls the callback when the disabled status of the field changes. */
-    onIsDisabledChanged: onIsDisabledChangedWithLocaleType
-    onIsDisabledChanged: onIsDisabledChangedType
+    onIsDisabledChanged: {
+      (callback: Function): Function
+      (locale: string, callback: Function): Function
+    }
   }
 
   interface EntryAPI {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -111,13 +111,13 @@ declare module 'contentful-ui-extensions-sdk' {
     removeValue: (locale?: string) => Promise<void>
     /** Calls the callback every time the value of the field is changed by an external event or when setValue() is called. */
     onValueChanged: {
-      (callback: (value: any) => void): Function
-      (locale: string, callback: (value: any) => void): Function
+      (callback: (value: any) => void): () => void
+      (locale: string, callback: (value: any) => void): () => void
     }
     /** Calls the callback when the disabled status of the field changes. */
     onIsDisabledChanged: {
-      (callback: Function): Function
-      (locale: string, callback: Function): Function
+      (callback: (isDisabled: boolean) => void): () => void
+      (locale: string, callback: (isDisabled: boolean) => void): () => void
     }
   }
 


### PR DESCRIPTION
# Purpose of PR

Overload entry field `onValueChanged` and `onIsDisabledChanged` methods.

<!--
Please describe the purpose of your pull request here. 

What do you want to add? Why do you want to add it? 

What are the use cases?
-->

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
