### PR TITLE
Updating the scheduled date typings to be strings

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -308,9 +308,11 @@ export type ScheduledAction = {
   sys: {
     id: string
     type: 'ScheduledAction'
-    createdAt: Date
+    /** ISO 8601 string */
+    createdAt: string
     createdBy: Link
-    canceledAt?: Date
+    /** ISO 8601 string */
+    canceledAt?: string
     canceledBy?: Link
     space: {
       sys: {
@@ -336,7 +338,8 @@ export type ScheduledAction = {
     }
   }
   scheduledFor: {
-    datetime: Date
+    /** ISO 8601 string */
+    datetime: string
   }
   action: ScheduledActionActionType
 }


### PR DESCRIPTION
This updates the typings for scheduled `ScheduledAction` to use a string for its date value.
I've included JSDocs to show up in most editors to indicate the format.

<img width="292" alt="Screen Shot 2020-05-05 at 12 54 54" src="https://user-images.githubusercontent.com/4086109/81059022-ef286d80-8ecf-11ea-89e2-29cc13dc6bbe.png">
