### PR TITLE
making PublicActionStatus useable in code

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -295,7 +295,7 @@ export interface WindowAPI {
 
 /* Scheduled Actions */
 
-export enum PublicActionStatus {
+export const enum PublicActionStatus {
   Scheduled = 'scheduled',
   Succeeded = 'succeeded',
   Failed = 'failed',


### PR DESCRIPTION
This change makes the `PublicActionStatus` useable in code. See how typescript differentiates between these two approaches in this example:

https://www.typescriptlang.org/play/index.html#code/KYOwrgtgBAglDeUDOYDGrhKVAvFARCupkvlAL4CwAUDagPYhIAuUAHrrAHREZY11GLKKEhQAQgmRo+2PIRkkyVWtQZNWAT07ieirEA