### PR TITLE
chore: Multiple fixes to semantic release

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,6 +4,9 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "daily"
+    commit_message:
+      prefix: "chore"
+      include_scope: false
     automerged_updates:
       - match:
           dependency_type: "development"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,28 @@
-# [3.24.0](https://github.com/contentful/ui-extensions-sdk/compare/v3.23.4...v3.24.0) (2021-01-04)
-
-
-### Bug Fixes
-
-* only expose signRequest in apps ([169ff70](https://github.com/contentful/ui-extensions-sdk/commit/169ff70a2d74498406560f51a6eec00af88f41a9))
-* request signing endpoint can be undefined ([2eb0d76](https://github.com/contentful/ui-extensions-sdk/commit/2eb0d76ee7fd79bf906069e7ecf842b16f1cd300))
-
+# [3.26.1](https://github.com/contentful/ui-extensions-sdk/compare/v3.26.0...v3.26.1) (2021-11-24)
 
 ### Features
 
-* [EXT-2360] add test for onvaluechanged ([#431](https://github.com/contentful/ui-extensions-sdk/issues/431)) ([229d930](https://github.com/contentful/ui-extensions-sdk/commit/229d93072242deab7c38db5c675ccdd1c058e1f7))
-* add request signing endpoint in space API ([1c7dc5f](https://github.com/contentful/ui-extensions-sdk/commit/1c7dc5f37750e98eafaf3a64f2c7659d9710b285))
-* log error if it appears app is running outside of iframe ([#390](https://github.com/contentful/ui-extensions-sdk/issues/390)) ([c46be9d](https://github.com/contentful/ui-extensions-sdk/commit/c46be9db35f0a6b72cb50851009b836146235b31))
+- Add env alias to IdsApi type
+
+# [3.25.1](https://github.com/contentful/ui-extensions-sdk/compare/v3.25.0...v3.26.0) (2021-11-24)
+
+### Features
+
+- Bump dependencies
+
+# [3.25.0](https://github.com/contentful/ui-extensions-sdk/compare/v3.24.0...v3.25.0) (2020-11-09)
+
+### Bug Fixes
+
+- only expose signRequest in apps ([169ff70](https://github.com/contentful/ui-extensions-sdk/commit/169ff70a2d74498406560f51a6eec00af88f41a9))
+- request signing endpoint can be undefined ([2eb0d76](https://github.com/contentful/ui-extensions-sdk/commit/2eb0d76ee7fd79bf906069e7ecf842b16f1cd300))
+
+### Features
+
+- [EXT-2360] add test for onvaluechanged ([#431](https://github.com/contentful/ui-extensions-sdk/issues/431)) ([229d930](https://github.com/contentful/ui-extensions-sdk/commit/229d93072242deab7c38db5c675ccdd1c058e1f7))
+
+# [3.24.0](https://github.com/contentful/ui-extensions-sdk/compare/v3.23.4...v3.24.0) (2020-11-02)
+
+### Features
+
+- log error if it appears app is running outside of iframe ([#390](https://github.com/contentful/ui-extensions-sdk/issues/390)) ([c46be9d](https://github.com/contentful/ui-extensions-sdk/commit/c46be9db35f0a6b72cb50851009b836146235b31))

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
       [
         "@semantic-release/git",
         {
+          "message": "chore: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
           "assets": [
             "CHANGELOG.md",
             "package.json",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,12 @@
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
       [
+        "@semantic-release/npm",
+        {
+          "npmPublish": false
+        }
+      ],
+      [
         "@semantic-release/exec",
         {
           "verifyConditionsCmd": "node ./scripts/verify.js",


### PR DESCRIPTION
* Remove scope from semantic release commit messages and dependabot commit messages. For consistency as most of our commit messages don't have a scope
* Because of missing git tags, the changelog was not created correctly. I manually fixed it. Also, I'll add the missing git tags.
* We didn't add the @semantic-release/npm package and therefore the version was not bumped. This is now fixed. The publish still happens using our custom script.