### PR TITLE
feat: export module as contentfulApp

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,6 +21,7 @@ module.exports = [
   makeConfigForOutput({
     file: pkg.main,
     format: 'umd',
-    name: 'contentfulExtension'
+    name: 'contentfulExtension',
+    footer: 'window.contentfulApp = window.contentfulExtension;'
   })
 ]


### PR DESCRIPTION
If you don't use a bundler you can simply import the library in your html file and use it with 

```javascript
window.contentfulExtension.init(...)
```

We want to make it possible to _also_ use `window.contentfulApp`. Unfortunately, it is not possible to export multiple variables using rollup. A workaround is using the `footer` property:
> Code to insert at end of bundle (outside wrapper)

This seems to be the recommended approach: https://github.com/rollup/rollup/issues/553#issuecomment-202166713

I tested it with the following code:
```html
    <script src="dist/cf-extension-api.js"></script>
    <script>
        console.log(window.contentfulApp);
        console.log(window.contentfulExtension);
    </script>
```