### PR TITLE
fix: [] improved types for ParametersAPI

### DIFF
--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -78,7 +78,7 @@ export interface LocationAPI {
 export interface ParametersAPI {
   installation: KeyValueMap
   instance: KeyValueMap
-  invocation?: KeyValueMap
+  invocation?: any
 }
 
 /* IDs */

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -18,7 +18,7 @@ import { DialogsAPI } from './dialogs.types'
 import { AppConfigAPI } from './app.types'
 import { NavigatorAPI } from './navigator.types'
 import { EntryFieldInfo, FieldInfo } from './field.types'
-import { Adapter } from 'contentful-management/types'
+import { Adapter, KeyValueMap } from 'contentful-management/types'
 
 /* User API */
 
@@ -76,9 +76,9 @@ export interface LocationAPI {
 /* Parameters API */
 
 export interface ParametersAPI {
-  installation: Object
-  instance: Object
-  invocation?: Object
+  installation: KeyValueMap
+  instance: KeyValueMap
+  invocation?: KeyValueMap
 }
 
 /* IDs */

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -12,7 +12,7 @@ import {
 import { EntryAPI } from './entry.types'
 import { SpaceAPI } from './space.types'
 import { WindowAPI } from './window.types'
-import { ContentEntitySys, Link } from './utils'
+import { ContentEntitySys, Link, SerializedJSONValue } from './utils'
 import { FieldAPI } from './field-locale.types'
 import { DialogsAPI } from './dialogs.types'
 import { AppConfigAPI } from './app.types'
@@ -78,7 +78,7 @@ export interface LocationAPI {
 export interface ParametersAPI {
   installation: KeyValueMap
   instance: KeyValueMap
-  invocation?: any
+  invocation?: SerializedJSONValue
 }
 
 /* IDs */

--- a/lib/types/dialogs.types.ts
+++ b/lib/types/dialogs.types.ts
@@ -1,3 +1,4 @@
+import { SerializedJSONValue } from './utils'
 export interface OpenAlertOptions {
   title: string
   message: string
@@ -20,7 +21,7 @@ export interface OpenCustomWidgetOptions {
   title?: string
   shouldCloseOnOverlayClick?: boolean
   shouldCloseOnEscapePress?: boolean
-  parameters?: any
+  parameters?: SerializedJSONValue
 }
 
 export interface EntityDialogOptions {

--- a/lib/types/dialogs.types.ts
+++ b/lib/types/dialogs.types.ts
@@ -20,7 +20,7 @@ export interface OpenCustomWidgetOptions {
   title?: string
   shouldCloseOnOverlayClick?: boolean
   shouldCloseOnEscapePress?: boolean
-  parameters?: Object
+  parameters?: any
 }
 
 export interface EntityDialogOptions {


### PR DESCRIPTION
# Purpose of PR
The previous type we used in the parameters API would not allow you to read any properties. This PR brings the type in line with the return value of the `getParameters` method. 
<!--
Please describe the purpose of your pull request here. 

What do you want to add? Why do you want to add it? 

What are the use cases?
-->

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
