### PR TITLE
test: fix openAsset waitForSlideIn test

### DIFF
--- a/test/cypress/integration/reusable/open-asset-test.ts
+++ b/test/cypress/integration/reusable/open-asset-test.ts
@@ -59,7 +59,7 @@ export function openAssetSlideInTest(iframeSelector: string, currentEntryId: str
     })
   })
 
-  it.only('opens asset using sdk.navigator.openAsset (slideIn = { waitForClose: true })', (done) => {
+  it('opens asset using sdk.navigator.openAsset (slideIn = { waitForClose: true })', (done) => {
     let closeClicked = false
     // callback should be called only after slide in is closed
     openAssetSlideInWaitExtension(iframeSelector, (result: any) => {

--- a/test/cypress/integration/reusable/open-asset-test.ts
+++ b/test/cypress/integration/reusable/open-asset-test.ts
@@ -59,15 +59,19 @@ export function openAssetSlideInTest(iframeSelector: string, currentEntryId: str
     })
   })
 
-  it('opens asset using sdk.navigator.openAsset (slideIn = { waitForClose: true })', (done) => {
+  it.only('opens asset using sdk.navigator.openAsset (slideIn = { waitForClose: true })', (done) => {
+    let closeClicked = false
     // callback should be called only after slide in is closed
     openAssetSlideInWaitExtension(iframeSelector, (result: any) => {
       expect(result.navigated).to.be.equal(true)
-      cy.get('[data-test-id="slide-in-layer"]').should('not.be.visible')
-      done()
+      expect(closeClicked).to.be.equal(true)
     })
 
     verifyAssetSlideInUrl(Constants.assets.testImage, currentEntryId)
-    clickSlideInClose()
+    closeClicked = true
+    clickSlideInClose().then(() => {
+      cy.get('[data-test-id="slide-in-layer"]').should('not.be.visible')
+      done()
+    })
   })
 }


### PR DESCRIPTION
# Purpose of PR

Fixes one of the slide-in asset editor tests that was failing after some internal changes in the web app. 

With those changes the callback returned from `openAsset()` with `waitForClose: true` option now triggers immediately after `clickSlideInClose()` and executed in the the same cy command context, prohibiting calling another cy command inside the promise. It caused the ["Cypress detected that you returned a promise from a command while also invoking one or more cy commands in that promise."](https://docs.cypress.io/guides/references/error-messages#Cypress-detected-that-you-returned-a-promise-from-a-command-while-also-invoking-one-or-more-cy-commands-in-that-promise) error.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
