### PR TITLE
feat: add openCurrent method to dialogs api

### DIFF
--- a/lib/dialogs.ts
+++ b/lib/dialogs.ts
@@ -8,6 +8,7 @@ export default function createDialogs(channel, ids) {
     openPrompt: openSimpleDialog.bind(null, 'prompt'),
     openExtension: openExtensionDialog,
     openCurrentApp: openCurrentAppDialog,
+    openCurrent: openCurrentDialog,
     selectSingleEntry: openEntitySelector.bind(null, 'Entry', false),
     selectSingleAsset: openEntitySelector.bind(null, 'Asset', false),
     selectMultipleEntries: openEntitySelector.bind(null, 'Entry', true),
@@ -23,7 +24,6 @@ export default function createDialogs(channel, ids) {
 
     // Use provided ID, default to the current extension.
     options.id = options.id || ids.extension
-
     if (options.id) {
       return channel.call('openDialog', 'extension', options)
     } else {
@@ -31,12 +31,19 @@ export default function createDialogs(channel, ids) {
     }
   }
 
+  function openCurrentDialog(options?) {
+    if (ids.app) {
+      return openCurrentAppDialog(options)
+    } else {
+      options.id = ids.extension
+      return openExtensionDialog(options)
+    }
+  }
+
   function openCurrentAppDialog(options?) {
     options = prepareOptions(options)
-
     // Force ID of the current app.
     options.id = ids.app
-
     if (options.id) {
       return channel.call('openDialog', 'app', options)
     } else {

--- a/lib/dialogs.ts
+++ b/lib/dialogs.ts
@@ -23,7 +23,7 @@ export default function createDialogs(channel, ids) {
     options = prepareOptions(options)
 
     // Use provided ID, default to the current extension.
-    options.id = options.id || ids.extension
+    options = { ...options, id: options.id || ids.extension }
     if (options.id) {
       return channel.call('openDialog', 'extension', options)
     } else {
@@ -35,15 +35,17 @@ export default function createDialogs(channel, ids) {
     if (ids.app) {
       return openCurrentAppDialog(options)
     } else {
-      options.id = ids.extension
-      return openExtensionDialog(options)
+      return openExtensionDialog({
+        ...options,
+        id: ids.extension
+      })
     }
   }
 
   function openCurrentAppDialog(options?) {
     options = prepareOptions(options)
     // Force ID of the current app.
-    options.id = ids.app
+    options = { ...options, id: ids.app }
     if (options.id) {
       return channel.call('openDialog', 'app', options)
     } else {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -391,8 +391,8 @@ export interface DialogsAPI {
   openExtension: (options: OpenCustomWidgetOptions) => Promise<any>
   /** Opens the current app in a dialog */
   openCurrentApp: (options?: Omit<OpenCustomWidgetOptions, 'id'>) => Promise<any>
-  /** Opens an extension or an app in a dialog */
-  openDialog: (
+  /** Opens the current extension or app in a dialog */
+  openCurrent: (
     options?: Omit<OpenCustomWidgetOptions, 'id'> | OpenCustomWidgetOptions
   ) => Promise<any>
   /** Opens a dialog for selecting a single entry. */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -391,6 +391,10 @@ export interface DialogsAPI {
   openExtension: (options: OpenCustomWidgetOptions) => Promise<any>
   /** Opens the current app in a dialog */
   openCurrentApp: (options?: Omit<OpenCustomWidgetOptions, 'id'>) => Promise<any>
+  /** Opens an extension or an app in a dialog */
+  openDialog: (
+    options?: Omit<OpenCustomWidgetOptions, 'id'> | OpenCustomWidgetOptions
+  ) => Promise<any>
   /** Opens a dialog for selecting a single entry. */
   selectSingleEntry: <T = Object>(options?: {
     locale?: string


### PR DESCRIPTION
# Purpose of PR
In order to avoid confusion with extensions and apps this PR introduces a new method for the dialogs API to open the `current` extension or app in a dialog. 
## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required

## PR Follow ups
- update field editors to make use of this new method
- add documentation for the `openCurrent` method

