### PR TITLE
chore: use ecosystem bot for releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - checkout
       - vault/get-secrets:
-          template-preset: "semantic-release"
+          template-preset: "semantic-release-ecosystem"
       - run:
           name: Setup NPM
           command: |

--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -5,4 +5,4 @@ services:
       - dependabot
   circleci:
     policies:
-      - semantic-release
+      - semantic-release-ecosystem


### PR DESCRIPTION
We want to use ecosystem-bot instead of wydah-gally