### PR TITLE
chore: do not use `npm-read` secret

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,6 @@ jobs:
           TERM: xterm
     steps:
       - checkout
-      - vault/get-secrets:
-          template-preset: "npm-read"
       - run:
           name: Npm Install
           command: npm ci

--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -5,5 +5,4 @@ services:
       - dependabot
   circleci:
     policies:
-      - npm-read
       - semantic-release


### PR DESCRIPTION
# Purpose of PR

It's not required to install the dependencies
