### PR TITLE
feat: test that SDK respects alias

### DIFF
--- a/test/cypress/integration/entry-editor-aliased.spec.ts
+++ b/test/cypress/integration/entry-editor-aliased.spec.ts
@@ -25,7 +25,7 @@ context(`Aliased Entry editor extension (${role})`, () => {
   })
 
   it('verifies that onValueChanged is called with the initial value and updates', () => {
-    const environmentId = Cypress.env('activeEnvironmentId')
+    const aliasId = Cypress.env('activeAliasId')
     const spaceId = Cypress.env('activeSpaceId')
     cy.intercept({
       method: 'GET',
@@ -34,7 +34,7 @@ context(`Aliased Entry editor extension (${role})`, () => {
 
     cy.getSdk(iframeSelector).then(async (sdk) => {
       sdk.space.getContentTypes()
-      cy.wait('@contentTypesRequest').its('request.url').should('include', environmentId)
+      cy.wait('@contentTypesRequest').its('request.url').should('include', aliasId)
     })
   })
 })

--- a/test/cypress/integration/entry-editor-aliased.spec.ts
+++ b/test/cypress/integration/entry-editor-aliased.spec.ts
@@ -24,17 +24,23 @@ context(`Aliased Entry editor extension (${role})`, () => {
     })
   })
 
-  it('verifies that onValueChanged is called with the initial value and updates', () => {
+  it('verifies that API calls use the active Alias', () => {
     const aliasId = Cypress.env('activeAliasId')
     const spaceId = Cypress.env('activeSpaceId')
     cy.intercept({
       method: 'GET',
       url: `/spaces/${spaceId}/environments/*/content_types`,
     }).as('contentTypesRequest')
+    cy.intercept({
+      method: 'GET',
+      url: `spaces/${spaceId}/environments/*/entries/${post.id}/tasks`,
+    }).as('tasksRequest')
 
     cy.getSdk(iframeSelector).then(async (sdk) => {
       sdk.space.getContentTypes()
       cy.wait('@contentTypesRequest').its('request.url').should('include', aliasId)
+      sdk.entry.getTasks()
+      cy.wait('@tasksRequest').its('request.url').should('include', aliasId)
     })
   })
 })

--- a/test/cypress/integration/entry-editor-aliased.spec.ts
+++ b/test/cypress/integration/entry-editor-aliased.spec.ts
@@ -25,7 +25,7 @@ context(`Aliased Entry editor extension (${role})`, () => {
   })
 
   it('verifies that onValueChanged is called with the initial value and updates', () => {
-    const aliasId = Cypress.env('activeAliasId')
+    const environmentId = Cypress.env('activeEnvironmentId')
     const spaceId = Cypress.env('activeSpaceId')
     cy.intercept({
       method: 'GET',
@@ -34,7 +34,7 @@ context(`Aliased Entry editor extension (${role})`, () => {
 
     cy.getSdk(iframeSelector).then(async (sdk) => {
       sdk.space.getContentTypes()
-      cy.wait('@contentTypesRequest').its('request.url').should('include', aliasId)
+      cy.wait('@contentTypesRequest').its('request.url').should('include', environmentId)
     })
   })
 })

--- a/test/cypress/integration/entry-editor-aliased.spec.ts
+++ b/test/cypress/integration/entry-editor-aliased.spec.ts
@@ -1,0 +1,40 @@
+import { entryAliased } from '../utils/paths'
+import { role } from '../utils/role'
+
+const post = {
+  id: Cypress.env('entries').onValueChanged,
+  title: 'My post to test onValueChanged',
+  body: 'body value',
+}
+
+const iframeSelector = '[data-test-id="cf-ui-workbench-content"] iframe'
+const entryExtensionSelector = 'cf-ui-card'
+
+context(`Aliased Entry editor extension (${role})`, () => {
+  beforeEach(() => {
+    cy.setupBrowserStorage()
+    cy.visit(entryAliased(post.id))
+    cy.findByTestId('workbench-title').should(($title) => {
+      expect($title).to.exist
+    })
+
+    cy.waitForIframeWithTestId(entryExtensionSelector)
+    cy.get('[data-test-id="cf-ui-workbench-content"]').within(() => {
+      cy.get('iframe').captureIFrameAs('extension')
+    })
+  })
+
+  it('verifies that onValueChanged is called with the initial value and updates', () => {
+    const aliasId = Cypress.env('activeAliasId')
+    const spaceId = Cypress.env('activeSpaceId')
+    cy.intercept({
+      method: 'GET',
+      url: `/spaces/${spaceId}/environments/*/content_types`,
+    }).as('contentTypesRequest')
+
+    cy.getSdk(iframeSelector).then(async (sdk) => {
+      sdk.space.getContentTypes()
+      cy.wait('@contentTypesRequest').its('request.url').should('include', aliasId)
+    })
+  })
+})

--- a/test/cypress/utils/paths.ts
+++ b/test/cypress/utils/paths.ts
@@ -2,9 +2,14 @@ import { role } from './role'
 
 const activeSpaceId = Cypress.env('activeSpaceId')
 const activeEnvironmentId = Cypress.env('activeEnvironmentId')
+const activeAliasId = Cypress.env('activeAliasId')
 
 export function entriesList() {
   return `/spaces/${activeSpaceId}/environments/${activeEnvironmentId}/entries`
+}
+
+export function entriesListAliased() {
+  return `/spaces/${activeSpaceId}/environments/${activeAliasId}/entries`
 }
 
 export function pageExtensionMaster(extensionId: string) {
@@ -17,6 +22,10 @@ export function pageExtension(extensionId: string) {
 
 export function entry(id: string) {
   return `${entriesList()}/${id}`
+}
+
+export function entryAliased(id: string) {
+  return `${entriesListAliased()}/${id}`
 }
 
 export function assetsList() {

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -114,6 +114,7 @@ const run = async () => {
     environmentId: tempEnvironmentId,
     role: 'admin',
     entries: entryIds,
+    aliasId: tempAliasId,
   })
   await runCypress('admin')
 
@@ -124,6 +125,7 @@ const run = async () => {
     environmentId: tempEnvironmentId,
     role: 'editor',
     entries: entryIds,
+    aliasId: tempAliasId,
   })
   await runCypress('editor', true)
 
@@ -139,6 +141,7 @@ const run = async () => {
     environmentId: 'master-test',
     role: 'editorMasterOnly',
     entries: newEntryIds,
+    aliasId: '',
   })
   await runCypress('editorMasterOnly', true)
 }

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -141,7 +141,7 @@ const run = async () => {
     environmentId: 'master-test',
     role: 'editorMasterOnly',
     entries: newEntryIds,
-    aliasId: '',
+    aliasId: tempAliasId,
   })
   await runCypress('editorMasterOnly', true)
 }

