### PR TITLE
fix: [3161] use correct type for conflicting errors

### DIFF
--- a/lib/types/validation-error.ts
+++ b/lib/types/validation-error.ts
@@ -1,5 +1,4 @@
 import { Link } from './utils'
-import { Entry } from './entities'
 
 export interface BaseValidationError {
   name: string
@@ -33,7 +32,7 @@ export interface RequiredValidationError extends BaseValidationError {
 
 export interface UniqueValidationError extends BaseValidationError {
   name: 'unique'
-  conflicting: Link<Entry>[]
+  conflicting: Link<'Entry', 'Link'>[]
 }
 
 export interface ProhibitRegexpValidationError extends BaseValidationError {

--- a/lib/types/validation-error.ts
+++ b/lib/types/validation-error.ts
@@ -1,3 +1,6 @@
+import { Link } from './utils'
+import { Entry } from './entities'
+
 export interface BaseValidationError {
   name: string
   message?: string
@@ -30,7 +33,7 @@ export interface RequiredValidationError extends BaseValidationError {
 
 export interface UniqueValidationError extends BaseValidationError {
   name: 'unique'
-  conflicting: string[]
+  conflicting: Link<Entry>[]
 }
 
 export interface ProhibitRegexpValidationError extends BaseValidationError {


### PR DESCRIPTION
# Purpose of PR
In upgrading another package I spotted that this type is wrong.

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
