### PR TITLE
fix: remove Promise<...> type from OnConfigureHandlerReturn [EXT-3082]

### DIFF
--- a/lib/types/app.types.ts
+++ b/lib/types/app.types.ts
@@ -15,10 +15,9 @@ export interface AppState {
 }
 
 export type OnConfigureHandlerReturn =
-  | Promise<{ parameters?: KeyValueMap | null; targetState?: AppState | null }>
   | { parameters?: KeyValueMap | null; targetState?: AppState | null }
   | false
-export type OnConfigureHandler = () => OnConfigureHandlerReturn
+export type OnConfigureHandler = () => OnConfigureHandlerReturn | Promise<OnConfigureHandlerReturn>
 
 export interface AppConfigAPI {
   /** Tells the web app that the app is loaded */


### PR DESCRIPTION
Small change to the `OnConfigureHandlerReturn` type. That way you can now write code like

```typescript
const onConfigure: async (): OnConfigureHandlerReturn => {
...
}
```

that was previously not possible because of

> Type 'OnConfigureHandlerReturn' is not a valid async function return type in ES5/ES3 because it does not refer to a Promise-compatible constructor value.

Also it was previously not valid to return `Promise<false>`