### PR TITLE
console.error when error happens in app handler.

### DIFF
--- a/lib/app.ts
+++ b/lib/app.ts
@@ -5,6 +5,11 @@ const isObject = o => typeof o === 'object' && o !== null && !Array.isArray(o)
 const isFunction = f => typeof f === 'function'
 const isPromise = p => isObject(p) && isFunction(p.then)
 
+const handleHandlerError = err => {
+  console.error(err)
+  return false
+}
+
 const runHandler = (handler, defaultResult, handlerArg?) => {
   // Handler was not registered. Registering a handler is not
   // required. We resolve with the default provided in this case.
@@ -18,6 +23,7 @@ const runHandler = (handler, defaultResult, handlerArg?) => {
   try {
     maybeResultPromise = typeof handlerArg === 'undefined' ? handler() : handler(handlerArg)
   } catch (err) {
+    console.error(err)
     return Promise.resolve(false)
   }
 
@@ -29,19 +35,18 @@ const runHandler = (handler, defaultResult, handlerArg?) => {
   }
 
   return resultPromise
-    .then(
-      result => {
-        if (result instanceof Error || result === false) {
-          return false
-        } else if (!isObject(result)) {
-          return defaultResult
-        } else {
-          return result
-        }
-      },
-      () => false
-    )
-    .catch(() => false)
+    .then(result => {
+      if (result instanceof Error) {
+        return Promise.reject(result)
+      } else if (result === false) {
+        return false
+      } else if (!isObject(result)) {
+        return defaultResult
+      } else {
+        return result
+      }
+    }, handleHandlerError)
+    .catch(handleHandlerError)
 }
 
 export default function createApp(channel) {

--- a/lib/app.ts
+++ b/lib/app.ts
@@ -7,7 +7,7 @@ const isPromise = p => isObject(p) && isFunction(p.then)
 
 const handleHandlerError = err => {
   console.error(err)
-  return false
+  return Promise.resolve(false)
 }
 
 const runHandler = (handler, defaultResult, handlerArg?) => {
@@ -23,8 +23,7 @@ const runHandler = (handler, defaultResult, handlerArg?) => {
   try {
     maybeResultPromise = typeof handlerArg === 'undefined' ? handler() : handler(handlerArg)
   } catch (err) {
-    console.error(err)
-    return Promise.resolve(false)
+    return handleHandlerError(err)
   }
 
   // If handler is synchronous, we wrap the result with a promise


### PR DESCRIPTION
# Purpose of PR
The app handlers such as `onConfig` swallow errors and `return false`. I've added `console.error` to keep the functionality the same while exposing errors that happen when these handlers are run for a better debugger experience.

When an error does occur, the handlers `return false` like mentioned about but the installation or save doesn't proceed. This is why I've opted to simply add `console.error` instead of trying to completely change the behavior of these handlers.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
