### PR TITLE
chore: remove stale entries before each run and fix envs

### DIFF
--- a/docs/run-integration-tests.md
+++ b/docs/run-integration-tests.md
@@ -2,7 +2,11 @@
 
 ## Writing tests and running them locally
 
-1. Create `.env` file at the root of the repository with the following variables:
+1. Create a test environment in our testing space. This environment should be a copy of `test-base`.
+
+Environments without the word `test` in their name are automatically deleted after two hours. So, choose a name like `<firstname>-test`.
+
+2. Create `.env` file at the root of the repository with the following variables:
 
 ```bash
 # Generate PAT token here: https://www.contentful.com/r/knowledgebase/personal-access-tokens/
@@ -19,7 +23,7 @@ TEST_LOCAL_SDK=true
 CONTENTFUL_LOCAL_TESTING_ENV=<envinonment-name-that-you-will-use-for-testing>
 ```
 
-2. Run the following commands
+3. Run the following commands
 
 ```bash
 # install all build dependencies
@@ -30,12 +34,12 @@ npm run build
 npm run integration:local
 ```
 
-3. Open Cypress in development mode
+4. Open Cypress in development mode
 
 ```bash
 npm run cypress:open
 ```
 
-4. Edit cypress tests
+5. Edit cypress tests
 
 Edit exising tests or create a new one in `test/cypress/integration` folder.

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -17,6 +17,7 @@ import deployExtensions from './tasks/deploy-extensions'
 import runCypress from './tasks/run-cypress'
 import deleteEntries from './tasks/delete-entries'
 import { createFixtures } from './tasks/create-fixtures'
