### PR TITLE
fix(ui-integration-suite): increase cypress default timeout to 15s [EXT-1913]

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -25,5 +25,5 @@
     "*osano.com"
   ],
   "chromeWebSecurity": false,
-  "defaultCommandTimeout": 7000
+  "defaultCommandTimeout": 15000
 }


### PR DESCRIPTION
# Purpose of PR

Increase the `defaultTimeout` to 15s to avoid inconsistent ui integration tests

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
