### PR TITLE
fix: make entity optional on navigator response

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -509,7 +509,7 @@ export interface NavigatorSlideInfo {
 
 export interface NavigatorOpenResponse<T> {
   navigated: boolean
-  entity: T
+  entity?: T
   slide?: NavigatorSlideInfo
 }
 


### PR DESCRIPTION
# Purpose of PR

As mentioned in #321, if an entry is deleted during a `navigator.openEntry` call with the `waitForClose` property, the promise is not resolved.
We should not resolve with an outdated entry, but also can not resolve with an nonexistent entry. For this reason we need to change the promise return type to allow for a missing entry in case it has been deleted during user interaction.

## PR Checklist

- [x] No update to tests are required, typing change only
- [x] Tests are passing
- [x] Typescript typings are updated
