### PR TITLE
feat: add warning notification support [SHE-785]

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -35,7 +35,7 @@ const LOCATION_TO_API_PRODUCERS: { [location: string]: ProducerFunc[] } = {
   [locations.LOCATION_ENTRY_EDITOR]: [makeSharedAPI, makeEntryAPI, makeEditorAPI],
   [locations.LOCATION_DIALOG]: [makeSharedAPI, makeDialogAPI, makeWindowAPI],
   [locations.LOCATION_PAGE]: [makeSharedAPI],
-  [locations.LOCATION_APP_CONFIG]: [makeSharedAPI, makeAppAPI]
+  [locations.LOCATION_APP_CONFIG]: [makeSharedAPI, makeAppAPI],
 }
 
 export default function createAPI(
@@ -57,7 +57,7 @@ function makeSharedAPI(channel: Channel, data: ConnectMessage): BaseExtensionSDK
   return {
     cmaAdapter: createAdapter(channel),
     location: {
-      is: tested => currentLocation === tested
+      is: (tested) => currentLocation === tested,
     },
     user,
     parameters,
@@ -67,7 +67,7 @@ function makeSharedAPI(channel: Channel, data: ConnectMessage): BaseExtensionSDK
       names: locales.names,
       fallbacks: locales.fallbacks,
       optional: locales.optional,
-      direction: locales.direction
+      direction: locales.direction,
     },
     space: createSpace(channel, initialContentTypes),
     dialogs: createDialogs(channel, ids),
@@ -76,27 +76,27 @@ function makeSharedAPI(channel: Channel, data: ConnectMessage): BaseExtensionSDK
     notifier: {
       success: (message: string) => channel.send('notify', { type: 'success', message }),
       error: (message: string) => channel.send('notify', { type: 'error', message }),
-      warning: (message: string) => channel.send('notify', { type: 'warning', message })
+      warning: (message: string) => channel.send('notify', { type: 'warning', message }),
     },
     ids,
     access: {
       can: (action: string, entity: any, patch?: JSONPatchItem[]) =>
         channel.call('checkAccess', action, entity, patch) as Promise<boolean>,
-      canEditAppConfig: () => channel.call('checkAppConfigAccess') as Promise<boolean>
-    }
+      canEditAppConfig: () => channel.call('checkAppConfigAccess') as Promise<boolean>,
+    },
   }
 }
 
 function makeWindowAPI(channel: Channel, _data: any, currentWindow: Window) {
   return {
-    window: createWindow(currentWindow, channel)
+    window: createWindow(currentWindow, channel),
   }
 }
 
 function makeEditorAPI(channel: Channel, data: any) {
   const { editorInterface } = data
   return {
-    editor: createEditor(channel, editorInterface)
+    editor: createEditor(channel, editorInterface),
   }
 }
 
@@ -108,7 +108,7 @@ function makeEntryAPI(
 
   return {
     contentType,
-    entry: createEntry(channel, entry, fieldInfo, createEntryField)
+    entry: createEntry(channel, entry, fieldInfo, createEntryField),
   }
 }
 
@@ -117,13 +117,13 @@ function makeFieldAPI(channel: Channel, { field }: ConnectMessage) {
     throw new Error('FieldAPI called for location without "field" property defined.')
   }
   return {
-    field: new FieldLocale(channel, field)
+    field: new FieldLocale(channel, field),
   }
 }
 
 function makeDialogAPI(channel: Channel) {
   return {
-    close: (data: any) => channel.send('closeDialog', data)
+    close: (data: any) => channel.send('closeDialog', data),
   }
 }
 
