### PR TITLE
Inject custom API creator

### DIFF
--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -3,29 +3,40 @@ const { Promise } = require('es6-promise')
 const connect = require('./channel')
 
 module.exports = function createInitializer(currentWindow, apiCreator) {
-  const apiDeferred = createDeferred()
-  const channelDeferred = createDeferred()
+  const connectDeferred = createDeferred()
 
-  channelDeferred.promise.then(channel => {
+  connectDeferred.promise.then(([channel]) => {
     const { document } = currentWindow
     document.addEventListener('focus', () => channel.send('setActive', true), true)
     document.addEventListener('blur', () => channel.send('setActive', false), true)
   })
 
+  // We need to connect right away so we can record incoming
+  // messages before `init` is called.
   connect(
     currentWindow,
-    (channel, params, messageQueue) => {
-      channelDeferred.resolve(channel)
+    (...args) => connectDeferred.resolve(args)
+  )
+
+  return function init(initCb, { makeCustomApi } = {}) {
+    connectDeferred.promise.then(([channel, params, messageQueue]) => {
       const api = apiCreator(channel, params, currentWindow)
+
+      let customApi
+      if (typeof makeCustomApi === 'function') {
+        customApi = makeCustomApi(channel, params)
+      }
+
+      // Handle pending incoming messages.
+      // APIs are created before so handlers are already
+      // registered on the channel.
       messageQueue.forEach(m => {
         channel._handleMessage(m)
       })
-      apiDeferred.resolve(api)
-    }
-  )
 
-  return function init(initCb) {
-    apiDeferred.promise.then(initCb)
+      // Hand over control to the developer.
+      initCb(api, customApi)
+    })
   }
 }
 

--- a/test/unit/initialize.spec.js
+++ b/test/unit/initialize.spec.js
@@ -17,7 +17,8 @@ describe('initializeApi(currentWindow, apiCreator)', function() {
   describe('callback', function() {
     beforeEach(function() {
       this.api = {}
-      this.init = initializeApi(this.dom.window, () => this.api)
+      this.apiCreator = sinon.stub().returns(this.api)
+      this.init = initializeApi(this.dom.window, this.apiCreator)
     })
 
     it('is not invoked before connecting', function() {
@@ -46,6 +47,23 @@ describe('initializeApi(currentWindow, apiCreator)', function() {
         expect(arg).to.equal(this.api)
         done()
       })
+      sendConnect(this.dom)
+    })
+
+    it('receives the result of the custom API creator', function(done) {
+      const customApi = {}
+      const makeCustomApi = sinon.stub().returns(customApi)
+
+      this.init(
+        (_, arg) => {
+          expect(arg).to.equal(customApi)
+          const [channel, params] = this.apiCreator.args[0]
+          expect(makeCustomApi).to.be.calledWithExactly(channel, params)
+          done()
+        },
+        { makeCustomApi }
+      )
+
       sendConnect(this.dom)
     })
   })


### PR DESCRIPTION
# Purpose of PR

Allow to create custom APIs. The creator function gets raw channel and init data and should return an object of methods.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
