### PR TITLE
feat: log error if it appears app is running outside of iframe

### DIFF
--- a/lib/initialize.ts
+++ b/lib/initialize.ts
@@ -22,8 +22,21 @@ export default function createInitializer(
 
   return function init(
     initCb: (sdk: KnownSDK, customSdk: any) => any,
-    { makeCustomApi }: { makeCustomApi?: Function } = {}
+    {
+      makeCustomApi,
+      supressIframeWarning
+    }: { makeCustomApi?: Function; supressIframeWarning?: boolean } = {
+      supressIframeWarning: false
+    }
   ) {
+    if (!supressIframeWarning && currentWindow.self === currentWindow.top) {
+      console.error(`Cannot use ui-extension-sdk outside of Contenful:
+
+In order for the ui-extension-sdk to function correctly, your app needs to be run in an iframe in the Contentful Web App.
+
+Learn more about local development with the ui-extension-sdk here:
+  https://www.contentful.com/developers/docs/extensibility/ui-extensions/faq/#how-can-i-use-the-ui-extension-sdk-locally`)
+    }
     connectDeferred.promise.then(
       ([channel, params, messageQueue]: [Channel, ConnectMessage, unknown[]]) => {
         const api = apiCreator(channel, params, currentWindow)

--- a/module-declaration.d.ts
+++ b/module-declaration.d.ts
@@ -1,6 +1,9 @@
 // will be appended to generated typings.d.ts
 declare module 'contentful-ui-extensions-sdk' {
-  export const init: <T extends KnownSDK = KnownSDK>(initCallback: (sdk: T) => any) => void
+  export const init: <T extends KnownSDK = KnownSDK>(
+    initCallback: (sdk: T) => any,
+    options?: { supressIframeWarning?: boolean }
+  ) => void
 
   export const locations: Locations
 }


### PR DESCRIPTION
This PR tries to make it more obvious what's going wrong when ui-extension-sdk is used outside of Contentful. It shows an error when init is called outside of an iframe

![image](https://user-images.githubusercontent.com/20307225/97564249-905a3180-19e4-11eb-936e-d4fe6d6d034d.png)

The link doesn't currently point to a specific question in the FAQ - I intend to update the FAQ with that information.