### PR TITLE
feat: add field linkType prop

### DIFF
--- a/lib/field-locale.ts
+++ b/lib/field-locale.ts
@@ -7,6 +7,7 @@ export default class FieldLocale implements FieldAPI {
   id: string
   locale: string
   type: string
+  linkType?: string
   required: boolean
   validations: any[]
   items?: Items
@@ -21,6 +22,7 @@ export default class FieldLocale implements FieldAPI {
     this.id = info.id
     this.locale = info.locale
     this.type = info.type
+    this.linkType = info.linkType
     this.required = info.required
     this.validations = info.validations
     this.items = info.items

--- a/lib/field.ts
+++ b/lib/field.ts
@@ -8,6 +8,7 @@ export default class Field implements EntryFieldAPI {
   id: string
   locales: string[]
   type: string
+  linkType?: string
   required: boolean
   validations: Object[]
   items?: Items
@@ -16,6 +17,7 @@ export default class Field implements EntryFieldAPI {
     this.id = info.id
     this.locales = info.locales
     this.type = info.type
+    this.linkType = info.linkType
     this.required = info.required
     this.validations = info.validations
     this.items = info.items
@@ -27,6 +29,7 @@ export default class Field implements EntryFieldAPI {
         const fieldLocale = new FieldLocale(channel, {
           id: info.id,
           type: info.type,
+          linkType: info.linkType,
           required: info.required,
           validations: info.validations,
           items: info.items,

--- a/lib/types/field-locale.types.ts
+++ b/lib/types/field-locale.types.ts
@@ -9,6 +9,8 @@ export interface FieldAPI {
   locale: string
   /** Holds the type of the field the app is attached to. */
   type: string
+  /** Link type of the field if it's a mono reference field */
+  linkType?: string
   /** Indicates if a value for this field is required */
   required: boolean
   /** A list of validations for this field that are defined in the content type. */

--- a/lib/types/field.types.ts
+++ b/lib/types/field.types.ts
@@ -7,6 +7,7 @@ export interface FieldInfo {
   id: string
   locale: string
   type: string
+  linkType?: string
   required: boolean
   validations: ContentTypeFieldValidation[]
   items?: Items
@@ -19,6 +20,7 @@ export interface EntryFieldInfo {
   id: string
   locales: string[]
   type: string
+  linkType?: string
   required: boolean
   validations: ContentTypeFieldValidation[]
   items?: Items
@@ -34,6 +36,8 @@ export interface EntryFieldAPI {
   locales: string[]
   /** Holds the type of the field. */
   type: string
+  /** Link type of the field if it's a mono reference field */
+  linkType?: string
   /** Indicates if a value for this field is required */
   required: boolean
   /** A list of validations for this field that are defined in the content type. */


### PR DESCRIPTION
# Purpose of PR

Expose field name in related APIs for convenience.
For instance, when using the React hook `useSDK` and trying to access the field data, we cannot differentiate between a One Reference field and a One Media field.

<img width="1008" alt="image" src="https://github.com/contentful/ui-extensions-sdk/assets/38511917/2e489708-ab06-4e83-9048-d0360d2fcee4">
