### PR TITLE
chore: ignore teamMemberships property for integration tests [HOMER-151]

### DIFF
--- a/test/cypress/utils/remove-variable-data.ts
+++ b/test/cypress/utils/remove-variable-data.ts
@@ -13,7 +13,8 @@ const isUser = (o: any): o is User => o.sys.type === 'User'
  */
 export function removeVariableData(obj: EnrichedContentType | User) {
   if (isUser(obj)) {
-    const { avatarUrl, ...user } = obj
+    // @ts-expect-error for tasks app EAP we allow passing in the teamMemberships but do not expose public types
+    const { avatarUrl, teamMemberships, ...user } = obj
 
     return user
   }


### PR DESCRIPTION
# Purpose of PR

For the tasks EAP we pass in a `teamMemberships` property to the `sdk.user` object but do not expose public types for it. This is only temporary until we implemented a proper authZ solution for the tasks app. This PR just ignores the `teamMemberships` property for the integration tests.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
