### PR TITLE
fix: remove entry and contenttype key from baseextensionsdk

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -8,6 +8,7 @@ import createEditor from './editor'
 import createNavigator from './navigator'
 import createApp from './app'
 import locations from './locations'
+import { BaseExtensionSDK } from './types'
 
 const DEFAULT_API_PRODUCERS = [
   makeSharedAPI,
@@ -35,7 +36,7 @@ export default function createAPI(channel, data, currentWindow) {
   }, {})
 }
 
-function makeSharedAPI(channel, data) {
+function makeSharedAPI(channel, data): BaseExtensionSDK {
   const { user, parameters, locales, ids, initialContentTypes } = data
   const currentLocation = data.location || locations.LOCATION_ENTRY_FIELD
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -555,6 +555,10 @@ export interface SharedEditorSDK {
     ) => Function
     onShowDisabledFieldsChanged: (callback: (value: boolean) => any) => Function
   }
+  /** Allows to read and update the value of any field of the current entry and to get the entry's metadata */
+  entry: EntryAPI
+  /** Information about the content type of the entry. */
+  contentType: ContentType
 }
 
 export type CrudAction = 'create' | 'read' | 'update' | 'delete'
@@ -575,10 +579,6 @@ export interface AccessAPI {
 }
 
 export interface BaseExtensionSDK {
-  /** Allows to read and update the value of any field of the current entry and to get the entry's metadata */
-  entry: EntryAPI
-  /** Information about the content type of the entry. */
-  contentType: ContentType
   /** Exposes methods that allow the extension to read and manipulate a wide range of objects in the space. */
   space: SpaceAPI
   /** Information about the current user and roles */
@@ -597,6 +597,8 @@ export interface BaseExtensionSDK {
   location: LocationAPI
   /** Exposes methods for checking user's access level */
   access: AccessAPI
+  /** Exposes relevant ids, keys may be ommited based on location */
+  ids: IdsAPI
 }
 
 export type EditorExtensionSDK = BaseExtensionSDK &

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-ui-extensions-sdk",
-  "version": "3.22.0",
+  "version": "3.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful-ui-extensions-sdk",
   "description": "SDK to develop custom UI Extension for the Contentful Web App",
-  "version": "3.22.0",
+  "version": "3.23.0",
   "author": "Contentful GmbH",
   "license": "MIT",
   "main": "dist/cf-extension-api.js",


### PR DESCRIPTION
I noticed that the type for `AppExtensionSDK` doesn't match the underlying implementation, as the type incorrectly includes an `entry` and `contentType` key. This error also applied to some of the other SDK types.

This PR just fixes that type error. 