### PR TITLE
chore: add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,13 @@
+# https://dependabot.com/docs/config-file/#dependabot-config-files
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "in_range"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -11,3 +11,13 @@ update_configs:
       - match:
           dependency_type: "production"
           update_type: "in_range"
+  - package_manager: "javascript"
+    directory: "/ui-extensions-sdk/test/extensions/test-extension"
+    update_schedule: "daily"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "in_range"


### PR DESCRIPTION
We are currently not updating our dependencies - neither automatically nor manually.
At the moment there are updates for 36 of our 50 dependencies. Also there are 10 security updates open.

This PR adds a dependabot config to automatically bump and merge all dev dependencies and in range dependencies.