### PR TITLE
fix(test): split tests in specific and reusable test suites

### DIFF
--- a/test/cypress/integration/dialog-extension-reusable.spec.ts
+++ b/test/cypress/integration/dialog-extension-reusable.spec.ts
@@ -1,0 +1,55 @@
+import { entry } from '../utils/paths'
+
+import { openEntryTest } from './reusable/open-entry-test'
+import { openAssetTest } from './reusable/open-asset-test'
+import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
+import { openDialogExtension } from './reusable/open-dialog-extension-test'
+import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
+import {
+  openSuccessNotificationTest,
+  openErrorNotificationTest
+} from './reusable/open-notifications-test'
+
+const post = {
+  id: '3MEimIRakHkmgmqvp1oIsM',
+  title: 'My post with a custom sidebar'
+}
+
+const iframeSidebarSelector = '[data-test-id="entry-editor-sidebar"] iframe'
+const iframeDialogSelector = '[data-test-id="cf-ui-modal"] iframe'
+const sidebarExtension = 'cf-ui-sidebar-extension'
+const dialogExtension = 'my-dialog-extension'
+
+context('Dialog extension', () => {
+  beforeEach(() => {
+    cy.setAuthTokenToLocalStorage()
+    cy.visit(entry(post.id))
+    cy.findByTestId('workbench-title').should($title => {
+      expect($title).to.exist
+    })
+
+    cy.waitForIframeWithTestId(sidebarExtension)
+
+    cy.findByTestId('entry-editor-sidebar').within(() => {
+      cy.get('iframe')
+        .should('have.length', 1)
+        .captureIFrameAs('sidebarExtension')
+    })
+
+    openDialogExtension(iframeSidebarSelector)
+
+    cy.findByTestId('cf-ui-modal').within(() => {
+      cy.waitForIframeWithTestId(dialogExtension)
+      cy.get('iframe').captureIFrameAs('extension')
+    })
+  })
+
+  /* Reusable Test */
+
+  openEntryTest(iframeDialogSelector)
+  openAssetTest(iframeDialogSelector)
+  openSdkUserDataTest(iframeDialogSelector)
+  openSdkLocalesDataTest(iframeDialogSelector)
+  openSuccessNotificationTest(iframeDialogSelector)
+  openErrorNotificationTest(iframeDialogSelector)
+})

--- a/test/cypress/integration/dialog-extension.spec.ts
+++ b/test/cypress/integration/dialog-extension.spec.ts
@@ -1,15 +1,7 @@
 import { entry } from '../utils/paths'
 
 import * as openPageExtensionTest from './reusable/open-page-extension-test'
-import { openEntryTest } from './reusable/open-entry-test'
-import { openAssetTest } from './reusable/open-asset-test'
-import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openDialogExtension } from './reusable/open-dialog-extension-test'
-import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
-import {
-  openSuccessNotificationTest,
-  openErrorNotificationTest
-} from './reusable/open-notifications-test'
 import { verifyLocation } from '../utils/verify-location'
 import {
   verifySdkInstallationParameters,
@@ -92,13 +84,4 @@ context('Dialog extension', () => {
       verifySdkInvocationParameters(iframeDialogSelector)
     })
   })
-
-  /* Reusable */
-
-  openEntryTest(iframeDialogSelector)
-  openAssetTest(iframeDialogSelector)
-  openSdkUserDataTest(iframeDialogSelector)
-  openSdkLocalesDataTest(iframeDialogSelector)
-  openSuccessNotificationTest(iframeDialogSelector)
-  openErrorNotificationTest(iframeDialogSelector)
 })

