### PR TITLE
feat: add canEditAppConfig method

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -72,6 +72,7 @@ function makeSharedAPI(channel: Channel, data: ConnectMessage): BaseExtensionSDK
     access: {
       can: (action: string, entity: any) =>
         channel.call('checkAccess', action, entity) as Promise<boolean>,
+      canEditAppConfig: () => channel.call('checkAppConfigAccess'),
     },
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -596,6 +596,8 @@ export interface AccessAPI {
     entity: 'ContentType' | ContentType | 'Asset' | 'Entry' | T
   ): Promise<boolean>
   can<T = Object>(action: ArchiveableAction, entity: 'Asset' | 'Entry' | T): Promise<boolean>
+  /** Whether the current user can edit app config */
+  canEditAppConfig: () => boolean
 }
 
 export interface BaseExtensionSDK {

--- a/test/unit/api.spec.ts
+++ b/test/unit/api.spec.ts
@@ -66,7 +66,7 @@ function test(expected: string[], location: string | undefined, expectedLocation
     'direction',
   ])
   expect(api.notifier).to.have.all.keys(['success', 'error'])
-  expect(api.access).to.have.all.keys(['can'])
+  expect(api.access).to.have.all.keys(['can', 'canEditAppConfig'])
 
   // Test location methods (currently only `is`).
   expect(Object.keys(api.location)).to.deep.equal(['is'])


### PR DESCRIPTION
# Purpose of PR
Add `canEditAppConfig` method

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
