### PR TITLE
test: [] check for slide in visibility instead of is clicked variable

### DIFF
--- a/test/cypress/integration/reusable/open-asset-test.ts
+++ b/test/cypress/integration/reusable/open-asset-test.ts
@@ -53,7 +53,7 @@ export function openAssetSlideInTest(iframeSelector: string, currentEntryId: str
   it('opens asset using sdk.navigator.openAsset (slideIn = true)', () => {
     openAssetSlideInExtension(iframeSelector).then((result) => {
       expect(result.navigated).to.be.equal(true)
-      cy.get('[data-test-id="slide-in-layer"]').should('not.be.visible')
+      cy.get('[data-test-id="slide-in-layer"]').should('be.visible')
       verifyAssetSlideInUrl(Constants.assets.testImage, currentEntryId)
       clickSlideInClose()
     })

--- a/test/cypress/integration/reusable/open-asset-test.ts
+++ b/test/cypress/integration/reusable/open-asset-test.ts
@@ -2,26 +2,26 @@ import { asset } from '../../utils/paths'
 import * as Constants from '../../../constants'
 
 export function openAssetExtension(iframeSelector: string) {
-  cy.getSdk(iframeSelector).then(sdk => {
+  cy.getSdk(iframeSelector).then((sdk) => {
     sdk.navigator.openAsset(Constants.assets.testImage)
   })
 }
 
 export function openAssetSlideInExtension(iframeSelector: string) {
-  return cy.getSdk(iframeSelector).then(sdk =>
+  return cy.getSdk(iframeSelector).then((sdk) =>
     sdk.navigator
       .openAsset(Constants.assets.testImage, {
-        slideIn: true
+        slideIn: true,
       })
       .then(cy.wrap)
   )
 }
 
 export function openAssetSlideInWaitExtension(iframeSelector: string, done: Function) {
-  cy.getSdk(iframeSelector).then(sdk => {
+  cy.getSdk(iframeSelector).then((sdk) => {
     sdk.navigator
       .openAsset(Constants.assets.testImage, {
-        slideIn: { waitForClose: true }
+        slideIn: { waitForClose: true },
       })
       .then(done)
   })
@@ -51,31 +51,23 @@ export function openAssetSlideInTest(iframeSelector: string, currentEntryId: str
   }
 
   it('opens asset using sdk.navigator.openAsset (slideIn = true)', () => {
-    let closeClicked = false
-
-    openAssetSlideInExtension(iframeSelector).then(result => {
+    openAssetSlideInExtension(iframeSelector).then((result) => {
       expect(result.navigated).to.be.equal(true)
-      expect(closeClicked).to.be.equal(false)
+      cy.get('[data-test-id="slide-in-layer"]').should('not.be.visible')
       verifyAssetSlideInUrl(Constants.assets.testImage, currentEntryId)
-      clickSlideInClose().then(() => {
-        closeClicked = true
-      })
+      clickSlideInClose()
     })
   })
 
-  it('opens asset using sdk.navigator.openAsset (slideIn = { waitForClose: true })', done => {
-    let closeClicked = false
-
+  it('opens asset using sdk.navigator.openAsset (slideIn = { waitForClose: true })', (done) => {
     // callback should be called only after slide in is closed
     openAssetSlideInWaitExtension(iframeSelector, (result: any) => {
       expect(result.navigated).to.be.equal(true)
-      expect(closeClicked).to.be.equal(true)
+      cy.get('[data-test-id="slide-in-layer"]').should('not.be.visible')
       done()
     })
 
     verifyAssetSlideInUrl(Constants.assets.testImage, currentEntryId)
-    clickSlideInClose().then(() => {
-      closeClicked = true
-    })
+    clickSlideInClose()
   })
 }


### PR DESCRIPTION
# Purpose of PR

Fixes some flakiness in the integration test.
Instead of setting a variable and checking if this variable is set after clicking the back button, this check is made more explicit by checking if the slide-in is really gone and no longer visible when the callback was called. 



## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