@@ -131,6 +131,6 @@ function makeAppAPI(channel: Channel) {
   const app = createApp(channel)
 
   return {
-    app
+    app,
   }
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -35,7 +35,7 @@ const LOCATION_TO_API_PRODUCERS: { [location: string]: ProducerFunc[] } = {
   [locations.LOCATION_ENTRY_EDITOR]: [makeSharedAPI, makeEntryAPI, makeEditorAPI],
   [locations.LOCATION_DIALOG]: [makeSharedAPI, makeDialogAPI, makeWindowAPI],
   [locations.LOCATION_PAGE]: [makeSharedAPI],
-  [locations.LOCATION_APP_CONFIG]: [makeSharedAPI, makeAppAPI],
+  [locations.LOCATION_APP_CONFIG]: [makeSharedAPI, makeAppAPI]
 }
 
 export default function createAPI(
@@ -57,7 +57,7 @@ function makeSharedAPI(channel: Channel, data: ConnectMessage): BaseExtensionSDK
   return {
     cmaAdapter: createAdapter(channel),
     location: {
-      is: (tested) => currentLocation === tested,
+      is: tested => currentLocation === tested
     },
     user,
     parameters,
@@ -67,35 +67,36 @@ function makeSharedAPI(channel: Channel, data: ConnectMessage): BaseExtensionSDK
       names: locales.names,
       fallbacks: locales.fallbacks,
       optional: locales.optional,
-      direction: locales.direction,
+      direction: locales.direction
     },
     space: createSpace(channel, initialContentTypes),
     dialogs: createDialogs(channel, ids),
     // Typecast because promises returned by navigator methods aren't typed
     navigator: createNavigator(channel, ids) as NavigatorAPI,
     notifier: {
-      success: (message) => channel.send('notify', { type: 'success', message }),
-      error: (message) => channel.send('notify', { type: 'error', message }),
+      success: (message: string) => channel.send('notify', { type: 'success', message }),
+      error: (message: string) => channel.send('notify', { type: 'error', message }),
+      warning: (message: string) => channel.send('notify', { type: 'warning', message })
     },
     ids,
     access: {
       can: (action: string, entity: any, patch?: JSONPatchItem[]) =>
         channel.call('checkAccess', action, entity, patch) as Promise<boolean>,
-      canEditAppConfig: () => channel.call('checkAppConfigAccess') as Promise<boolean>,
-    },
+      canEditAppConfig: () => channel.call('checkAppConfigAccess') as Promise<boolean>
+    }
   }
 }
 
 function makeWindowAPI(channel: Channel, _data: any, currentWindow: Window) {
   return {
-    window: createWindow(currentWindow, channel),
+    window: createWindow(currentWindow, channel)
   }
 }
 
 function makeEditorAPI(channel: Channel, data: any) {
   const { editorInterface } = data
   return {
-    editor: createEditor(channel, editorInterface),
+    editor: createEditor(channel, editorInterface)
   }
 }
 
@@ -107,7 +108,7 @@ function makeEntryAPI(
 
   return {
     contentType,
-    entry: createEntry(channel, entry, fieldInfo, createEntryField),
+    entry: createEntry(channel, entry, fieldInfo, createEntryField)
   }
 }
 
@@ -116,13 +117,13 @@ function makeFieldAPI(channel: Channel, { field }: ConnectMessage) {
     throw new Error('FieldAPI called for location without "field" property defined.')
   }
   return {
-    field: new FieldLocale(channel, field),
+    field: new FieldLocale(channel, field)
   }
 }
 
 function makeDialogAPI(channel: Channel) {
   return {
-    close: (data: any) => channel.send('closeDialog', data),
+    close: (data: any) => channel.send('closeDialog', data)
   }
 }
 
@@ -130,6 +131,6 @@ function makeAppAPI(channel: Channel) {
   const app = createApp(channel)
 
   return {
-    app,
+    app
   }
 }

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -64,6 +64,8 @@ export interface NotifierAPI {
   success: (message: string) => void
   /** Displays an error notification in the notification area of the Web App. */
   error: (message: string) => void
+  /** Displays a warning notification in the notification area of the Web App. */
+  warning: (message: string) => void
 }
 
 /* Location API */

--- a/test/unit/api.spec.ts
+++ b/test/unit/api.spec.ts
@@ -66,7 +66,7 @@ function test(expected: string[], location: string | undefined, expectedLocation
     'optional',
     'direction',
   ])
-  expect(api.notifier).to.have.all.keys(['success', 'error'])
+  expect(api.notifier).to.have.all.keys(['success', 'error', 'warning'])
   expect(api.access).to.have.all.keys(['can', 'canEditAppConfig'])
 
   // Test location methods (currently only `is`).


### PR DESCRIPTION
# Purpose of PR

We want to add support for warning notifications in order to have this as outcome:
![image](https://user-images.githubusercontent.com/954889/161720250-7ae07ac0-9839-437e-8423-b0c1f22ab210.png)

`field-editors` uses the App SDK in order to send notifications, but we only support `success` and `error` notifications, which is not ideal for our user case.

## PR Checklist

- [x] Tests are updated
- [x] Tests are passing
- [x] Typescript typings are updated
