### PR TITLE
fix: return same SDK instance when calling `init` multiple times [EXT-3497]

### DIFF
--- a/lib/initialize.ts
+++ b/lib/initialize.ts
@@ -5,9 +5,10 @@ export default function createInitializer(
   currentWindow: Window,
   apiCreator: (channel: Channel, data: ConnectMessage, window: Window) => KnownSDK
 ) {
-  const connectDeferred = createDeferred()
+  const connectDeferred =
+    createDeferred<[channel: Channel, message: ConnectMessage, messageQueue: unknown[]]>()
 
-  connectDeferred.promise.then(([channel]: [Channel]) => {
+  connectDeferred.promise.then(([channel]) => {
     const { document } = currentWindow
     document.addEventListener('focus', () => channel.send('setActive', true), true)
     document.addEventListener('blur', () => channel.send('setActive', false), true)
@@ -17,6 +18,7 @@ export default function createInitializer(
   // messages before `init` is called.
   connect(currentWindow, (...args) => connectDeferred.resolve(args))
 
+  let initializedSdks: Promise<[sdk: KnownSDK, customSdk: any]> | undefined
   return function init(
     initCb: (sdk: KnownSDK, customSdk: any) => any,
     {
@@ -34,26 +36,33 @@ In order for the ui-extension-sdk to function correctly, your app needs to be ru
 Learn more about local development with the ui-extension-sdk here:
   https://www.contentful.com/developers/docs/extensibility/ui-extensions/faq/#how-can-i-use-the-ui-extension-sdk-locally`)
     }
-    connectDeferred.promise.then(
-      ([channel, params, messageQueue]: [Channel, ConnectMessage, unknown[]]) => {
-        const api = apiCreator(channel, params, currentWindow)
 
-        let customApi
-        if (typeof makeCustomApi === 'function') {
-          customApi = makeCustomApi(channel, params)
-        }
+    if (!initializedSdks) {
+      initializedSdks = new Promise((resolve) => {
+        connectDeferred.promise.then(([channel, params, messageQueue]) => {
+          const api = apiCreator(channel, params, currentWindow)
 
-        // Handle pending incoming messages.
-        // APIs are created before so handlers are already
-        // registered on the channel.
-        messageQueue.forEach((m) => {
-          // TODO Expose private handleMessage method
-          ;(channel as any)._handleMessage(m)
+          let customApi
+          if (typeof makeCustomApi === 'function') {
+            customApi = makeCustomApi(channel, params)
+          }
+
+          // Handle pending incoming messages.
+          // APIs are created before so handlers are already
+          // registered on the channel.
+          messageQueue.forEach((m) => {
+            // TODO Expose private handleMessage method
+            ;(channel as any)._handleMessage(m)
+          })
+
+          resolve([api, customApi])
         })
+      })
+    }
 
-        // Hand over control to the developer.
-        initCb(api, customApi)
-      }
+    initializedSdks.then(([sdk, customSdk]) =>
+      // Hand over control to the developer.
+      initCb(sdk, customSdk)
     )
   }
 }

--- a/lib/initialize.ts
+++ b/lib/initialize.ts
@@ -38,25 +38,23 @@ Learn more about local development with the ui-extension-sdk here:
     }
 
     if (!initializedSdks) {
-      initializedSdks = new Promise((resolve) => {
-        connectDeferred.promise.then(([channel, params, messageQueue]) => {
-          const api = apiCreator(channel, params, currentWindow)
+      initializedSdks = connectDeferred.promise.then(([channel, params, messageQueue]) => {
+        const api = apiCreator(channel, params, currentWindow)
 
-          let customApi
-          if (typeof makeCustomApi === 'function') {
-            customApi = makeCustomApi(channel, params)
-          }
+        let customApi
+        if (typeof makeCustomApi === 'function') {
+          customApi = makeCustomApi(channel, params)
+        }
 
-          // Handle pending incoming messages.
-          // APIs are created before so handlers are already
-          // registered on the channel.
-          messageQueue.forEach((m) => {
-            // TODO Expose private handleMessage method
-            ;(channel as any)._handleMessage(m)
-          })
-
-          resolve([api, customApi])
+        // Handle pending incoming messages.
+        // APIs are created before so handlers are already
+        // registered on the channel.
+        messageQueue.forEach((m) => {
+          // TODO Expose private handleMessage method
+          ;(channel as any)._handleMessage(m)
         })
+
+        return [api, customApi]
       })
     }
 

--- a/test/unit/initialize.spec.ts
+++ b/test/unit/initialize.spec.ts
@@ -35,7 +35,8 @@ describe('initializeApi(currentWindow, apiCreator)', function () {
       const cb = sinon.spy()
       sendConnect(this.dom)
       await wait()
-      await this.init(cb)
+      this.init(cb)
+      await wait()
       expect(cb).to.be.called // eslint-disable-line no-unused-expressions
     })
 

--- a/test/unit/initialize.spec.ts
+++ b/test/unit/initialize.spec.ts
@@ -64,6 +64,19 @@ describe('initializeApi(currentWindow, apiCreator)', function () {
 
       sendConnect(this.dom)
     })
+
+    it('receives same sdk instance when init is called twice', async function () {
+      const cbA = sinon.spy()
+      const cbB = sinon.spy()
+      sendConnect(this.dom)
+      this.init(cbA)
+      this.init(cbB)
+      await wait()
+
+      expect(cbA).to.be.called // eslint-disable-line no-unused-expressions
+      expect(cbB).to.be.called // eslint-disable-line no-unused-expressions
+      expect(cbA.getCall(0).args[0]).to.eq(cbB.getCall(0).args[0])
+    })
   })
 
   it('calls apiCreator with channel and params', function () {


### PR DESCRIPTION
# Purpose of PR

With this PR we ensure that only a single SDK instance exists within an app.

This fixes an issue where multiple SDKs subscribe and respond to an event sent from the host application. E.g. the `sdk.app.onConfigure` hook.

This might be a breaking change if someone decides to mutate the returned SDK. With this change, the mutation would also be returned for all other `init` calls. I assume only very few people do this, so this is only a patch release.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
