### PR TITLE
feat: add typings for custom SDK []

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,13 +1,17 @@
 import createInitializer from './initialize'
 import createAPI from './api'
-import { KnownSDK } from './types'
+import { ConnectMessage, KnownSDK } from './types'
+import { Channel } from './channel'
 
 export * from './types'
 export { default as locations } from './locations'
 
-type Init = <T extends KnownSDK = KnownSDK>(
-  initCallback: (sdk: T) => any,
-  options?: { supressIframeWarning?: boolean }
+type Init = <
+  T extends KnownSDK = KnownSDK,
+  C extends ((channel: Channel, params: ConnectMessage) => any) | undefined = undefined
+>(
+  initCallback: C extends Function ? (sdk: T, customSdk: ReturnType<C>) => any : (sdk: T) => any,
+  options?: { makeCustomApi: C; supressIframeWarning?: boolean }
 ) => void
 
 export const init = createInitializer(window, createAPI) as Init


### PR DESCRIPTION
# Purpose of PR

While working on the new `tasks-app`, we faced TS issues because the generation and passing of a custom SDK aren't supported by the exposed types from app-sdk.

I added conditional typing for `makeCustomApi`. If the function is undefined, `initCallback` only contains the first `sdk` parameter. Otherwise, it will pass the result from `makeCustomApi` as second parameter.

## Discussion
@giotiskl  already briefed me that we hide that intentionally since it's not supposed to be public. If this is the case, I leave the decision to extensibility whether we may expose it or decline this PR. My reasoning would be that we already expose that functionality even though developers don't see it in the types. So we don't actually add an insecure function but make things easier for us (not having to use `@tslint-ignore` in our repos but have the correct types). If we go for "security by obscurity" and decline this PR, I would ask for a discussion what the most correct way should be instead :)

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
