### PR TITLE
feat: add type parameter to create task input data

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -191,6 +191,7 @@ export interface TaskSys {
 
 export interface TaskInputData {
   assignedToId: string
+  assignedToType?: 'User' | 'Team'
   body: string
   status: TaskState
   dueDate?: string


### PR DESCRIPTION
# Purpose of PR

Add the assignedToType filed to the TaskInputData so the task could be assigned to other entity types but the User.
Make this field optional for backward compatibility.


## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
