### PR TITLE
Extend entity selector options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-ui-extensions-sdk",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful-ui-extensions-sdk",
   "description": "SDK to develop custom UI Extension for the Contentful Web App",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "author": "Contentful GmbH",
   "license": "MIT",
   "main": "dist/cf-extension-api.js",

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -393,12 +393,16 @@ declare module 'contentful-ui-extensions-sdk' {
       max?: number
     }) => Promise<T[] | null>
     /** Opens a dialog for selecting a single asset. */
-    selectSingleAsset: <T = Object>(options?: { locale?: string }) => Promise<T | null>
+    selectSingleAsset: <T = Object>(options?: {
+      locale?: string
+      mimetypeGroups?: string[]
+    }) => Promise<T | null>
     /** Opens a dialog for selecting multiple assets. */
     selectMultipleAssets: <T = Object>(options?: {
       locale?: string
       min?: number
       max?: number
+      mimetypeGroups?: string[]
     }) => Promise<T[] | null>
   }
 


### PR DESCRIPTION
# Purpose of PR

Update type definitions to reflect all possible options for `selectSingleAsset` and `selectMultipleAssets`.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
