### PR TITLE
fix: make api configuration functions types match implementation

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -657,9 +657,9 @@ export interface AppConfigAPI {
   /** Returns parameters of an App, null otherwise */
   getParameters: <T = Object>() => Promise<null | T>
   /** Registers a handler to be called to produce parameters for an App */
-  onConfigure: (handler: Function) => Promise<void>
+  onConfigure: (handler: Function) => void
   /** Registers a handler to be called once configuration was finished */
-  onConfigurationCompleted: (handler: Function) => Promise<void>
+  onConfigurationCompleted: (handler: Function) => void
 }
 
 export type AppExtensionSDK = Omit<BaseExtensionSDK, 'ids'> & {


### PR DESCRIPTION
# Purpose of PR

Another issue I discovered whilst trying to implement the AppSdk, these types didn't actually match the implementation, as onConfigure and onConfigurationComplete don't return anything!