--- a/test/integration/local.ts
+++ b/test/integration/local.ts
@@ -14,6 +14,7 @@ const config = {
   spaceId: process.env.CONTENTFUL_SPACE_ID!,
   baseUrl: process.env.CONTENTFUL_APP!,
   environmentId: process.env.CONTENTFUL_LOCAL_TESTING_ENV!,
+  aliasId: process.env.CONTENTFUL_LOCAL_TESTING_ALIAS!,
   testLocalSdk: process.env.TEST_LOCAL_SDK === 'true',
 }
 
@@ -59,6 +60,7 @@ async function run() {
     managementToken: config.managementToken,
     spaceId: config.spaceId,
     environmentId: config.environmentId,
+    aliasId: config.aliasId,
     role: 'admin',
     entries: entryIds,
   })

--- a/test/integration/tasks/create-configuration-files.ts
+++ b/test/integration/tasks/create-configuration-files.ts
@@ -6,18 +6,21 @@ export async function createCypressConfiguration({
   environmentId,
   role,
   entries,
+  aliasId,
 }: {
   managementToken: string
   spaceId: string
   environmentId: string
   role: string
   entries: Record<string, string>
+  aliasId: string
 }) {
   printStepTitle(`${role}: Creating Cypress configuration based on environment variables`)
   writeJSONFile(resolvePath('cypress.env.json'), {
     managementToken,
     activeSpaceId: spaceId,
     activeEnvironmentId: environmentId,
+    activeAliasId: aliasId,
     role,
     entries,
   })

--- a/test/integration/tasks/create-new-environment.ts
+++ b/test/integration/tasks/create-new-environment.ts
@@ -23,6 +23,9 @@ export default async () => {
     'test-base'
   )) as any
 
+  const aliasId = nanoid()
+  const alias = (await space.createEnvironmentAliasWithId(aliasId, { environment })) as any
+
   let status = environment.sys.status.sys.id
 
   while (status !== 'ready') {
@@ -33,5 +36,5 @@ export default async () => {
 
   console.log(`New "${environmentId}" environment is created`)
 
-  return environmentId
+  return { environmentId, aliasId: alias.sys.id }
 }

--- a/test/integration/tasks/create-new-environment.ts
+++ b/test/integration/tasks/create-new-environment.ts
@@ -23,9 +23,6 @@ export default async () => {
     'test-base'
   )) as any
 
-  const aliasId = nanoid()
-  const alias = (await space.createEnvironmentAliasWithId(aliasId, { environment })) as any
-
   let status = environment.sys.status.sys.id
 
   while (status !== 'ready') {
@@ -35,6 +32,11 @@ export default async () => {
   }
 
   console.log(`New "${environmentId}" environment is created`)
+
+  const aliasId = nanoid()
+  const alias = (await space.createEnvironmentAliasWithId(aliasId, { environment })) as any
+
+  console.log(`New "${aliasId}" alias is created`)
 
   return { environmentId, aliasId: alias.sys.id }
 }

--- a/test/integration/tasks/delete-new-environment-alias.ts
+++ b/test/integration/tasks/delete-new-environment-alias.ts
@@ -1,0 +1,16 @@
+import { getCurrentSpace } from '../contentful-client'
+import { printStepTitle } from '../utils'
+
+export default async (aliasId: string) => {
+  printStepTitle('Remove previously created environment alias')
+
+  const space = await getCurrentSpace()
+
+  const alias = await space.getEnvironmentAlias(aliasId)
+
+  await alias.delete()
+
+  console.log(`"${aliasId}" alias is deleted`)
+
+  return true
+}


### PR DESCRIPTION
Adds a test for the entry editor location to make sure the SDK is hitting the correct endpoints in aliased environments.

If we're happy with this approach, we might want to add similar tests for each SDK/location as a follow up