### PR TITLE
feat: added worflowdefinition type to exported entities and to api.types

### DIFF
--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -8,6 +8,7 @@ import {
   Entry,
   Task,
   Asset,
+  WorkflowDefinition,
 } from './entities'
 import { EntryAPI } from './entry.types'
 import { SpaceAPI } from './space.types'
@@ -141,7 +142,7 @@ export type JSONPatchItem = {
   path: string
   value?: any
 }
-type PatchEntity = Entry | Task | Asset
+type PatchEntity = Entry | Task | Asset | WorkflowDefinition
 
 export interface AccessAPI {
   can(action: 'read' | 'update', entity: 'EditorInterface' | EditorInterface): Promise<boolean>

--- a/lib/types/entities.ts
+++ b/lib/types/entities.ts
@@ -17,6 +17,7 @@ export type {
   TeamProps as Team,
   UploadProps as Upload,
   UserProps as User,
+  WorkflowDefinitionProps as WorkflowDefinition,
 } from 'contentful-management/types'
 
 export interface CanonicalRequest {


### PR DESCRIPTION
# Purpose of PR
In order to call `access.can` inside the workflows marketplace app, we need to update the apps SDK so that `WorkflowDefinition` is typed as a `PatchEntity`
