### PR TITLE
test: retry visit on integration tests

### DIFF
--- a/test/cypress/integration/dialog-extension-reusable.spec.ts
+++ b/test/cypress/integration/dialog-extension-reusable.spec.ts
@@ -1,4 +1,4 @@
-import { openEntryTest, visitEntry } from './reusable/open-entry-test'
+import { openEntryTest } from './reusable/open-entry-test'
 import { openAssetTest } from './reusable/open-asset-test'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openDialogExtension } from './reusable/open-dialog-extension-test'
@@ -22,7 +22,7 @@ const dialogExtension = 'my-dialog-extension'
 context(`Dialog extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    visitEntry(post.id)
+    cy.visitEntryWithRetry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/dialog-extension-reusable.spec.ts
+++ b/test/cypress/integration/dialog-extension-reusable.spec.ts
@@ -44,9 +44,9 @@ context(`Dialog extension (${role})`, () => {
   /* Reusable Test */
 
   openEntryTest(iframeDialogSelector)
-  // openAssetTest(iframeDialogSelector)
-  // openSdkUserDataTest(iframeDialogSelector)
-  // openSdkLocalesDataTest(iframeDialogSelector)
-  // openSuccessNotificationTest(iframeDialogSelector)
-  // openErrorNotificationTest(iframeDialogSelector)
+  openAssetTest(iframeDialogSelector)
+  openSdkUserDataTest(iframeDialogSelector)
+  openSdkLocalesDataTest(iframeDialogSelector)
+  openSuccessNotificationTest(iframeDialogSelector)
+  openErrorNotificationTest(iframeDialogSelector)
 })

--- a/test/cypress/integration/dialog-extension-reusable.spec.ts
+++ b/test/cypress/integration/dialog-extension-reusable.spec.ts
@@ -1,6 +1,4 @@
-import { entry } from '../utils/paths'
-
-import { openEntryTest } from './reusable/open-entry-test'
+import { openEntryTest, visitEntry } from './reusable/open-entry-test'
 import { openAssetTest } from './reusable/open-asset-test'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openDialogExtension } from './reusable/open-dialog-extension-test'
@@ -24,7 +22,7 @@ const dialogExtension = 'my-dialog-extension'
 context(`Dialog extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    cy.visit(entry(post.id))
+    visitEntry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })
@@ -46,9 +44,9 @@ context(`Dialog extension (${role})`, () => {
   /* Reusable Test */
 
   openEntryTest(iframeDialogSelector)
-  openAssetTest(iframeDialogSelector)
-  openSdkUserDataTest(iframeDialogSelector)
-  openSdkLocalesDataTest(iframeDialogSelector)
-  openSuccessNotificationTest(iframeDialogSelector)
-  openErrorNotificationTest(iframeDialogSelector)
+  // openAssetTest(iframeDialogSelector)
+  // openSdkUserDataTest(iframeDialogSelector)
+  // openSdkLocalesDataTest(iframeDialogSelector)
+  // openSuccessNotificationTest(iframeDialogSelector)
+  // openErrorNotificationTest(iframeDialogSelector)
 })