--- a/test/cypress/integration/entry-editor-extension-reusable.spec.ts
+++ b/test/cypress/integration/entry-editor-extension-reusable.spec.ts
@@ -1,0 +1,71 @@
+import { entry } from '../utils/paths'
+
+import { openPageExtensionTest } from './reusable/open-page-extension-test'
+import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
+import { openEntrySlideInTest, openEntryTest } from './reusable/open-entry-test'
+import { openAssetTest, openAssetSlideInTest } from './reusable/open-asset-test'
+import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
+import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
+import { checkSdkEntryDataTest } from './reusable/check-sdk-entry-data-test'
+import { checkSdkSpaceMethods } from './reusable/check-sdk-space-methods-test'
+import { checkSdkNavigationSlideInCallbackTest } from './reusable/check-sdk-navigation-slide-in-callback-test'
+import {
+  openSuccessNotificationTest,
+  openErrorNotificationTest
+} from './reusable/open-notifications-test'
+
+const post = {
+  id: '5mwUiJB2kThfAG9ZnRNuNQ',
+  title: 'My post with a custom entry editor',
+  body: 'body value'
+}
+
+const iframeSelector = '[data-test-id="cf-ui-workbench-content"] iframe'
+const entryExtensionSelector = 'cf-ui-card'
+
+context('Entry editor extension', () => {
+  beforeEach(() => {
+    cy.setAuthTokenToLocalStorage()
+    cy.visit(entry(post.id))
+    cy.findByTestId('workbench-title').should($title => {
+      expect($title).to.exist
+    })
+
+    cy.waitForIframeWithTestId(entryExtensionSelector)
+    cy.get('[data-test-id="cf-ui-workbench-content"]').within(() => {
+      cy.get('iframe').captureIFrameAs('extension')
+    })
+  })
+
+  it('verify that entry editor extension is rendered and onIsDisabledChanged handler is called', () => {
+    cy.get('@extension').within(() => {
+      cy.findByTestId('title-field')
+        .should('exist')
+        .and('have.value', post.title)
+        .and('not.have.attr', 'disabled')
+    })
+
+    cy.get('@extension').within(() => {
+      cy.findByTestId('body-field')
+        .should('exist')
+        .and('have.value', post.body)
+        .and('not.have.attr', 'disabled')
+    })
+  })
+
+  /* Reusable tests */
+
+  openPageExtensionTest(iframeSelector)
+  openDialogExtensionTest(iframeSelector)
+  openEntryTest(iframeSelector)
+  openEntrySlideInTest(iframeSelector, post.id)
+  openAssetTest(iframeSelector)
+  openAssetSlideInTest(iframeSelector, post.id)
+  openSdkUserDataTest(iframeSelector)
+  openSdkLocalesDataTest(iframeSelector)
+  checkSdkEntryDataTest(iframeSelector)
+  checkSdkSpaceMethods(iframeSelector)
+  openSuccessNotificationTest(iframeSelector)
+  openErrorNotificationTest(iframeSelector)
+  checkSdkNavigationSlideInCallbackTest(iframeSelector)
+})

--- a/test/cypress/integration/entry-editor-extension.spec.ts
+++ b/test/cypress/integration/entry-editor-extension.spec.ts
@@ -1,18 +1,4 @@
 import { entry } from '../utils/paths'
-
-import { openPageExtensionTest } from './reusable/open-page-extension-test'
-import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
-import { openEntrySlideInTest, openEntryTest } from './reusable/open-entry-test'
-import { openAssetTest, openAssetSlideInTest } from './reusable/open-asset-test'
-import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
-import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
-import { checkSdkEntryDataTest } from './reusable/check-sdk-entry-data-test'
-import { checkSdkSpaceMethods } from './reusable/check-sdk-space-methods-test'
-import { checkSdkNavigationSlideInCallbackTest } from './reusable/check-sdk-navigation-slide-in-callback-test'
-import {
-  openSuccessNotificationTest,
-  openErrorNotificationTest
-} from './reusable/open-notifications-test'
 import { verifyLocation } from '../utils/verify-location'
 import {
   verifySdkInstallationParameters,
@@ -91,20 +77,4 @@ context('Entry editor extension', () => {
       verifySdkInstanceParameters(iframeSelector)
     })
   })
