### PR TITLE
feat: listen to new schemaerrorschangedforfieldlocale events

### DIFF
--- a/lib/field-locale.ts
+++ b/lib/field-locale.ts
@@ -44,8 +44,10 @@ export default class FieldLocale implements FieldAPI {
       }
     })
 
-    channel.addHandler('schemaErrorsChanged', errors => {
-      this._schemaErrorsChangedSignal.dispatch(errors)
+    channel.addHandler('schemaErrorsChangedForFieldLocale', (id, locale, errors) => {
+      if (id === this.id && locale === this.locale) {
+        this._schemaErrorsChangedSignal.dispatch(errors)
+      }
     })
   }
 

--- a/test/unit/field-locale.spec.ts
+++ b/test/unit/field-locale.spec.ts
@@ -112,7 +112,12 @@ describe('FieldLocale', () => {
   })
 
   describe('.onSchemaErrorsChanged(handler)', () => {
-    testChannelSignal('onSchemaErrorsChanged', 'schemaErrorsChanged')
+    testChannelSignal(
+      'onSchemaErrorsChanged',
+      'schemaErrorsChangedForFieldLocale',
+      [info.id, info.locale, [{ message: 'oh no' }]],
+      [[{ message: 'oh no' }]]
+    )
   })
 
   describe('.onValueChanged(handler)', () => {


### PR DESCRIPTION
# Purpose of PR
This change makes it possible to handle errors inside of entry extensions, by following a similar approach that was used to make `isDisabled` available in entry extensions.

This shouldn't be merged until we're confident that adding these events to user interface hasn't caused any issues.
## PR Checklist
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