--- a/test/cypress/integration/dialog-extension.spec.ts
+++ b/test/cypress/integration/dialog-extension.spec.ts
@@ -1,4 +1,3 @@
-import { entry } from '../utils/paths'
 import { role } from '../utils/role'
 import { verifyLocation } from '../utils/verify-location'
 import {
@@ -8,6 +7,7 @@ import {
 import idsData from './fixtures/ids-data.json'
 import { openDialogExtension } from './reusable/open-dialog-extension-test'
 import * as openPageExtensionTest from './reusable/open-page-extension-test'
+import { visitEntry } from './reusable/open-entry-test'
 
 const post = {
   id: Cypress.env('entries').sidebarExtension,
@@ -23,7 +23,7 @@ context(`Dialog extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
 
-    cy.visit(entry(post.id))
+    visitEntry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/dialog-extension.spec.ts
+++ b/test/cypress/integration/dialog-extension.spec.ts
@@ -7,7 +7,6 @@ import {
 import idsData from './fixtures/ids-data.json'
 import { openDialogExtension } from './reusable/open-dialog-extension-test'
 import * as openPageExtensionTest from './reusable/open-page-extension-test'
-import { visitEntry } from './reusable/open-entry-test'
 
 const post = {
   id: Cypress.env('entries').sidebarExtension,
@@ -23,7 +22,7 @@ context(`Dialog extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
 
-    visitEntry(post.id)
+    cy.visitEntryWithRetry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/entry-editor-extension-reusable.spec.ts
+++ b/test/cypress/integration/entry-editor-extension-reusable.spec.ts
@@ -1,8 +1,6 @@
-import { entry } from '../utils/paths'
-
 import { openPageExtensionTest } from './reusable/open-page-extension-test'
 import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
-import { openEntrySlideInTest, openEntryTest } from './reusable/open-entry-test'
+import { openEntrySlideInTest, openEntryTest, visitEntry } from './reusable/open-entry-test'
 import { openAssetTest, openAssetSlideInTest } from './reusable/open-asset-test'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
@@ -27,7 +25,7 @@ const entryExtensionSelector = 'cf-ui-card'
 context(`Entry editor extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    cy.visit(entry(post.id))
+    visitEntry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/entry-editor-extension-reusable.spec.ts
+++ b/test/cypress/integration/entry-editor-extension-reusable.spec.ts
@@ -1,6 +1,6 @@
 import { openPageExtensionTest } from './reusable/open-page-extension-test'
 import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
-import { openEntrySlideInTest, openEntryTest, visitEntry } from './reusable/open-entry-test'
+import { openEntrySlideInTest, openEntryTest } from './reusable/open-entry-test'
 import { openAssetTest, openAssetSlideInTest } from './reusable/open-asset-test'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
@@ -25,7 +25,7 @@ const entryExtensionSelector = 'cf-ui-card'
 context(`Entry editor extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    visitEntry(post.id)
+    cy.visitEntryWithRetry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/entry-editor-extension.spec.ts
+++ b/test/cypress/integration/entry-editor-extension.spec.ts
@@ -6,7 +6,6 @@ import {
 } from '../utils/verify-parameters'
 import idsData from './fixtures/ids-data.json'
 import contentTypeData from './fixtures/content-type-data/entry-editor-ext.json'
-import { visitEntry } from './reusable/open-entry-test'
 
 const post = {
   id: Cypress.env('entries').entryEditorExtension,
@@ -20,7 +19,7 @@ const entryExtensionSelector = 'cf-ui-card'
 context(`Entry editor extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    visitEntry(post.id)
+    cy.visitEntryWithRetry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/entry-editor-extension.spec.ts
+++ b/test/cypress/integration/entry-editor-extension.spec.ts
@@ -1,4 +1,3 @@
-import { entry } from '../utils/paths'
 import { role } from '../utils/role'
 import { verifyLocation } from '../utils/verify-location'
 import {
@@ -7,6 +6,7 @@ import {
 } from '../utils/verify-parameters'
 import idsData from './fixtures/ids-data.json'
 import contentTypeData from './fixtures/content-type-data/entry-editor-ext.json'
+import { visitEntry } from './reusable/open-entry-test'
 
 const post = {
   id: Cypress.env('entries').entryEditorExtension,
@@ -20,7 +20,7 @@ const entryExtensionSelector = 'cf-ui-card'
 context(`Entry editor extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    cy.visit(entry(post.id))
+    visitEntry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/entry-editor-on-value-changed.spec.ts
+++ b/test/cypress/integration/entry-editor-on-value-changed.spec.ts
@@ -1,5 +1,4 @@
 import { role } from '../utils/role'
-import { visitEntry } from './reusable/open-entry-test'
 
 const post = {
   id: Cypress.env('entries').onValueChanged,
@@ -13,7 +12,7 @@ const entryExtensionSelector = 'cf-ui-card'
 context(`Entry editor extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    visitEntry(post.id)
+    cy.visitEntryWithRetry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/entry-editor-on-value-changed.spec.ts
+++ b/test/cypress/integration/entry-editor-on-value-changed.spec.ts
@@ -1,5 +1,5 @@
-import { entry } from '../utils/paths'
 import { role } from '../utils/role'
+import { visitEntry } from './reusable/open-entry-test'
 
 const post = {
   id: Cypress.env('entries').onValueChanged,
@@ -13,7 +13,7 @@ const entryExtensionSelector = 'cf-ui-card'
 context(`Entry editor extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    cy.visit(entry(post.id))
+    visitEntry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/field-extension-reusable.spec.ts
+++ b/test/cypress/integration/field-extension-reusable.spec.ts
@@ -1,8 +1,6 @@
-import { entry } from '../utils/paths'
-
 import { openPageExtensionTest } from './reusable/open-page-extension-test'
 import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
-import { openEntryTest, openEntrySlideInTest } from './reusable/open-entry-test'
+import { openEntryTest, openEntrySlideInTest, visitEntry } from './reusable/open-entry-test'
 import { openAssetTest, openAssetSlideInTest } from './reusable/open-asset-test'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
@@ -26,7 +24,7 @@ const fieldUiTestId = 'cf-ui-text-input'
 context(`Field extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    cy.visit(entry(post.id))
+    visitEntry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/field-extension-reusable.spec.ts
+++ b/test/cypress/integration/field-extension-reusable.spec.ts
@@ -1,6 +1,6 @@
 import { openPageExtensionTest } from './reusable/open-page-extension-test'
 import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
-import { openEntryTest, openEntrySlideInTest, visitEntry } from './reusable/open-entry-test'
+import { openEntryTest, openEntrySlideInTest } from './reusable/open-entry-test'
 import { openAssetTest, openAssetSlideInTest } from './reusable/open-asset-test'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
@@ -24,7 +24,7 @@ const fieldUiTestId = 'cf-ui-text-input'
 context(`Field extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    visitEntry(post.id)
+    cy.visitEntryWithRetry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/field-extension.spec.ts
+++ b/test/cypress/integration/field-extension.spec.ts
@@ -1,4 +1,3 @@
-import { entry } from '../utils/paths'
 import { openPageExtensionWithSubRoute } from './reusable/open-page-extension-test'
 import { role } from '../utils/role'
 import { verifyLocation } from '../utils/verify-location'
@@ -9,6 +8,7 @@ import {
 import idsData from './fixtures/ids-data.json'
 import contentTypeData from './fixtures/content-type-data/field-ext.json'
 import parameters from './fixtures/parameters.json'
+import { visitEntry } from './reusable/open-entry-test'
 
 const post = {
   id: Cypress.env('entries').fieldExtension,
@@ -23,7 +23,7 @@ const pageExtensionTestId = 'my-page-extension'
 context(`Field extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    cy.visit(entry(post.id))
+    visitEntry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/field-extension.spec.ts
+++ b/test/cypress/integration/field-extension.spec.ts
@@ -8,7 +8,6 @@ import {
 import idsData from './fixtures/ids-data.json'
 import contentTypeData from './fixtures/content-type-data/field-ext.json'
 import parameters from './fixtures/parameters.json'
-import { visitEntry } from './reusable/open-entry-test'
 
 const post = {
   id: Cypress.env('entries').fieldExtension,
@@ -23,7 +22,7 @@ const pageExtensionTestId = 'my-page-extension'
 context(`Field extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    visitEntry(post.id)
+    cy.visitEntryWithRetry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/initialize.spec.ts
+++ b/test/cypress/integration/initialize.spec.ts
@@ -2,7 +2,6 @@ import { actionSelectors } from '../../constants'
 import { pageExtension } from '../utils/paths'
 import { role } from '../utils/role'
 import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
-import { visitEntry } from './reusable/open-entry-test'
 
 context(`Initialize (${role})`, () => {
   beforeEach(() => {
@@ -10,7 +9,7 @@ context(`Initialize (${role})`, () => {
   })
 
   it('Entry Editor', () => {
-    visitEntry(Cypress.env('entries').entryEditorExtension)
+    cy.visitEntryWithRetry(Cypress.env('entries').entryEditorExtension)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })
@@ -26,7 +25,7 @@ context(`Initialize (${role})`, () => {
   })
 
   it('Field Extension', () => {
-    visitEntry(Cypress.env('entries').fieldExtension)
+    cy.visitEntryWithRetry(Cypress.env('entries').fieldExtension)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })
@@ -40,7 +39,7 @@ context(`Initialize (${role})`, () => {
   })
 
   it('Sidebar Extension', () => {
-    visitEntry(Cypress.env('entries').sidebarExtension)
+    cy.visitEntryWithRetry(Cypress.env('entries').sidebarExtension)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })
@@ -71,7 +70,7 @@ context(`Initialize (${role})`, () => {
 
   describe('Dialog Extension', () => {
     beforeEach(() => {
-      visitEntry(Cypress.env('entries').sidebarExtension)
+      cy.visitEntryWithRetry(Cypress.env('entries').sidebarExtension)
       cy.findByTestId('workbench-title').should(($title) => {
         expect($title).to.exist
       })

--- a/test/cypress/integration/initialize.spec.ts
+++ b/test/cypress/integration/initialize.spec.ts
@@ -1,7 +1,8 @@
 import { actionSelectors } from '../../constants'
-import { entry, pageExtension } from '../utils/paths'
+import { pageExtension } from '../utils/paths'
 import { role } from '../utils/role'
 import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
+import { visitEntry } from './reusable/open-entry-test'
 
 context(`Initialize (${role})`, () => {
   beforeEach(() => {
@@ -9,7 +10,7 @@ context(`Initialize (${role})`, () => {
   })
 
   it('Entry Editor', () => {
-    cy.visit(entry(Cypress.env('entries').entryEditorExtension))
+    visitEntry(Cypress.env('entries').entryEditorExtension)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })
@@ -25,7 +26,7 @@ context(`Initialize (${role})`, () => {
   })
 
   it('Field Extension', () => {
-    cy.visit(entry(Cypress.env('entries').fieldExtension))
+    visitEntry(Cypress.env('entries').fieldExtension)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })
@@ -39,7 +40,7 @@ context(`Initialize (${role})`, () => {
   })
 
   it('Sidebar Extension', () => {
-    cy.visit(entry(Cypress.env('entries').sidebarExtension))
+    visitEntry(Cypress.env('entries').sidebarExtension)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })
@@ -70,7 +71,7 @@ context(`Initialize (${role})`, () => {
 
   describe('Dialog Extension', () => {
     beforeEach(() => {
-      cy.visit(entry(Cypress.env('entries').sidebarExtension))
+      visitEntry(Cypress.env('entries').sidebarExtension)
       cy.findByTestId('workbench-title').should(($title) => {
         expect($title).to.exist
       })

--- a/test/cypress/integration/reusable/open-entry-test.ts
+++ b/test/cypress/integration/reusable/open-entry-test.ts
@@ -2,16 +2,30 @@ import { entry } from '../../utils/paths'
 import * as Constants from '../../../constants'
 
 export function openEntryExtension(iframeSelector: string) {
-  cy.getSdk(iframeSelector).then(sdk => {
+  cy.getSdk(iframeSelector).then((sdk) => {
     sdk.navigator.openEntry(Constants.entries.testImageWrapper)
   })
 }
 
 export function openEntrySlideInExtension(iframeSelector: string) {
-  cy.getSdk(iframeSelector).then(sdk => {
+  cy.getSdk(iframeSelector).then((sdk) => {
     sdk.navigator.openEntry(Constants.entries.testImageWrapper, {
-      slideIn: true
+      slideIn: true,
     })
+  })
+}
+
+export function visitEntry(id: string, noRetry?: boolean) {
+  cy.visit(entry(id))
+
+  cy.findByTestId('slide-in-base').then((base) => {
+    cy.intercept('GET', /entries/).as('getEntry')
+    cy.wait('@getEntry')
+    const hasError = base.find('div').find(`[data-test-id="emptystate-error"]`).length
+    if (hasError && !noRetry) {
+      cy.wait(1000)
+      visitEntry(id, true)
+    }
   })
 }
 

--- a/test/cypress/integration/reusable/open-entry-test.ts
+++ b/test/cypress/integration/reusable/open-entry-test.ts
@@ -15,24 +15,6 @@ export function openEntrySlideInExtension(iframeSelector: string) {
   })
 }
 
-export function visitEntry(id: string, noRetry?: boolean) {
-  cy.visit(entry(id))
-
-  if (!noRetry) {
-    // retry when there was an error on loading the entry
-    cy.findByTestId('slide-in-base').then((base) => {
-      cy.intercept('GET', /entries/).as('getEntry')
-      cy.wait('@getEntry')
-      // check if there an error rendered in the ui
-      const hasError = base.find('div').find(`[data-test-id="emptystate-error"]`).length
-      if (hasError) {
-        cy.wait(1000)
-        visitEntry(id, true)
-      }
-    })
-  }
-}
-
 export function verifyEntryPageUrl(entryId: string) {
   cy.url().should('eq', Cypress.config().baseUrl + entry(entryId))
 }

--- a/test/cypress/integration/reusable/open-entry-test.ts
+++ b/test/cypress/integration/reusable/open-entry-test.ts
@@ -18,15 +18,19 @@ export function openEntrySlideInExtension(iframeSelector: string) {
 export function visitEntry(id: string, noRetry?: boolean) {
   cy.visit(entry(id))
 
-  cy.findByTestId('slide-in-base').then((base) => {
-    cy.intercept('GET', /entries/).as('getEntry')
-    cy.wait('@getEntry')
-    const hasError = base.find('div').find(`[data-test-id="emptystate-error"]`).length
-    if (hasError && !noRetry) {
-      cy.wait(1000)
-      visitEntry(id, true)
-    }
-  })
+  if (!noRetry) {
+    // retry when there was an error on loading the entry
+    cy.findByTestId('slide-in-base').then((base) => {
+      cy.intercept('GET', /entries/).as('getEntry')
+      cy.wait('@getEntry')
+      // check if there an error rendered in the ui
+      const hasError = base.find('div').find(`[data-test-id="emptystate-error"]`).length
+      if (hasError) {
+        cy.wait(1000)
+        visitEntry(id, true)
+      }
+    })
+  }
 }
 
 export function verifyEntryPageUrl(entryId: string) {

--- a/test/cypress/integration/sidebar-extension-reusable.spec.ts
+++ b/test/cypress/integration/sidebar-extension-reusable.spec.ts
@@ -1,6 +1,6 @@
 import { openPageExtensionTest } from './reusable/open-page-extension-test'
 import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
-import { openEntrySlideInTest, openEntryTest, visitEntry } from './reusable/open-entry-test'
+import { openEntrySlideInTest, openEntryTest } from './reusable/open-entry-test'
 import { openAssetSlideInTest, openAssetTest } from './reusable/open-asset-test'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
@@ -22,7 +22,7 @@ const sidebarExtension = 'cf-ui-sidebar-extension'
 context(`Sidebar extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    visitEntry(post.id)
+    cy.visitEntryWithRetry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/sidebar-extension-reusable.spec.ts
+++ b/test/cypress/integration/sidebar-extension-reusable.spec.ts
@@ -1,7 +1,6 @@
-import { entry } from '../utils/paths'
 import { openPageExtensionTest } from './reusable/open-page-extension-test'
 import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
-import { openEntrySlideInTest, openEntryTest } from './reusable/open-entry-test'
+import { openEntrySlideInTest, openEntryTest, visitEntry } from './reusable/open-entry-test'
 import { openAssetSlideInTest, openAssetTest } from './reusable/open-asset-test'
 import { openSdkUserDataTest } from './reusable/open-sdk-user-data-test'
 import { openSdkLocalesDataTest } from './reusable/open-sdk-locales-data-test'
@@ -23,8 +22,7 @@ const sidebarExtension = 'cf-ui-sidebar-extension'
 context(`Sidebar extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-
-    cy.visit(entry(post.id))
+    visitEntry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/sidebar-extension.spec.ts
+++ b/test/cypress/integration/sidebar-extension.spec.ts
@@ -1,4 +1,3 @@
-import { entry } from '../utils/paths'
 import * as Constants from '../../constants'
 import { role } from '../utils/role'
 import { verifyLocation } from '../utils/verify-location'
@@ -9,6 +8,7 @@ import {
 import idsData from './fixtures/ids-data.json'
 import contentTypeData from './fixtures/content-type-data/sidebar-ext.json'
 import { ContentType, EntryAPI, SidebarExtensionSDK } from '../../../lib/types'
+import { visitEntry } from './reusable/open-entry-test'
 
 const post = {
   id: Cypress.env('entries').sidebarExtension,
@@ -26,7 +26,7 @@ const sidebarExtension = 'cf-ui-sidebar-extension'
 context(`Sidebar extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    cy.visit(entry(post.id))
+    visitEntry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/integration/sidebar-extension.spec.ts
+++ b/test/cypress/integration/sidebar-extension.spec.ts
@@ -8,7 +8,6 @@ import {
 import idsData from './fixtures/ids-data.json'
 import contentTypeData from './fixtures/content-type-data/sidebar-ext.json'
 import { ContentType, EntryAPI, SidebarExtensionSDK } from '../../../lib/types'
-import { visitEntry } from './reusable/open-entry-test'
 
 const post = {
   id: Cypress.env('entries').sidebarExtension,
@@ -26,7 +25,7 @@ const sidebarExtension = 'cf-ui-sidebar-extension'
 context(`Sidebar extension (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
-    visitEntry(post.id)
+    cy.visitEntryWithRetry(post.id)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist
     })

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -31,7 +31,7 @@ Cypress.Commands.add('waitForIframeWithTestId', function waitForIframe(testId) {
   })
 })
 
-Cypress.Commands.add('visitEntryWithRetry', function setupBrowserStorage(id) {
+Cypress.Commands.add('visitEntryWithRetry', function visitEntryWithRetry(id) {
   let statusCode: null | number = null
   cy.visit(entry(id))
   cy.intercept('GET', /entries/, (req) => {

--- a/test/extensions/test-extension/package-lock.json
+++ b/test/extensions/test-extension/package-lock.json
@@ -3560,9 +3560,9 @@
       }
     },
     "contentful-ui-extensions-sdk": {
-      "version": "3.31.1",
-      "resolved": "https://registry.npmjs.org/contentful-ui-extensions-sdk/-/contentful-ui-extensions-sdk-3.31.1.tgz",
-      "integrity": "sha512-GT6MQVza8N5LnxT+dsMkcUWgtKeQwWBOOKD7Lw/EhVBYfHt8alnDKGpVBmk2QwMR3oABU02mQ9hmGbVwSL4Wzg=="
+      "version": "3.34.3",
+      "resolved": "https://registry.npmjs.org/contentful-ui-extensions-sdk/-/contentful-ui-extensions-sdk-3.34.3.tgz",
+      "integrity": "sha512-D7vumMFcl8+1GYmxbbOSZhscEzlQgxkrPZfo+VRYT59ZbdpajGA88TXGO2436YRdIhrzi2lR3b6T+qWPrMfr3g=="
     },
     "convert-source-map": {
       "version": "1.6.0",


### PR DESCRIPTION
# Purpose of PR

To prevent some flaky integration tests failing when reaching the rate limit on visiting the entry, this adds a command to visit entries and when failed with a 429 it waits 1second and revisits the page.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
