### PR TITLE
docs: rename UIE SDK to App SDK in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# Contentful UI Extensions SDK
+# App SDK
 
-The UI Extensions SDK is a JavaScript library that allows developers to create custom Contentful Apps
+The App SDK (formerly known as UI Extensions SDK) is a JavaScript library that allows developers to create custom Contentful Apps
 for the Contentful Web App. Every Contentful App has to include the library in its source.
 
 ## Resources
 
+- [App SDK reference](https://www.contentful.com/developers/docs/extensibility/ui-extensions/sdk/)
+- [App Framework general documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/)
 - [UI Extensions general documentation](https://www.contentful.com/developers/docs/extensibility/ui-extensions/)
-- [UI Extensions SDK reference](https://www.contentful.com/developers/docs/extensibility/ui-extensions/sdk-reference/)
 - [Contentful Apps Management HTTP API reference](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-definitions)
 - [Contentful Apps FAQ](https://www.contentful.com/developers/docs/extensibility/app-framework/faq/)
 - [Contentful Apps repository](https://github.com/contentful/apps)
@@ -14,8 +15,8 @@ for the Contentful Web App. Every Contentful App has to include the library in i
 - [Contentful Changelog](https://www.contentful.com/developers/changelog/)
 - [Forma 36: The Contentful Design System](https://f36.contentful.com/)
 - [Forma 36 guide for Contentful Apps](https://www.contentful.com/developers/docs/extensibility/ui-extensions/component-library/)
-- [`contentful-ui-extensions-sdk` at npm](https://www.npmjs.com/package/contentful-ui-extensions-sdk)
 - [`create-contentful-app`](https://github.com/contentful/create-contentful-app) - CLI tool for developing apps without the hassle of managing build configurations
+- [`contentful-ui-extensions-sdk` at npm](https://www.npmjs.com/package/contentful-ui-extensions-sdk)
 
 ## Getting help
 
@@ -32,7 +33,7 @@ A new package version is automatically published to npm using [semantic-release]
 
 To manually publish the package, run `node ./scripts/publish.js`.
 
-We always publish two packages with identical data:
+This repository is published as two packages with identical data. We recommend using `@contentful/app-sdk`.
 
-- `contentful-ui-extensions-sdk`
 - `@contentful/app-sdk`
+- `contentful-ui-extensions-sdk`


### PR DESCRIPTION
UIE SDK -> App SDK

We keep the old name but prioritize the new one.