### PR TITLE
remove guard in onConfigure* handlers

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -51,9 +51,7 @@ module.exports = function createApp(channel) {
   }
 
   const setHandler = (stage, handler) => {
-    if (handlers[stage]) {
-      throw new Error('Cannot register a handler twice.')
-    } else if (!isFunction(handler)) {
+    if (!isFunction(handler)) {
       throw new Error('Handler must be a function.')
     } else {
       handlers[stage] = handler

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-ui-extensions-sdk",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful-ui-extensions-sdk",
   "description": "SDK to develop custom UI Extension for the Contentful Web App",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "author": "Contentful GmbH",
   "license": "MIT",
   "main": "dist/cf-extension-api.js",

--- a/test/unit/app.spec.js
+++ b/test/unit/app.spec.js
@@ -35,11 +35,18 @@ const describeAppHookMessageExchange = ({ description, method, stage, sendsResul
       }).to.throw(/must be a function/)
     })
 
-    it('only allows to register a handler once', () => {
-      app[method](() => {})
-      expect(() => {
-        app[method](() => {})
-      }).to.throw(/handler twice/)
+    it('will only call the last added handler', () => {
+      const first = sinon.spy()
+      const second = sinon.spy()
+
+      app[method](first)
+      app[method](second)
+
+      const [, sendMessage] = channelStub.addHandler.args[0]
+      sendMessage({ stage })
+
+      sinon.assert.notCalled(first)
+      sinon.assert.calledOnce(second)
     })
 
     it('does the exchange when handler is not defined', () => test(undefined, {}))


### PR DESCRIPTION
# Purpose of PR

Removing the guard in the `onConfigure*` handlers gives more flexibility to devs.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
