### PR TITLE
feat: better typings for user API

### DIFF
--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -1,4 +1,4 @@
-import { ContentType, EditorInterface, SpaceMembership } from './entities'
+import { ContentType, EditorInterface, SpaceMembership, Role } from './entities'
 import { EntryAPI } from './entry.types'
 import { SpaceAPI } from './space.types'
 import { WindowAPI } from './window.types'
@@ -10,6 +10,7 @@ import { NavigatorAPI } from './navigator.types'
 import { EntryFieldInfo, FieldInfo } from './field.types'
 
 /* User API */
+
 export interface UserAPI {
   sys: {
     id: string
@@ -19,7 +20,14 @@ export interface UserAPI {
   lastName: string
   email: string
   avatarUrl: string
-  spaceMembership: SpaceMembership
+  // Although called SpaceMembership, this type does not abide to entity
+  // with same name. Keeping it the same (with more precise types) for
+  // backwards compatibility
+  spaceMembership: {
+    sys: Pick<SpaceMembership['sys'], 'id' | 'type'>
+    admin: SpaceMembership['admin']
+    roles: Pick<Role, 'name' | 'description'>[]
+  }
 }
 
 /* Locales API */

--- a/lib/types/entities.ts
+++ b/lib/types/entities.ts
@@ -10,6 +10,7 @@ export type {
   SpaceMembershipProps as SpaceMembership,
   ContentFields as ContentTypeField,
   EntryProps as Entry,
+  RoleProps as Role,
   KeyValueMap,
 } from 'contentful-management/types'
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -43,6 +43,7 @@ export type {
   TagVisibility,
   Task,
   Entry,
+  Role,
 } from './entities'
 
 export type { EntryAPI, TaskAPI, TaskInputData } from './entry.types'


### PR DESCRIPTION
Add better types for User API, capturing the fact that `roles` is an incomplete (does not include permissions and policies) resolved `Role` list, rather than a list of links.