-
-  /* Reusable tests */
-
-  openPageExtensionTest(iframeSelector)
-  openDialogExtensionTest(iframeSelector)
-  openEntryTest(iframeSelector)
-  openEntrySlideInTest(iframeSelector, post.id)
-  openAssetTest(iframeSelector)
-  openAssetSlideInTest(iframeSelector, post.id)
-  openSdkUserDataTest(iframeSelector)
-  openSdkLocalesDataTest(iframeSelector)
-  checkSdkEntryDataTest(iframeSelector)
-  checkSdkSpaceMethods(iframeSelector)
-  openSuccessNotificationTest(iframeSelector)
-  openErrorNotificationTest(iframeSelector)
-  checkSdkNavigationSlideInCallbackTest(iframeSelector)
 })

--- a/test/cypress/integration/field-extension-reusable.spec.ts
+++ b/test/cypress/integration/field-extension-reusable.spec.ts
@@ -1,0 +1,60 @@
+import { entry } from '../utils/paths'
+
+import { openPageExtensionTest } from './reusable/open-page-extension-test'
+import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
+import { openEntryTest, openEntrySlideInTest } from './reusable/open-entry-test'
+import { openAssetTest, openAssetSlideInTest } from './reusable/open-asset-test'
+import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
+import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
+import { checkSdkEntryDataTest } from './reusable/check-sdk-entry-data-test'
+import { checkSdkSpaceMethods } from './reusable/check-sdk-space-methods-test'
+import { checkSdkNavigationSlideInCallbackTest } from './reusable/check-sdk-navigation-slide-in-callback-test'
+import {
+  openSuccessNotificationTest,
+  openErrorNotificationTest
+} from './reusable/open-notifications-test'
+
+const post = {
+  id: '1MDrvtuLDk0PcxS5nCkugC',
+  title: 'My first post'
+}
+
+const iframeSelector = '[data-field-api-name="title"] iframe'
+const fieldUiTestId = 'cf-ui-text-input'
+
+context('Field extension', () => {
+  beforeEach(() => {
+    cy.setAuthTokenToLocalStorage()
+    cy.visit(entry(post.id))
+    cy.findByTestId('workbench-title').should($title => {
+      expect($title).to.exist
+    })
+
+    cy.waitForIframeWithTestId(fieldUiTestId)
+    cy.get(iframeSelector).captureIFrameAs('extension')
+  })
+
+  it('verifies field extension is rendered and onIsDisabledChanged handler is called', () => {
+    cy.get('@extension').within(() => {
+      cy.findByTestId('cf-ui-text-input')
+        .should('exist')
+        .and('not.have.attr', 'disabled')
+    })
+  })
+
+  /* Reusable tests */
+
+  openPageExtensionTest(iframeSelector)
+  openDialogExtensionTest(iframeSelector)
+  openEntryTest(iframeSelector)
+  openEntrySlideInTest(iframeSelector, post.id)
+  openAssetTest(iframeSelector)
+  openAssetSlideInTest(iframeSelector, post.id)
+  openSdkUserDataTest(iframeSelector)
+  openSdkLocalesDataTest(iframeSelector)
+  checkSdkEntryDataTest(iframeSelector)
+  checkSdkSpaceMethods(iframeSelector)
+  openSuccessNotificationTest(iframeSelector)
+  openErrorNotificationTest(iframeSelector)
+  checkSdkNavigationSlideInCallbackTest(iframeSelector)
+})

--- a/test/cypress/integration/field-extension.spec.ts
+++ b/test/cypress/integration/field-extension.spec.ts
@@ -1,21 +1,5 @@
 import { entry } from '../utils/paths'
-
-import {
-  openPageExtensionTest,
-  openPageExtensionWithSubRoute
-} from './reusable/open-page-extension-test'
-import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
-import { openEntryTest, openEntrySlideInTest } from './reusable/open-entry-test'
-import { openAssetTest, openAssetSlideInTest } from './reusable/open-asset-test'
-import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
-import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
-import { checkSdkEntryDataTest } from './reusable/check-sdk-entry-data-test'
-import { checkSdkSpaceMethods } from './reusable/check-sdk-space-methods-test'
-import { checkSdkNavigationSlideInCallbackTest } from './reusable/check-sdk-navigation-slide-in-callback-test'
-import {
-  openSuccessNotificationTest,
-  openErrorNotificationTest
-} from './reusable/open-notifications-test'
+import { openPageExtensionWithSubRoute } from './reusable/open-page-extension-test'
 import { verifyLocation } from '../utils/verify-location'
 import {
   verifySdkInstallationParameters,
@@ -96,20 +80,4 @@ context('Field extension', () => {
       expect(sdk.parameters.invocation).to.deep.equal({ path: location.pathname })
     })
   })
