### PR TITLE
fix: make ContentEntityType more specific

### DIFF
--- a/lib/types/utils.ts
+++ b/lib/types/utils.ts
@@ -33,7 +33,7 @@ export interface CollectionResponse<T> {
   sys: { type: string }
 }
 
-export type ContentEntityType = 'Entry' | 'Asset' | string
+export type ContentEntityType = 'Entry' | 'Asset'
 
 export interface ContentEntitySys {
   space: Link


### PR DESCRIPTION
# Purpose of PR

The type `ContentEntityType` currently has a value of `'Entry' | 'Asset' | string`, which the TypeScript compiler aggresively reduces to just `string` since both `'Entry'` and `'Asset'` are subtypes of `string`. This PR forces the compiler not to reduce the union, which also makes autocomplete work for the literals we want to allow 🙂 

## Info
There are ways to avoid the reduction by using `string & {}` in the union instead of just `string`. This makes the compiler treat the literals and the string type as separate, since the literals don't inherit from `string & {}`. `type-fest` provides a helper for this type that I've used in this PR.

More information and discussion in this TS issue: https://github.com/microsoft/TypeScript/issues/29729

