### PR TITLE
fix(AccessSDK): patch is not a supported action [EXT-3041]

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -699,7 +699,7 @@ export interface AccessAPI {
   ): Promise<boolean>
   can<T = Object>(action: ArchiveableAction, entity: 'Asset' | 'Entry' | T): Promise<boolean>
   can<T = Object>(
-    action: 'patch',
+    action: 'update',
     entity: 'Asset' | 'Entry' | T,
     patch: JSONPatchItem[]
   ): Promise<boolean>


### PR DESCRIPTION
# Purpose of PR
Instead of Patch as an action, we use update but pass a patch as an option instead

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