+import deleteStaleEntries from './tasks/delete-stale-entries'
 
 const config = {
   managementTokenAdmin: process.env.CONTENTFUL_CMA_TOKEN!,
@@ -70,6 +71,12 @@ const run = async () => {
     await deleteStaleEnvironments()
   } catch (e) {
     console.error('Could not delete all stale environments')
+  }
+
+  try {
+    await deleteStaleEntries()
+  } catch (e) {
+    console.error('Could not delete all stale entries')
   }
 
   try {

--- a/test/integration/tasks/delete-stale-entries.ts
+++ b/test/integration/tasks/delete-stale-entries.ts
@@ -23,6 +23,10 @@ export default async (client = plainClient) => {
         const id = entry.sys.id
 
         try {
+          if (entry.sys.publishedVersion) {
+            await client.entry.unpublish({ entryId: id, environmentId: 'master-test' })
+          }
+
           await client.entry.delete({ entryId: id, environmentId: 'master-test' })
           console.log(`Deleted entry ${id}`)
           return id

--- a/test/integration/tasks/delete-stale-entries.ts
+++ b/test/integration/tasks/delete-stale-entries.ts
@@ -1,5 +1,6 @@
+import { EntryProps, KeyValueMap } from 'contentful-management/types'
 import { plainClient } from '../contentful-client'
-import { printStepTitle, sleep } from '../utils'
+import { printStepTitle } from '../utils'
 
 const TWO_HOURS_IN_MS = 60 * 60 * 2 * 1000
 
@@ -9,30 +10,29 @@ export default async (client = plainClient) => {
   const entryCollection = await client.entry.getMany({ environmentId: 'master-test' })
   const { items: entries } = entryCollection
 
-  const isStaleEntry = (timeStamp: string) => {
-    const entryDate = new Date(timeStamp).getTime()
+  const isStaleEntry = (entry: EntryProps<KeyValueMap>) => {
+    const entryDate = new Date(entry.sys.createdAt).getTime()
     const difference = Date.now() - entryDate
     return difference >= TWO_HOURS_IN_MS
   }
 
-  const deletedEntries: string[] = []
-  for (const entry of entries) {
-    const {
-      sys: { createdAt, id },
-    } = entry
-    if (!isStaleEntry(createdAt)) {
-      continue
-    }
+  const promiseResults = await Promise.allSettled(
+    entries
+      .filter((entry) => isStaleEntry(entry))
+      .map(async (entry) => {
+        const id = entry.sys.id
 
-    try {
-      await client.entry.delete({ entryId: id })
-      console.log(`Deleted entry ${id}`)
-      deletedEntries.push(id)
-      await sleep(200)
-    } catch (error) {
-      console.error(`Could not delete entry ${id}`)
-    }
-  }
+        try {
+          await client.entry.delete({ entryId: id, environmentId: 'master-test' })
+          console.log(`Deleted entry ${id}`)
+          return id
+        } catch (error) {
+          console.error(`Could not delete entry ${id}`)
+        }
+      })
+  )
 
-  return deletedEntries
+  return promiseResults
+    .filter((r): r is PromiseFulfilledResult<string> => r.status === 'fulfilled')
+    .map((r) => r.value)
 }

--- a/test/integration/tasks/delete-stale-entries.ts
+++ b/test/integration/tasks/delete-stale-entries.ts
@@ -1,0 +1,38 @@
+import { plainClient } from '../contentful-client'
+import { printStepTitle, sleep } from '../utils'
+
+const TWO_HOURS_IN_MS = 60 * 60 * 2 * 1000
+
+export default async (client = plainClient) => {
+  printStepTitle('Removing stale entries from master-test')
+
+  const entryCollection = await client.entry.getMany({ environmentId: 'master-test' })
+  const { items: entries } = entryCollection
+
+  const isStaleEntry = (timeStamp: string) => {
+    const entryDate = new Date(timeStamp).getTime()
+    const difference = Date.now() - entryDate
+    return difference >= TWO_HOURS_IN_MS
+  }
+
+  const deletedEntries: string[] = []
+  for (const entry of entries) {
+    const {
+      sys: { createdAt, id },
+    } = entry
+    if (!isStaleEntry(createdAt)) {
+      continue
+    }
+
+    try {
+      await client.entry.delete({ entryId: id })
+      console.log(`Deleted entry ${id}`)
+      deletedEntries.push(id)
+      await sleep(200)
+    } catch (error) {
+      console.error(`Could not delete entry ${id}`)
+    }
+  }
+
+  return deletedEntries
+}

--- a/test/mocks/entries.ts
+++ b/test/mocks/entries.ts
@@ -1,0 +1,32 @@
+function yesterday() {
+  const now = new Date()
+  const oneDayAgo = now.valueOf() - 60 * 60 * 24 * 1000
+  return new Date(oneDayAgo).toISOString()
+}
+
+const today = new Date().toISOString()
+
+export default {
+  total: 36,
+  limit: 100,
+  skip: 0,
+  sys: {
+    type: 'Array',
+  },
+  items: [
+    {
+      sys: {
+        type: 'Entry',
+        id: 'b4ltnOQh2HkAFBZVMzdz7',
+        createdAt: yesterday(),
+      },
+    },
+    {
+      sys: {
+        type: 'Entry',
+        id: 'V1StGXR8_Z5jdHi6B-myT',
+        createdAt: today,
+      },
+    },
+  ],
+}

--- a/test/unit/delete-stale-entries.spec.ts
+++ b/test/unit/delete-stale-entries.spec.ts
@@ -1,0 +1,21 @@
+import deleteStaleEntries from '../integration/tasks/delete-stale-entries'
+import entryMocks from '../mocks/entries'
+import { expect } from '../helpers'
+import { PlainClientAPI } from 'contentful-management'
+
+describe('DeleteStaleEntries', () => {
+  let plainClient: PlainClientAPI
+  beforeEach(() => {
+    plainClient = {
+      entry: {
+        getMany: () => Promise.resolve(entryMocks),
+        delete: () => Promise.resolve(),
+      },
+    } as unknown as PlainClientAPI
+  })
+
+  it('should delete an entry that is older than one day', async () => {
+    const expectedResult = ['b4ltnOQh2HkAFBZVMzdz7']
+    expect(await deleteStaleEntries(plainClient)).to.eql(expectedResult)
+  })
+})

--- a/test/unit/delete-stale-environments.spec.ts
+++ b/test/unit/delete-stale-environments.spec.ts
@@ -8,14 +8,8 @@ describe('DeleteStaleEnvironments', () => {
   beforeEach(() => {
     plainClient = {
       environment: {
-        getMany: () =>
-          Promise.resolve({
-            ...environmentMocks,
-            items: environmentMocks.items.map((environment) => ({
-              ...environment,
-              delete: () => Promise.resolve(),
-            })),
-          }),
+        getMany: () => Promise.resolve(environmentMocks),
+        delete: () => Promise.resolve(),
       },
     } as unknown as PlainClientAPI
   })


### PR DESCRIPTION
# Purpose of PR

With this PR we delete stale entries from `master-test` before every run. In theory these should be deleted after the tests finish, but in some cases CI crashes and some leftovers remain in the `master-test` environment. The implementation is almost identical to removing stale environments.

The stale environment removal task had a few implementation issues:
- You can't use `.forEach` with async functions as we cannot `await` for `forEach` to finish with all promises. I therefore rewrote this to a `for ... of ...`
- We are using the plain cma client here which means that we cannot call `environment.delete()` or `entry.delete()`. I adjusted the code to use the plain client syntax for deletion.