### PR TITLE
feat: allow creation of field locale instance from field

### DIFF
--- a/lib/field.ts
+++ b/lib/field.ts
@@ -32,11 +32,11 @@ export default class Field {
   }
 
   getValue(locale) {
-    return this.getFieldLocale(locale).getValue()
+    return this._getFieldLocale(locale).getValue()
   }
 
   setValue(value, locale) {
-    return this.getFieldLocale(locale).setValue(value)
+    return this._getFieldLocale(locale).setValue(value)
   }
 
   removeValue(locale) {
@@ -48,7 +48,7 @@ export default class Field {
       handler = locale
       locale = undefined
     }
-    return this.getFieldLocale(locale).onValueChanged(handler)
+    return this._getFieldLocale(locale).onValueChanged(handler)
   }
 
   onIsDisabledChanged(locale, handler) {
@@ -57,12 +57,20 @@ export default class Field {
       locale = undefined
     }
 
-    return this.getFieldLocale(locale).onIsDisabledChanged(handler)
+    return this._getFieldLocale(locale).onIsDisabledChanged(handler)
   }
 
-  getFieldLocale(locale = this._defaultLocale) {
+  private _getFieldLocale(locale = this._defaultLocale) {
     assertHasLocale(this, locale)
     return this._fieldLocales[locale]
+  }
+
+  getLocaleSpecificField(locale) {
+    if (!locale) {
+      throw new Error(`getLocaleSpecificField must be passed a locale`)
+    }
+
+    return this._getFieldLocale(locale)
   }
 }
 

--- a/lib/field.ts
+++ b/lib/field.ts
@@ -32,11 +32,11 @@ export default class Field {
   }
 
   getValue(locale) {
-    return this._getFieldLocale(locale).getValue()
+    return this.getFieldLocale(locale).getValue()
   }
 
   setValue(value, locale) {
-    return this._getFieldLocale(locale).setValue(value)
+    return this.getFieldLocale(locale).setValue(value)
   }
 
   removeValue(locale) {
@@ -48,7 +48,7 @@ export default class Field {
       handler = locale
       locale = undefined
     }
-    return this._getFieldLocale(locale).onValueChanged(handler)
+    return this.getFieldLocale(locale).onValueChanged(handler)
   }
 
   onIsDisabledChanged(locale, handler) {
@@ -57,10 +57,10 @@ export default class Field {
       locale = undefined
     }
 
-    return this._getFieldLocale(locale).onIsDisabledChanged(handler)
+    return this.getFieldLocale(locale).onIsDisabledChanged(handler)
   }
 
