### PR TITLE
fix: allow OnConfigureHandlerReturn props to be null [EXT-2869]

### DIFF
--- a/lib/types/app.types.ts
+++ b/lib/types/app.types.ts
@@ -15,8 +15,8 @@ export interface AppState {
 }
 
 export type OnConfigureHandlerReturn =
-  | Promise<{ parameters?: KeyValueMap; targetState?: AppState }>
-  | { parameters?: KeyValueMap; targetState?: AppState }
+  | Promise<{ parameters?: KeyValueMap | null; targetState?: AppState | null }>
+  | { parameters?: KeyValueMap | null; targetState?: AppState | null }
   | false
 export type OnConfigureHandler = () => OnConfigureHandlerReturn
 


### PR DESCRIPTION
We currently get the following error when updating to app sdk v4 in a fresh CCA app

```
Type 'Promise<{ parameters: AppInstallationParameters; targetState: AppState | null; }>' is not assignable to type 'OnConfigureHandlerReturn'.
  Type 'Promise<{ parameters: AppInstallationParameters; targetState: AppState | null; }>' is not assignable to type 'Promise<{ parameters?: KeyValueMap | undefined; targetState?: AppState | undefined; }>'.
    Type '{ parameters: AppInstallationParameters; targetState: AppState | null; }' is not assignable to type '{ parameters?: KeyValueMap | undefined; targetState?: AppState | undefined; }'.
      Types of property 'targetState' are incompatible.
        Type 'AppState | null' is not assignable to type 'AppState | undefined'.
          Type 'null' is not assignable to type 'AppState | undefined'.  TS2322

    35 |     // invoked when a user attempts to install the app or update
    36 |     // its configuration.
  > 37 |     props.sdk.app.onConfigure(() => onConfigure());
       |                                     ^
    38 |   }, [props.sdk, onConfigure]);
    39 |
    40 |   useEffect(() => {
```

This PR allows `null` to be returned for `parameters` and `targetState`.