### PR TITLE
fix: make signRequest non optional

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -60,7 +60,7 @@ function makeSharedAPI(channel: Channel, data: ConnectMessage): BaseExtensionSDK
       optional: locales.optional,
       direction: locales.direction,
     },
-    space: createSpace(channel, initialContentTypes, ids),
+    space: createSpace(channel, initialContentTypes),
     dialogs: createDialogs(channel, ids),
     // Typecast because promises returned by navigator methods aren't typed
     navigator: createNavigator(channel, ids) as NavigatorAPI,

--- a/lib/space.ts
+++ b/lib/space.ts
@@ -1,6 +1,5 @@
 import { ContentType, SpaceAPI } from './types'
 import { Channel } from './channel'
-import { IdsAPI } from '../typings'
 
 const spaceMethods: Array<keyof SpaceAPI> = [
   'getContentType',
@@ -52,15 +51,11 @@ const spaceMethods: Array<keyof SpaceAPI> = [
 
 export default function createSpace(
   channel: Channel,
-  initialContentTypes: ContentType[],
-  ids: IdsAPI
+  initialContentTypes: ContentType[]
 ): SpaceAPI {
   const space = {} as SpaceAPI
 
   spaceMethods.forEach((methodName) => {
-    if (methodName === 'signRequest' && ids && !ids.app) {
-      return
-    }
     space[methodName] = function (...args: any[]) {
       return channel.call('callSpaceMethod', methodName, args)
     } as any

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -337,7 +337,7 @@ export interface SpaceAPI {
   /* Returns a list of scheduled actions for the currenst space & environment */
   getAllScheduledActions: () => Promise<ScheduledAction[]>
 
-  signRequest?: (request: CanonicalRequest) => Promise<Record<string, string>>
+  signRequest: (request: CanonicalRequest) => Promise<Record<string, string>>
 }
 
 /* Locales API */


### PR DESCRIPTION
# Purpose of PR
Make the signRequest function non optional, as it is checked at runtime - and we want to provide a consistent API surface

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
