### PR TITLE
fix: [EXT-3363] use correct IDS api for fields

### DIFF
--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -192,13 +192,13 @@ export interface BaseExtensionSDK {
 
 export type EditorExtensionSDK = Omit<BaseExtensionSDK, 'ids'> &
   SharedEditorSDK & {
-    /** A set of IDs actual for the app */
+    /** A set of IDs for the app */
     ids: Omit<IdsAPI, 'field'>
   }
 
 export type SidebarExtensionSDK = Omit<BaseExtensionSDK, 'ids'> &
   SharedEditorSDK & {
-    /** A set of IDs actual for the app */
+    /** A set of IDs for the app */
     ids: Omit<IdsAPI, 'field'>
     /** Methods to update the size of the iframe the app is contained within.  */
     window: WindowAPI
@@ -206,6 +206,8 @@ export type SidebarExtensionSDK = Omit<BaseExtensionSDK, 'ids'> &
 
 export type FieldExtensionSDK = BaseExtensionSDK &
   SharedEditorSDK & {
+    /** A set of IDs for the app */
+    ids: IdsAPI
     /** Gives you access to the value and metadata of the field the app is attached to. */
     field: FieldAPI
     /** Methods to update the size of the iframe the app is contained within.  */
@@ -213,7 +215,7 @@ export type FieldExtensionSDK = BaseExtensionSDK &
   }
 
 export type DialogExtensionSDK = Omit<BaseExtensionSDK, 'ids'> & {
-  /** A set of IDs actual for the app */
+  /** A set of IDs for the app */
   ids: Omit<IdsAPI, EntryScopedIds>
   /** Closes the dialog and resolves openCurrentApp promise with data */
   close: (data?: any) => void


### PR DESCRIPTION
# Purpose of PR
Previously the IDs API type for the FieldExtensionSDK actually excluded field specific ids. This PR fixes that issue.


Error that we saw previously: 
![image](https://user-images.githubusercontent.com/20307225/153609659-d9d2ec34-5a75-484a-aa3a-e27347a13693.png)

<!--
Please describe the purpose of your pull request here. 

What do you want to add? Why do you want to add it? 

What are the use cases?
-->

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
