### PR TITLE
chore: remove workflows version number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ jobs:
           command: npm run semantic-release
 
 workflows:
-  version: 2
   # run on every commit
   commit:
     jobs:


### PR DESCRIPTION
`workflows.version` is deprecated since config version 2.1: https://discuss.circleci.com/t/circleci-2-1-config-overview/26057
