### PR TITLE
fix: pass through required properties to fieldLocale from field

### DIFF
--- a/lib/field.ts
+++ b/lib/field.ts
@@ -21,6 +21,10 @@ export default class Field {
     this._fieldLocales = info.locales.reduce((acc, locale) => {
       const fieldLocale = new FieldLocale(channel, {
         id: info.id,
+        type: info.type,
+        required: info.required,
+        validations: info.validations,
+        items: info.items,
         locale,
         value: info.values[locale]
       })


### PR DESCRIPTION
We actually need these info types now that we are able to get the fieldLocale instance
from the field. 😨 

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
