### PR TITLE
chore: use cimg/node instead of circleci/node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
 
   semantic-release:
     docker:
-      - image: circleci/node:16.13.2
+      - image: cimg/node:16.13.2
     steps:
       - checkout
       - run:


### PR DESCRIPTION
`circleci/node` is a legacy image and therefore doesn't have the latest node versions

https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/