-
-  /* Reusable tests */
-
-  openPageExtensionTest(iframeSelector)
-  openDialogExtensionTest(iframeSelector)
-  openEntryTest(iframeSelector)
-  openEntrySlideInTest(iframeSelector, post.id)
-  openAssetTest(iframeSelector)
-  openAssetSlideInTest(iframeSelector, post.id)
-  openSdkUserDataTest(iframeSelector)
-  openSdkLocalesDataTest(iframeSelector)
-  checkSdkEntryDataTest(iframeSelector)
-  checkSdkSpaceMethods(iframeSelector)
-  openSuccessNotificationTest(iframeSelector)
-  openErrorNotificationTest(iframeSelector)
-  checkSdkNavigationSlideInCallbackTest(iframeSelector)
 })

--- a/test/cypress/integration/page-extension-reusable.spec.ts
+++ b/test/cypress/integration/page-extension-reusable.spec.ts
@@ -1,0 +1,36 @@
+import { pageExtension } from '../utils/paths'
+
+import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
+import { openEntryTest } from './reusable/open-entry-test'
+import { openAssetTest } from './reusable/open-asset-test'
+import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
+import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
+import {
+  openSuccessNotificationTest,
+  openErrorNotificationTest
+} from './reusable/open-notifications-test'
+
+const iframeSelector = '[data-test-id="page-extension"] iframe'
+const pageExtensionId = 'my-page-extension'
+
+context('Page extension', () => {
+  beforeEach(() => {
+    cy.setAuthTokenToLocalStorage()
+    cy.visit(pageExtension('test-extension'))
+
+    cy.findByTestId('page-extension').within(() => {
+      cy.waitForIframeWithTestId(pageExtensionId)
+      cy.get('iframe').captureIFrameAs('extension')
+    })
+  })
+
+  /* Reusable tests */
+
+  openDialogExtensionTest(iframeSelector)
+  openEntryTest(iframeSelector)
+  openAssetTest(iframeSelector)
+  openSdkUserDataTest(iframeSelector)
+  openSdkLocalesDataTest(iframeSelector)
+  openSuccessNotificationTest(iframeSelector)
+  openErrorNotificationTest(iframeSelector)
+})

--- a/test/cypress/integration/page-extension.spec.ts
+++ b/test/cypress/integration/page-extension.spec.ts
@@ -1,14 +1,4 @@
 import { pageExtension } from '../utils/paths'
-
-import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
-import { openEntryTest } from './reusable/open-entry-test'
-import { openAssetTest } from './reusable/open-asset-test'
-import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
-import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
-import {
-  openSuccessNotificationTest,
-  openErrorNotificationTest
-} from './reusable/open-notifications-test'
 import { verifyLocation } from '../utils/verify-location'
 import { verifySdkInstallationParameters } from '../utils/verify-parameters'
 import idsData from './fixtures/ids-data.json'
@@ -68,14 +58,4 @@ context('Page extension', () => {
       expect(sdk.parameters.invocation).to.deep.equal({ path: '' })
     })
   })
-
-  /* Reusable tests */
-
-  openDialogExtensionTest(iframeSelector)
-  openEntryTest(iframeSelector)
-  openAssetTest(iframeSelector)
-  openSdkUserDataTest(iframeSelector)
-  openSdkLocalesDataTest(iframeSelector)
-  openSuccessNotificationTest(iframeSelector)
-  openErrorNotificationTest(iframeSelector)
 })

