### PR TITLE
feat: add getCurrentState method to uie-sdk app api

### DIFF
--- a/lib/app.ts
+++ b/lib/app.ts
@@ -82,6 +82,9 @@ export default function createApp(channel) {
     getParameters() {
       return channel.call('callAppMethod', 'getParameters')
     },
+    getCurrentState() {
+      return channel.call('callAppMethod', 'getCurrentState')
+    },
     onConfigure(handler) {
       setHandler(HOOK_STAGE_PRE_INSTALL, handler)
     },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -196,6 +196,7 @@ export interface EditorInterface {
     widgetNamespace: string
     settings?: Object
   }
+  editors?: Array<EditorInterface['editor']>
 }
 
 /* Space API */
@@ -634,11 +635,23 @@ export type PageExtensionSDK = BaseExtensionSDK & {
   ids: Omit<IdsAPI, 'field' | 'entry' | 'contentType'>
 }
 
+interface AppStateEditorInterfaceItem {
+  controls?: Array<{ fieldId: string }>
+  sidebar?: { position: number }
+  editor?: boolean
+}
+
+export interface AppState {
+  EditorInterface: Record<ContentType['sys']['id'], AppStateEditorInterfaceItem>
+}
+
 export interface AppConfigAPI {
   /** Tells the web app that the app is loaded */
   setReady: () => Promise<void>
   /** Returns true if an App is installed **/
   isInstalled: () => Promise<boolean>
+  /** Returns current state of an App **/
+  getCurrentState: () => Promise<AppState>
   /** Returns parameters of an App, null otherwise **/
   getParameters: <T = Object>() => Promise<null | T>
   /** Registers a handler to be called to produce parameters for an App **/

--- a/test/unit/api.spec.ts
+++ b/test/unit/api.spec.ts
@@ -116,6 +116,7 @@ describe('createAPI()', () => {
       'setReady',
       'isInstalled',
       'getParameters',
+      'getCurrentState',
       'onConfigure',
       'onConfigurationCompleted'
     ])


### PR DESCRIPTION
## Context

This change is meant to make the App SDK able to fetch the state to be manipulated and provided to the `targetState` portion of the return value of the `onConfig` hook.

### Example flow
1. Get the current state by using `getCurrentState` method
2. Modify the state to introduce/remove/change where the app is to be rendered
3. Return the modified state as `targetState` in the `onConfiguration` callback

[Reference](https://www.contentful.com/developers/docs/extensibility/ui-extensions/sdk-reference/#register-an-app-configuration-hook)

### To Do
- [x] tests;
- [x] documentation;
- [x] typings; 