### PR TITLE
feat(AccessAPI): add support for JSON patches in access sdk [EXT-3041]

### DIFF
--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -130,6 +130,11 @@ export interface SharedEditorSDK {
 type CrudAction = 'create' | 'read' | 'update' | 'delete'
 type PublishableAction = 'publish' | 'unpublish'
 type ArchiveableAction = 'archive' | 'unarchive'
+type JSONPatchItem = {
+  op: 'remove' | 'replace' | 'add'
+  path: string
+  value?: any
+}
 
 export interface AccessAPI {
   can(action: 'read' | 'update', entity: 'EditorInterface' | EditorInterface): Promise<boolean>
@@ -145,6 +150,12 @@ export interface AccessAPI {
   ): Promise<boolean>
 
   can<T = Object>(action: ArchiveableAction, entity: 'Asset' | 'Entry' | T): Promise<boolean>
+
+  can<T = Object>(
+    action: 'patch',
+    entity: 'Asset' | 'Entry' | T,
+    patch?: JSONPatchItem[]
+  ): Promise<boolean>
 
   /** Whether the current user can edit app config */
   canEditAppConfig: () => Promise<boolean>

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -5,6 +5,9 @@ import {
   Role,
   ContentTypeField,
   Metadata,
+  Entry,
+  Task,
+  Asset,
 } from './entities'
 import { EntryAPI } from './entry.types'
 import { SpaceAPI } from './space.types'
@@ -135,6 +138,7 @@ type JSONPatchItem = {
   path: string
   value?: any
 }
+type PatchEntity = Entry | Task | Asset | 'Asset' | 'Entry' | 'Task'
 
 export interface AccessAPI {
   can(action: 'read' | 'update', entity: 'EditorInterface' | EditorInterface): Promise<boolean>
@@ -151,11 +155,7 @@ export interface AccessAPI {
 
   can<T = Object>(action: ArchiveableAction, entity: 'Asset' | 'Entry' | T): Promise<boolean>
 
-  can<T = Object>(
-    action: 'patch',
-    entity: 'Asset' | 'Entry' | T,
-    patch?: JSONPatchItem[]
-  ): Promise<boolean>
+  can(action: 'patch', entity: PatchEntity, patch: JSONPatchItem[]): Promise<boolean>
 
   /** Whether the current user can edit app config */
   canEditAppConfig: () => Promise<boolean>

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -155,7 +155,7 @@ export interface AccessAPI {
 
   can<T = Object>(action: ArchiveableAction, entity: 'Asset' | 'Entry' | T): Promise<boolean>
 
-  can(action: 'patch', entity: PatchEntity, patch: JSONPatchItem[]): Promise<boolean>
+  can(action: 'update', entity: PatchEntity, patch: JSONPatchItem[]): Promise<boolean>
 
   /** Whether the current user can edit app config */
   canEditAppConfig: () => Promise<boolean>

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -138,7 +138,7 @@ type JSONPatchItem = {
   path: string
   value?: any
 }
-type PatchEntity = Entry | Task | Asset | 'Asset' | 'Entry' | 'Task'
+type PatchEntity = Entry | Task | Asset
 
 export interface AccessAPI {
   can(action: 'read' | 'update', entity: 'EditorInterface' | EditorInterface): Promise<boolean>


### PR DESCRIPTION
# Purpose of PR

Add support for checking patches for all entities supported in access sdk

## PR Checklist

- [x] Tests are not required
- [ ] Typescript typings are added/updated/not required
