### PR TITLE
fix: [] Make openNewAsset options param optional

### DIFF
--- a/lib/types/navigator.types.ts
+++ b/lib/types/navigator.types.ts
@@ -53,7 +53,7 @@ export interface NavigatorAPI {
     options?: NavigatorAPIOptions
   ) => Promise<NavigatorOpenResponse<Entry<Fields>>>
   /** Opens a new asset in the current Web App session. */
-  openNewAsset: (options: NavigatorAPIOptions) => Promise<NavigatorOpenResponse<Asset>>
+  openNewAsset: (options?: NavigatorAPIOptions) => Promise<NavigatorOpenResponse<Asset>>
   /** Navigates to a page extension in the current Web App session. Calling without `options` will navigate to the home route of your page extension. */
   openPageExtension: (options?: PageExtensionOptions) => Promise<NavigatorPageResponse>
   /** Navigates to the app's page location. */


### PR DESCRIPTION
# Purpose of PR
`options` param of `openNewAsset` is not optional, but object's internal fields are. That forces to pass empty object if `slideIn` prop not needed. Fixing this.