### PR TITLE
Metadata typings

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -132,12 +132,16 @@ export interface EntryFieldAPI {
 }
 
 export interface EntryAPI {
-  /** Returns metadata for an entry. */
+  /** Returns sys for an entry. */
   getSys: () => EntrySys
-  /** Calls the callback with metadata every time that metadata changes. */
+  /** Calls the callback with sys every time that sys changes. */
   onSysChanged: (callback: (sys: EntrySys) => void) => Function
   /** Allows to control the values of all other fields in the current entry. */
   fields: { [key: string]: EntryFieldAPI }
+  /** Optional metadata on an entry */
+  metadata?: {
+    tags?: Link[]
+  }
 }
 
 /* Content Type API */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-ui-extensions-sdk",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful-ui-extensions-sdk",
   "description": "SDK to develop custom UI Extension for the Contentful Web App",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "author": "Contentful GmbH",
   "license": "MIT",
   "main": "dist/cf-extension-api.js",


### PR DESCRIPTION
Adding types for the optional metadata object found on `sdk.entry.metadata`.