### PR TITLE
fix: update onConfigure type to match reference

### DIFF
--- a/lib/app.ts
+++ b/lib/app.ts
@@ -1,5 +1,6 @@
 import { Channel } from './channel'
 import { AppConfigAPI, AppState } from './types'
+import { OnConfigureHandler } from './types/app.types'
 import { KeyValueMap } from './types/entities'
 
 const HOOK_STAGE_PRE_INSTALL = 'preInstall'
@@ -104,12 +105,7 @@ export default function createApp(channel: Channel): AppConfigAPI {
     getCurrentState() {
       return channel.call('callAppMethod', 'getCurrentState') as Promise<AppState | null>
     },
-    onConfigure(
-      handler: () =>
-        | Promise<{ parameters?: KeyValueMap; targetState?: AppState }>
-        | { parameters?: KeyValueMap; targetState?: AppState }
-        | false
-    ) {
+    onConfigure(handler: OnConfigureHandler) {
       setHandler(HOOK_STAGE_PRE_INSTALL, handler)
     },
     onConfigurationCompleted(handler: (err: null | { message: string }) => void) {

--- a/lib/app.ts
+++ b/lib/app.ts
@@ -105,10 +105,10 @@ export default function createApp(channel: Channel): AppConfigAPI {
       return channel.call('callAppMethod', 'getCurrentState') as Promise<AppState | null>
     },
     onConfigure(
-      handler: () => {
-        parameters?: KeyValueMap
-        targetState?: AppState
-      }
+      handler: () =>
+        | Promise<{ parameters?: KeyValueMap; targetState?: AppState }>
+        | { parameters?: KeyValueMap; targetState?: AppState }
+        | false
     ) {
       setHandler(HOOK_STAGE_PRE_INSTALL, handler)
     },

--- a/lib/types/app.types.ts
+++ b/lib/types/app.types.ts
@@ -25,10 +25,10 @@ export interface AppConfigAPI {
   getParameters: <T extends KeyValueMap = KeyValueMap>() => Promise<null | T>
   /** Registers a handler to be called to produce parameters for an App */
   onConfigure: (
-    handler: () => {
-      parameters?: KeyValueMap
-      targetState?: AppState
-    }
+    handler: () =>
+      | Promise<{ parameters?: KeyValueMap; targetState?: AppState }>
+      | { parameters?: KeyValueMap; targetState?: AppState }
+      | false
   ) => void
   /** Registers a handler to be called once configuration was finished */
   onConfigurationCompleted: (handler: (err: null | { message: string }) => void) => void

--- a/lib/types/app.types.ts
+++ b/lib/types/app.types.ts
@@ -14,6 +14,12 @@ export interface AppState {
   EditorInterface: Record<ContentType['sys']['id'], AppStateEditorInterfaceItem>
 }
 
+export type OnConfigureHandlerReturn =
+  | Promise<{ parameters?: KeyValueMap; targetState?: AppState }>
+  | { parameters?: KeyValueMap; targetState?: AppState }
+  | false
+export type OnConfigureHandler = () => OnConfigureHandlerReturn
+
 export interface AppConfigAPI {
   /** Tells the web app that the app is loaded */
   setReady: () => Promise<void>
@@ -24,12 +30,7 @@ export interface AppConfigAPI {
   /** Returns parameters of an App, null otherwise */
   getParameters: <T extends KeyValueMap = KeyValueMap>() => Promise<null | T>
   /** Registers a handler to be called to produce parameters for an App */
-  onConfigure: (
-    handler: () =>
-      | Promise<{ parameters?: KeyValueMap; targetState?: AppState }>
-      | { parameters?: KeyValueMap; targetState?: AppState }
-      | false
-  ) => void
+  onConfigure: (handler: OnConfigureHandler) => void
   /** Registers a handler to be called once configuration was finished */
   onConfigurationCompleted: (handler: (err: null | { message: string }) => void) => void
 }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -20,7 +20,12 @@ export type {
   UserAPI,
 } from './api.types'
 
-export type { AppConfigAPI, AppState } from './app.types'
+export type {
+  AppConfigAPI,
+  AppState,
+  OnConfigureHandler,
+  OnConfigureHandlerReturn,
+} from './app.types'
 
 export type {
   DialogsAPI,


### PR DESCRIPTION
> The callback provided can be synchronous or asynchronous.

> If the callback returns false, throws or returns a promise which will be eventually rejected, the process is aborted and no changes are made. This way the app can validate its state and user inputs before continuing.