-  private _getFieldLocale(locale) {
+  getFieldLocale(locale) {
     locale = locale || this._defaultLocale
     assertHasLocale(this, locale)
     return this._fieldLocales[locale]

--- a/lib/field.ts
+++ b/lib/field.ts
@@ -68,7 +68,7 @@ export default class Field {
 
   getLocaleSpecificField(locale) {
     if (!locale) {
-      throw new Error(`getLocaleSpecificField must be passed a locale`)
+      throw new Error('getLocaleSpecificField must be passed a locale')
     }
 
     return this._getFieldLocale(locale)

--- a/lib/field.ts
+++ b/lib/field.ts
@@ -60,7 +60,8 @@ export default class Field {
     return this._getFieldLocale(locale).onIsDisabledChanged(handler)
   }
 
-  private _getFieldLocale(locale = this._defaultLocale) {
+  private _getFieldLocale(locale) {
+    locale = locale || this._defaultLocale
     assertHasLocale(this, locale)
     return this._fieldLocales[locale]
   }

--- a/lib/field.ts
+++ b/lib/field.ts
@@ -66,9 +66,9 @@ export default class Field {
     return this._fieldLocales[locale]
   }
 
-  getLocaleSpecificField(locale) {
+  getForLocale(locale) {
     if (!locale) {
-      throw new Error('getLocaleSpecificField must be passed a locale')
+      throw new Error('getForLocale must be passed a locale')
     }
 
     return this._getFieldLocale(locale)

--- a/lib/field.ts
+++ b/lib/field.ts
@@ -60,8 +60,7 @@ export default class Field {
     return this.getFieldLocale(locale).onIsDisabledChanged(handler)
   }
 
-  getFieldLocale(locale) {
-    locale = locale || this._defaultLocale
+  getFieldLocale(locale = this._defaultLocale) {
     assertHasLocale(this, locale)
     return this._fieldLocales[locale]
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -120,6 +120,8 @@ export interface EntryFieldAPI {
     (callback: (isDisabled: boolean) => void): () => void
     (locale: string, callback: (isDisabled: boolean) => void): () => void
   }
+
+  getFieldLocale: (locale: string) => FieldAPI
 }
 
 export interface EntryAPI {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -121,6 +121,8 @@ export interface EntryFieldAPI {
     (locale: string, callback: (isDisabled: boolean) => void): () => void
   }
 
+  /** Get an instance of FieldAPI for this field, specific to the locale that is
+   * passed as an argument */
   getForLocale: (locale: string) => FieldAPI
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -121,7 +121,7 @@ export interface EntryFieldAPI {
     (locale: string, callback: (isDisabled: boolean) => void): () => void
   }
 
-  getLocaleSpecificField: (locale: string) => FieldAPI
+  getForLocale: (locale: string) => FieldAPI
 }
 
 export interface EntryAPI {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -121,7 +121,7 @@ export interface EntryFieldAPI {
     (locale: string, callback: (isDisabled: boolean) => void): () => void
   }
 
-  getFieldLocale: (locale: string) => FieldAPI
+  getLocaleSpecificField: (locale: string) => FieldAPI
 }
 
 export interface EntryAPI {

--- a/test/unit/field.spec.ts
+++ b/test/unit/field.spec.ts
@@ -1,6 +1,7 @@
 import { sinon, expect, describeAttachHandlerMember } from '../helpers'
 
 import Field from '../../lib/field'
+import FieldLocale from '../../lib/field-locale'
 
 describe(`Field`, () => {
   let channelStub
@@ -247,6 +248,21 @@ describe(`Field`, () => {
       it(`updates the value when receiving a change message`, function() {
         this.receiveValueChanged(field.id, defaultLocale, 'CHANGED')
         expect(field.getValue()).to.equal('CHANGED')
+      })
+    })
+
+    describe('getFieldLocale called with a locale', () => {
+      let result
+      beforeEach(() => {
+        result = field.getFieldLocale('en-US')
+      })
+
+      it('returns a fieldLocale instance', () => {
+        expect(result).to.be.an.instanceOf(FieldLocale)
+      })
+
+      it('contains the expect value for that locale', () => {
+        expect(result.getValue()).to.equal(info.values['en-US'])
       })
     })
   })

--- a/test/unit/field.spec.ts
+++ b/test/unit/field.spec.ts
@@ -251,10 +251,10 @@ describe(`Field`, () => {
       })
     })
 
-    describe('getLocaleSpecificField called with a locale', () => {
+    describe('getForLocale called with a locale', () => {
       let result
       beforeEach(() => {
-        result = field.getLocaleSpecificField('en-US')
+        result = field.getForLocale('en-US')
       })
 
       it('returns a fieldLocale instance', () => {

--- a/test/unit/field.spec.ts
+++ b/test/unit/field.spec.ts
@@ -251,10 +251,10 @@ describe(`Field`, () => {
       })
     })
 
-    describe('getFieldLocale called with a locale', () => {
+    describe('getLocaleSpecificField called with a locale', () => {
       let result
       beforeEach(() => {
-        result = field.getFieldLocale('en-US')
+        result = field.getLocaleSpecificField('en-US')
       })
 
       it('returns a fieldLocale instance', () => {


### PR DESCRIPTION
# Purpose of PR
In order to use our Field Editor components with the Entry editor SDK, we need to have some way to get a `fieldLocale` object from an entry. I think the easiest way to do this is to make it possible to extract a fieldLocale from a field. 

Basically this PR just makes an existing private method public.

One thing that I'm not sure of, is how it's possible to determine from the Entry API which locale is currently being edited. 

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
