### PR TITLE
chore: bump cron job for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ workflows:
       - integration
     triggers:
       - schedule:
-          cron: '0 0,2,4,6,8,10,12,14,16,18,20,22 * * *'
+          cron: '0 * * * *'
           filters:
             branches:
               only:


### PR DESCRIPTION
# Purpose of PR

In order to get more confidence with extension sdk we bump the cron job to run every hour.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