--- a/test/cypress/integration/sidebar-extension-reusable.spec.ts
+++ b/test/cypress/integration/sidebar-extension-reusable.spec.ts
@@ -1,0 +1,52 @@
+import { entry } from '../utils/paths'
+import { openPageExtensionTest } from './reusable/open-page-extension-test'
+import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
+import { openEntrySlideInTest, openEntryTest } from './reusable/open-entry-test'
+import { openAssetSlideInTest, openAssetTest } from './reusable/open-asset-test'
+import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
+import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
+import { checkSdkEntryDataTest } from './reusable/check-sdk-entry-data-test'
+import {
+  openSuccessNotificationTest,
+  openErrorNotificationTest
+} from './reusable/open-notifications-test'
+
+const post = {
+  id: '3MEimIRakHkmgmqvp1oIsM',
+  title: 'My post with a custom sidebar'
+}
+
+const iframeSelector = '[data-test-id="entry-editor-sidebar"] iframe'
+const sidebarExtension = 'cf-ui-sidebar-extension'
+
+context('Sidebar extension', () => {
+  beforeEach(() => {
+    cy.setAuthTokenToLocalStorage()
+
+    cy.visit(entry(post.id))
+    cy.findByTestId('workbench-title').should($title => {
+      expect($title).to.exist
+    })
+
+    cy.waitForIframeWithTestId(sidebarExtension)
+
+    cy.findByTestId('entry-editor-sidebar').within(() => {
+      cy.get('iframe')
+        .should('have.length', 1)
+        .captureIFrameAs('extension')
+    })
+  })
+
+  /* Reusable tests */
+  openPageExtensionTest(iframeSelector)
+  openDialogExtensionTest(iframeSelector)
+  openEntryTest(iframeSelector)
+  openEntrySlideInTest(iframeSelector, post.id)
+  openAssetTest(iframeSelector)
+  openAssetSlideInTest(iframeSelector, post.id)
+  openSdkUserDataTest(iframeSelector)
+  openSdkLocalesDataTest(iframeSelector)
+  checkSdkEntryDataTest(iframeSelector)
+  openSuccessNotificationTest(iframeSelector)
+  openErrorNotificationTest(iframeSelector)
+})

--- a/test/cypress/integration/sidebar-extension.spec.ts
+++ b/test/cypress/integration/sidebar-extension.spec.ts
@@ -1,16 +1,5 @@
 import { entry } from '../utils/paths'
 import * as Constants from '../../constants'
-import { openPageExtensionTest } from './reusable/open-page-extension-test'
-import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
-import { openEntrySlideInTest, openEntryTest } from './reusable/open-entry-test'
-import { openAssetSlideInTest, openAssetTest } from './reusable/open-asset-test'
-import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
-import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
-import { checkSdkEntryDataTest } from './reusable/check-sdk-entry-data-test'
-import {
-  openSuccessNotificationTest,
-  openErrorNotificationTest
-} from './reusable/open-notifications-test'
 import { verifyLocation } from '../utils/verify-location'
 import {
   verifySdkInstallationParameters,
@@ -84,16 +73,4 @@ context('Sidebar extension', () => {
   })
 
   /* Reusable tests */
-
-  openPageExtensionTest(iframeSelector)
-  openDialogExtensionTest(iframeSelector)
-  openEntryTest(iframeSelector)
-  openEntrySlideInTest(iframeSelector, post.id)
-  openAssetTest(iframeSelector)
-  openAssetSlideInTest(iframeSelector, post.id)
-  openSdkUserDataTest(iframeSelector)
-  openSdkLocalesDataTest(iframeSelector)
-  checkSdkEntryDataTest(iframeSelector)
-  openSuccessNotificationTest(iframeSelector)
-  openErrorNotificationTest(iframeSelector)
 })


### PR DESCRIPTION
# Purpose of PR

In order to improve stability for the test suite for the `user_interface` the long running test suites are splitted into specific tests and reusable tests. Cypress slows down on long running tests and make the integration tests on certain environments timeout. Splitting it into multiple tests suites avoids this problem.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
