### PR TITLE
chore(test): run integration tests every 2 hours

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ workflows:
       - integration
     triggers:
       - schedule:
-          cron: '0 */2 * * *'
+          cron: '0 0,2,4,6,8,10,12,14,16,18,20,22 * * *'
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ workflows:
       - integration
     triggers:
       - schedule:
-          cron: '2 22 * * *'
+          cron: '0 */2 * * *'
           filters:
             branches:
               only:


### PR DESCRIPTION
# Purpose of PR

To get faster feedback in case of flakiness of the integration tests, we run the integration test now every 2 hours.

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
