### PR TITLE
chore: revert bump cypress from 7.2.0 to 7.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2675,9 +2675,9 @@
       }
     },
     "cypress": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-7.3.0.tgz",
-      "integrity": "sha512-aseRCH1tRVCrM6oEfja6fR/bo5l6e4SkHRRSATh27UeN4f/ANC8U7tGIulmrISJVy9xuOkOdbYKbUb2MNM+nrw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-7.2.0.tgz",
+      "integrity": "sha512-lHHGay+YsffDn4M0bkkwezylBVHUpwwhtqte4LNPrFRCHy77X38+1PUe3neFb3glVTM+rbILtTN6FhO2djcOuQ==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -12271,9 +12271,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "chai-as-promised": "7.1.1",
     "contentful-management": "7.18.2",
     "cross-spawn": "7.0.3",
-    "cypress": "7.3.0",
+    "cypress": "7.2.0",
     "cypress-multi-reporters": "1.5.0",
     "dotenv": "9.0.2",
     "eslint": "7.26.0",


### PR DESCRIPTION
Reverts contentful/ui-extensions-sdk#702