### PR TITLE
fix: copy entries to target environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,7 @@ jobs:
       - run: npm run build
       - run:
           name: npm run integration
-          command: |
-            set -e
-            npm run integration
+          command: npm run integration
       - run: 
           command: npm run merge-report
           when: always

--- a/test/cypress/integration/initialize.spec.ts
+++ b/test/cypress/integration/initialize.spec.ts
@@ -9,7 +9,6 @@ context(`Initialize (${role})`, () => {
   })
 
   it('Entry Editor', () => {
-    throw new Error('kaboom')
     cy.visitEntryWithRetry(Cypress.env('entries').entryEditorExtension)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist

--- a/test/cypress/integration/initialize.spec.ts
+++ b/test/cypress/integration/initialize.spec.ts
@@ -10,10 +10,10 @@ context.only(`Initialize (${role})`, () => {
   })
 
   it('Entry Editor', () => {
-    throw new AssertionError('ERRROR')
-
     cy.visitEntryWithRetry(Cypress.env('entries').entryEditorExtension)
     cy.findByTestId('workbench-title').should(($title) => {
+      throw new AssertionError('ERRROR')
+
       expect($title).to.exist
     })
 

--- a/test/cypress/integration/initialize.spec.ts
+++ b/test/cypress/integration/initialize.spec.ts
@@ -2,17 +2,19 @@ import { actionSelectors } from '../../constants'
 import { pageExtension } from '../utils/paths'
 import { role } from '../utils/role'
 import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
+import AssertionError = Chai.AssertionError
 
-context(`Initialize (${role})`, () => {
+context.only(`Initialize (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
   })
 
   it('Entry Editor', () => {
+    throw new AssertionError('ERRROR')
+
     cy.visitEntryWithRetry(Cypress.env('entries').entryEditorExtension)
     cy.findByTestId('workbench-title').should(($title) => {
-      // THIS IS PURPOSELY WRONG TO TEST WHETHER CIRCLE CATCHES THE ERROR
-      expect($title).to.not.exist
+      expect($title).to.exist
     })
 
     cy.waitForIframeWithTestId('cf-ui-card')

--- a/test/cypress/integration/initialize.spec.ts
+++ b/test/cypress/integration/initialize.spec.ts
@@ -11,7 +11,8 @@ context(`Initialize (${role})`, () => {
   it('Entry Editor', () => {
     cy.visitEntryWithRetry(Cypress.env('entries').entryEditorExtension)
     cy.findByTestId('workbench-title').should(($title) => {
-      expect($title).to.exist
+      // THIS IS PURPOSELY WRONG TO TEST WHETHER CIRCLE CATCHES THE ERROR
+      expect($title).to.not.exist
     })
 
     cy.waitForIframeWithTestId('cf-ui-card')

--- a/test/cypress/integration/initialize.spec.ts
+++ b/test/cypress/integration/initialize.spec.ts
@@ -2,7 +2,7 @@ import { actionSelectors } from '../../constants'
 import { pageExtension } from '../utils/paths'
 import { role } from '../utils/role'
 import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
-import AssertionError = Chai.AssertionError
+import { AssertionError } from 'chai'
 
 context.only(`Initialize (${role})`, () => {
   beforeEach(() => {

--- a/test/cypress/integration/initialize.spec.ts
+++ b/test/cypress/integration/initialize.spec.ts
@@ -2,9 +2,8 @@ import { actionSelectors } from '../../constants'
 import { pageExtension } from '../utils/paths'
 import { role } from '../utils/role'
 import { openDialogExtensionTest } from './reusable/open-dialog-extension-test'
-import { AssertionError } from 'chai'
 
-context.only(`Initialize (${role})`, () => {
+context(`Initialize (${role})`, () => {
   beforeEach(() => {
     cy.setupBrowserStorage()
   })
@@ -12,8 +11,6 @@ context.only(`Initialize (${role})`, () => {
   it('Entry Editor', () => {
     cy.visitEntryWithRetry(Cypress.env('entries').entryEditorExtension)
     cy.findByTestId('workbench-title').should(($title) => {
-      throw new AssertionError('ERRROR')
-
       expect($title).to.exist
     })
 

--- a/test/cypress/integration/initialize.spec.ts
+++ b/test/cypress/integration/initialize.spec.ts
@@ -9,6 +9,7 @@ context(`Initialize (${role})`, () => {
   })
 
   it('Entry Editor', () => {
+    throw new Error('kaboom')
     cy.visitEntryWithRetry(Cypress.env('entries').entryEditorExtension)
     cy.findByTestId('workbench-title').should(($title) => {
       expect($title).to.exist

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -45,6 +45,7 @@ let tempEnvironmentId: any
 const tempEntries: { environmentId: string; entryId: string }[] = []
 
 const cleanup = async () => {
+  throw new Error('boom')
   if (tempEnvironmentId) {
     try {
       await asyncRetry(() => deleteEnvironment(tempEnvironmentId), { retries: 3 })
@@ -102,28 +103,28 @@ const run = async () => {
     onValueChanged: idsData.onValueChanged.entry,
   }
 
-  // Admin
-  await createCypressConfiguration({
-    managementToken: config.managementTokenAdmin,
-    spaceId: config.spaceId,
-    environmentId: tempEnvironmentId,
-    aliasId: testAliasId,
-    role: 'admin',
-    entries: entryIds,
-  })
-
-  await runCypress('admin')
-
-  // Editor
-  await createCypressConfiguration({
-    managementToken: config.managementTokenEditor,
-    spaceId: config.spaceId,
-    environmentId: tempEnvironmentId,
-    aliasId: testAliasId,
-    role: 'editor',
-    entries: entryIds,
-  })
-  await runCypress('editor', true)
+  // // Admin
+  // await createCypressConfiguration({
+  //   managementToken: config.managementTokenAdmin,
+  //   spaceId: config.spaceId,
+  //   environmentId: tempEnvironmentId,
+  //   aliasId: testAliasId,
+  //   role: 'admin',
+  //   entries: entryIds,
+  // })
+  //
+  // await runCypress('admin')
+  //
+  // // Editor
+  // await createCypressConfiguration({
+  //   managementToken: config.managementTokenEditor,
+  //   spaceId: config.spaceId,
+  //   environmentId: tempEnvironmentId,
+  //   aliasId: testAliasId,
+  //   role: 'editor',
+  //   entries: entryIds,
+  // })
+  // await runCypress('editor', true)
 
   // Editor (master only)
   const newEntryIds = await copyEntries(entryIds)

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -112,7 +112,7 @@ const run = async () => {
     entries: entryIds,
   })
 
-  // await runCypress('admin')
+  await runCypress('admin')
 
   // Editor
   await createCypressConfiguration({
@@ -123,7 +123,7 @@ const run = async () => {
     role: 'editor',
     entries: entryIds,
   })
-  // await runCypress('editor', true)
+  await runCypress('editor', true)
 
   // Editor (master only)
   const newEntryIds = await copyEntries(entryIds)

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -45,7 +45,6 @@ let tempEnvironmentId: any
 const tempEntries: { environmentId: string; entryId: string }[] = []
 
 const cleanup = async () => {
-  throw new Error('boom')
   if (tempEnvironmentId) {
     try {
       await asyncRetry(() => deleteEnvironment(tempEnvironmentId), { retries: 3 })
@@ -103,28 +102,28 @@ const run = async () => {
     onValueChanged: idsData.onValueChanged.entry,
   }
 
-  // // Admin
-  // await createCypressConfiguration({
-  //   managementToken: config.managementTokenAdmin,
-  //   spaceId: config.spaceId,
-  //   environmentId: tempEnvironmentId,
-  //   aliasId: testAliasId,
-  //   role: 'admin',
-  //   entries: entryIds,
-  // })
-  //
-  // await runCypress('admin')
-  //
-  // // Editor
-  // await createCypressConfiguration({
-  //   managementToken: config.managementTokenEditor,
-  //   spaceId: config.spaceId,
-  //   environmentId: tempEnvironmentId,
-  //   aliasId: testAliasId,
-  //   role: 'editor',
-  //   entries: entryIds,
-  // })
-  // await runCypress('editor', true)
+  // Admin
+  await createCypressConfiguration({
+    managementToken: config.managementTokenAdmin,
+    spaceId: config.spaceId,
+    environmentId: tempEnvironmentId,
+    aliasId: testAliasId,
+    role: 'admin',
+    entries: entryIds,
+  })
+
+  await runCypress('admin')
+
+  // Editor
+  await createCypressConfiguration({
+    managementToken: config.managementTokenEditor,
+    spaceId: config.spaceId,
+    environmentId: tempEnvironmentId,
+    aliasId: testAliasId,
+    role: 'editor',
+    entries: entryIds,
+  })
+  await runCypress('editor', true)
 
   // Editor (master only)
   const newEntryIds = await copyEntries(entryIds)

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -147,8 +147,8 @@ const run = async () => {
     await run()
     await cleanup()
   } catch (err) {
-    console.log(err)
-    await cleanup()
+    console.error(err)
+    await cleanup().catch(console.error)
     process.exit(1)
   }
 })()

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -112,7 +112,7 @@ const run = async () => {
     entries: entryIds,
   })
 
-  await runCypress('admin')
+  // await runCypress('admin')
 
   // Editor
   await createCypressConfiguration({
@@ -123,7 +123,7 @@ const run = async () => {
     role: 'editor',
     entries: entryIds,
   })
-  await runCypress('editor', true)
+  // await runCypress('editor', true)
 
   // Editor (master only)
   const newEntryIds = await copyEntries(entryIds)

--- a/test/integration/tasks/copy-entries.ts
+++ b/test/integration/tasks/copy-entries.ts
@@ -4,15 +4,16 @@ import { printStepTitle } from '../utils'
 export default async function copyEntries(entryIds: Record<string, string>) {
   printStepTitle('Copying entries from test-base to master-test')
 
-  const environmentId = 'test-base'
+  const sourceEnvironmentId = 'test-base'
+  const targetEnvironmentId = 'master-test'
 
   const newEntryIds: Record<string, string> = {}
   for (const [entryLabel, entryId] of Object.entries(entryIds)) {
-    const entry = await plainClient.entry.get({ entryId, environmentId })
+    const entry = await plainClient.entry.get({ entryId, environmentId: sourceEnvironmentId })
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { sys, ...rest } = entry
     const newEntry = await plainClient.entry.create(
-      { contentTypeId: entry.sys.contentType.sys.id, environmentId },
+      { contentTypeId: entry.sys.contentType.sys.id, environmentId: targetEnvironmentId },
       rest
     )
     newEntryIds[entryLabel] = newEntry.sys.id


### PR DESCRIPTION
Changes:
* `set -e` is unneeded: CircleCI already runs the shell with that flag on
* I wanted to streamline the setup across environments removing the third "staging" environment we use for tests. This would require changes which might be breaking for other peoples' (user, internal) workflows. Reverted it to its previous state
* If cleanup upon failure fails itself, the test shouldn't be green 🙃 