### PR TITLE
feat: exported workflow definition type

### DIFF
--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -56,6 +56,7 @@ export type {
   Task,
   Team,
   User,
+  WorkflowDefinition,
 } from './entities'
 
 export type { EntryAPI, TaskAPI, TaskInputData } from './entry.types'


### PR DESCRIPTION
# Purpose of PR
Last PR did not export Workflow Definition from the `types/index` file

