### PR TITLE
chore: fix space.waitUntilAssetProcessed typing

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -258,7 +258,7 @@ export interface SpaceAPI {
     query?: InputArgs
   ) => Promise<CollectionResponse<T>>
   createUpload: (base64data: string) => void
-  waitUntilAssetProcessed: (assetId: string, locale: string) => void
+  waitUntilAssetProcessed: (assetId: string, locale: string) => Promise<void>
 
   /** Returns all users who belong to the space. */
   getUsers: <T = Object>() => Promise<CollectionResponse<T>>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-ui-extensions-sdk",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful-ui-extensions-sdk",
   "description": "SDK to develop custom UI Extension for the Contentful Web App",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "author": "Contentful GmbH",
   "license": "MIT",
   "main": "dist/cf-extension-api.js",


### PR DESCRIPTION
# Purpose of PR

The `space.waitUntilAssetProcessed` was wrong as it is async in the implementation but sync in the typing.


## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
