### PR TITLE
feat: adds optional types for parameters [EXT-4381]

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -19,6 +19,7 @@ import {
 import { Channel } from './channel'
 import { createAdapter } from './cmaAdapter'
 import { createCMAClient } from './cma'
+import { KeyValueMap } from 'contentful-management/types'
 
 const DEFAULT_API_PRODUCERS = [
   makeSharedAPI,
@@ -56,7 +57,10 @@ export default function createAPI(
   }, {}) as any
 }
 
-function makeSharedAPI(channel: Channel, data: ConnectMessage): BaseAppSDK {
+function makeSharedAPI(
+  channel: Channel,
+  data: ConnectMessage
+): BaseAppSDK<KeyValueMap, KeyValueMap, never> {
   const { user, parameters, locales, ids, initialContentTypes } = data
   const currentLocation = data.location || locations.LOCATION_ENTRY_FIELD
 

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -79,10 +79,14 @@ export interface LocationAPI {
 
 /* Parameters API */
 
-export interface ParametersAPI {
-  installation: KeyValueMap
-  instance: KeyValueMap
-  invocation?: SerializedJSONValue
+export interface ParametersAPI<
+  InstallationParameters extends KeyValueMap,
+  InstanceParameters extends KeyValueMap,
+  InvocationParameters extends SerializedJSONValue
+> {
+  installation: InstallationParameters
+  instance: InstanceParameters
+  invocation: InvocationParameters
 }
 
 /* IDs */
@@ -212,7 +216,11 @@ export interface AccessAPI {
 
 type EntryScopedIds = 'field' | 'entry' | 'contentType'
 
-export interface BaseAppSDK {
+export interface BaseAppSDK<
+  InstallationParameters extends KeyValueMap,
+  InstanceParameters extends KeyValueMap,
+  InvocationParameters extends SerializedJSONValue
+> {
   /** @deprecated since version 4.0.0 consider using the CMA instead
    * See https://www.contentful.com/developers/docs/extensibility/app-framework/sdk/#using-the-contentful-management-library for more details
    */
@@ -228,7 +236,7 @@ export interface BaseAppSDK {
   /** Methods for displaying notifications. */
   notifier: NotifierAPI
   /** Exposes app configuration parameters */
-  parameters: ParametersAPI
+  parameters: ParametersAPI<InstallationParameters, InstanceParameters, InvocationParameters>
   /** Exposes method to identify app's location */
   location: LocationAPI
   /** Exposes methods for checking user's access level */
@@ -241,13 +249,19 @@ export interface BaseAppSDK {
   cma: CMAClient
 }
 
-export type EditorAppSDK = Omit<BaseAppSDK, 'ids'> &
+export type EditorAppSDK<
+  InstallationParameters extends KeyValueMap = KeyValueMap,
+  InstanceParameters extends KeyValueMap = KeyValueMap
+> = Omit<BaseAppSDK<InstallationParameters, InstanceParameters, never>, 'ids'> &
   SharedEditorSDK & {
     /** A set of IDs for the app */
     ids: Omit<IdsAPI, 'field'>
   }
 
-export type SidebarAppSDK = Omit<BaseAppSDK, 'ids'> &
+export type SidebarAppSDK<
+  InstallationParameters extends KeyValueMap = KeyValueMap,
+  InstanceParameters extends KeyValueMap = KeyValueMap
+> = Omit<BaseAppSDK<InstallationParameters, InstanceParameters, never>, 'ids'> &
   SharedEditorSDK & {
     /** A set of IDs for the app */
     ids: Omit<IdsAPI, 'field'>
@@ -255,7 +269,10 @@ export type SidebarAppSDK = Omit<BaseAppSDK, 'ids'> &
     window: WindowAPI
   }
 
-export type FieldAppSDK = BaseAppSDK &
+export type FieldAppSDK<
+  InstallationParameters extends KeyValueMap = KeyValueMap,
+  InstanceParameters extends KeyValueMap = KeyValueMap
+> = BaseAppSDK<InstallationParameters, InstanceParameters, never> &
   SharedEditorSDK & {
     /** A set of IDs for the app */
     ids: IdsAPI
@@ -265,7 +282,11 @@ export type FieldAppSDK = BaseAppSDK &
     window: WindowAPI
   }
 
-export type DialogAppSDK = Omit<BaseAppSDK, 'ids'> & {
+export type DialogAppSDK<
+  InstallationParameters extends KeyValueMap = KeyValueMap,
+  InstanceParameters extends KeyValueMap = KeyValueMap,
+  InvocationParameters extends SerializedJSONValue = SerializedJSONValue
+> = Omit<BaseAppSDK<InstallationParameters, InstanceParameters, InvocationParameters>, 'ids'> & {
   /** A set of IDs for the app */
   ids: Omit<IdsAPI, EntryScopedIds>
   /** Closes the dialog and resolves openCurrentApp promise with data */
@@ -274,56 +295,70 @@ export type DialogAppSDK = Omit<BaseAppSDK, 'ids'> & {
   window: WindowAPI
 }
 
-export type PageAppSDK = Omit<BaseAppSDK, 'ids'> & {
+export type PageAppSDK<
+  InstallationParameters extends KeyValueMap = KeyValueMap,
+  InstanceParameters extends KeyValueMap = KeyValueMap,
+  InvocationParameters extends SerializedJSONValue = { path: string }
+> = Omit<BaseAppSDK<InstallationParameters, InstanceParameters, InvocationParameters>, 'ids'> & {
   /** A set of IDs actual for the app */
   ids: Omit<IdsAPI, EntryScopedIds>
 }
 
-export type HomeAppSDK = Omit<BaseAppSDK, 'ids'> & {
+export type HomeAppSDK<
+  InstallationParameters extends KeyValueMap = KeyValueMap,
+  InstanceParameters extends KeyValueMap = KeyValueMap
+> = Omit<BaseAppSDK<InstallationParameters, InstanceParameters, never>, 'ids'> & {
   ids: Omit<IdsAPI, EntryScopedIds>
 }
 
-export type ConfigAppSDK = Omit<BaseAppSDK, 'ids'> & {
+export type ConfigAppSDK<
+  InstallationParameters extends KeyValueMap = KeyValueMap,
+  InstanceParameters extends KeyValueMap = KeyValueMap
+> = Omit<BaseAppSDK<InstallationParameters, InstanceParameters, never>, 'ids'> & {
   /** A set of IDs actual for the app */
   ids: Omit<IdsAPI, EntryScopedIds | 'extension' | 'app'> & { app: string }
   app: AppConfigAPI
 }
 
-export type KnownAppSDK =
-  | FieldAppSDK
-  | SidebarAppSDK
-  | DialogAppSDK
-  | EditorAppSDK
-  | PageAppSDK
-  | ConfigAppSDK
-  | HomeAppSDK
+export type KnownAppSDK<
+  InstallationParameters extends KeyValueMap = KeyValueMap,
+  InstanceParameters extends KeyValueMap = KeyValueMap,
+  InvocationParameters extends SerializedJSONValue = SerializedJSONValue
+> =
+  | FieldAppSDK<InstallationParameters, InstanceParameters>
+  | SidebarAppSDK<InstallationParameters, InstanceParameters>
+  | DialogAppSDK<InstallationParameters, InstanceParameters, InvocationParameters>
+  | EditorAppSDK<InstallationParameters, InstanceParameters>
+  | PageAppSDK<InstallationParameters, InstanceParameters, InvocationParameters>
+  | ConfigAppSDK<InstallationParameters, InstanceParameters>
+  | HomeAppSDK<InstallationParameters, InstanceParameters>
 
 /** @deprecated consider using {@link BaseAppSDK} */
-export type BaseExtensionSDK = BaseAppSDK
+export type BaseExtensionSDK = BaseAppSDK<KeyValueMap, KeyValueMap, never>
 
 /** @deprecated consider using {@link EditorAppSDK} */
-export type EditorExtensionSDK = EditorAppSDK
+export type EditorExtensionSDK = EditorAppSDK<KeyValueMap, KeyValueMap>
 
 /** @deprecated consider using {@link SidebarAppSDK} */
-export type SidebarExtensionSDK = SidebarAppSDK
+export type SidebarExtensionSDK = SidebarAppSDK<KeyValueMap, KeyValueMap>
 
 /** @deprecated consider using {@link FieldAppSDK} */
-export type FieldExtensionSDK = FieldAppSDK
+export type FieldExtensionSDK = FieldAppSDK<KeyValueMap, KeyValueMap>
 
 /** @deprecated consider using {@link DialogAppSDK} */
-export type DialogExtensionSDK = DialogAppSDK
+export type DialogExtensionSDK = DialogAppSDK<KeyValueMap, KeyValueMap>
 
 /** @deprecated consider using {@link PageAppSDK} */
-export type PageExtensionSDK = PageAppSDK
+export type PageExtensionSDK = PageAppSDK<KeyValueMap, KeyValueMap, { path: string }>
 
 /** @deprecated consider using {@link HomeAppSDK} */
-export type HomeExtensionSDK = HomeAppSDK
+export type HomeExtensionSDK = HomeAppSDK<KeyValueMap, KeyValueMap>
 
 /** @deprecated consider using {@link ConfigAppSDK} */
-export type AppExtensionSDK = ConfigAppSDK
+export type AppExtensionSDK = ConfigAppSDK<KeyValueMap, KeyValueMap>
 
 /** @deprecated consider using {@link KnownAppSDK} */
-export type KnownSDK = KnownAppSDK
+export type KnownSDK = KnownAppSDK<KeyValueMap, KeyValueMap, SerializedJSONValue>
 
 export interface Locations {
   LOCATION_ENTRY_FIELD: 'entry-field'
@@ -339,7 +374,7 @@ export interface Locations {
 export interface ConnectMessage {
   id: string
   location: Location[keyof Location]
-  parameters: ParametersAPI
+  parameters: ParametersAPI<KeyValueMap, KeyValueMap, never>
   locales: LocalesAPI
   user: UserAPI
   initialContentTypes: ContentType[]

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -284,9 +284,8 @@ export type FieldAppSDK<
 
 export type DialogAppSDK<
   InstallationParameters extends KeyValueMap = KeyValueMap,
-  InstanceParameters extends KeyValueMap = KeyValueMap,
   InvocationParameters extends SerializedJSONValue = SerializedJSONValue
-> = Omit<BaseAppSDK<InstallationParameters, InstanceParameters, InvocationParameters>, 'ids'> & {
+> = Omit<BaseAppSDK<InstallationParameters, never, InvocationParameters>, 'ids'> & {```
   /** A set of IDs for the app */
   ids: Omit<IdsAPI, EntryScopedIds>
   /** Closes the dialog and resolves openCurrentApp promise with data */
@@ -295,26 +294,25 @@ export type DialogAppSDK<
   window: WindowAPI
 }
 
-export type PageAppSDK<
-  InstallationParameters extends KeyValueMap = KeyValueMap,
-  InstanceParameters extends KeyValueMap = KeyValueMap,
-  InvocationParameters extends SerializedJSONValue = { path: string }
-> = Omit<BaseAppSDK<InstallationParameters, InstanceParameters, InvocationParameters>, 'ids'> & {
+export type PageAppSDK<InstallationParameters extends KeyValueMap = KeyValueMap> = Omit<
+  BaseAppSDK<InstallationParameters, never, { path: string }>,
+  'ids'
+> & {
   /** A set of IDs actual for the app */
   ids: Omit<IdsAPI, EntryScopedIds>
 }
 
-export type HomeAppSDK<
-  InstallationParameters extends KeyValueMap = KeyValueMap,
-  InstanceParameters extends KeyValueMap = KeyValueMap
-> = Omit<BaseAppSDK<InstallationParameters, InstanceParameters, never>, 'ids'> & {
+export type HomeAppSDK<InstallationParameters extends KeyValueMap = KeyValueMap> = Omit<
+  BaseAppSDK<InstallationParameters, never, never>,
+  'ids'
+> & {
   ids: Omit<IdsAPI, EntryScopedIds>
 }
 
-export type ConfigAppSDK<
-  InstallationParameters extends KeyValueMap = KeyValueMap,
-  InstanceParameters extends KeyValueMap = KeyValueMap
-> = Omit<BaseAppSDK<InstallationParameters, InstanceParameters, never>, 'ids'> & {
+export type ConfigAppSDK<InstallationParameters extends KeyValueMap = KeyValueMap> = Omit<
+  BaseAppSDK<InstallationParameters, never, never>,
+  'ids'
+> & {
   /** A set of IDs actual for the app */
   ids: Omit<IdsAPI, EntryScopedIds | 'extension' | 'app'> & { app: string }
   app: AppConfigAPI

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -327,11 +327,11 @@ export type KnownAppSDK<
 > =
   | FieldAppSDK<InstallationParameters, InstanceParameters>
   | SidebarAppSDK<InstallationParameters, InstanceParameters>
-  | DialogAppSDK<InstallationParameters, InstanceParameters, InvocationParameters>
+  | DialogAppSDK<InstallationParameters, InvocationParameters>
   | EditorAppSDK<InstallationParameters, InstanceParameters>
-  | PageAppSDK<InstallationParameters, InstanceParameters, InvocationParameters>
-  | ConfigAppSDK<InstallationParameters, InstanceParameters>
-  | HomeAppSDK<InstallationParameters, InstanceParameters>
+  | PageAppSDK<InstallationParameters>
+  | ConfigAppSDK<InstallationParameters>
+  | HomeAppSDK<InstallationParameters>
 
 /** @deprecated consider using {@link BaseAppSDK} */
 export type BaseExtensionSDK = BaseAppSDK<KeyValueMap, KeyValueMap, never>

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -356,7 +356,7 @@ export type HomeExtensionSDK = HomeAppSDK<KeyValueMap, KeyValueMap>
 export type AppExtensionSDK = ConfigAppSDK<KeyValueMap, KeyValueMap>
 
 /** @deprecated consider using {@link KnownAppSDK} */
-export type KnownSDK = KnownAppSDK<KeyValueMap, KeyValueMap, SerializedJSONValue>
+export type KnownSDK = KnownAppSDK
 
 export interface Locations {
   LOCATION_ENTRY_FIELD: 'entry-field'

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -217,9 +217,9 @@ export interface AccessAPI {
 type EntryScopedIds = 'field' | 'entry' | 'contentType'
 
 export interface BaseAppSDK<
-  InstallationParameters extends KeyValueMap,
-  InstanceParameters extends KeyValueMap,
-  InvocationParameters extends SerializedJSONValue
+  InstallationParameters extends KeyValueMap = KeyValueMap,
+  InstanceParameters extends KeyValueMap = KeyValueMap,
+  InvocationParameters extends SerializedJSONValue = SerializedJSONValue
 > {
   /** @deprecated since version 4.0.0 consider using the CMA instead
    * See https://www.contentful.com/developers/docs/extensibility/app-framework/sdk/#using-the-contentful-management-library for more details
@@ -285,7 +285,7 @@ export type FieldAppSDK<
 export type DialogAppSDK<
   InstallationParameters extends KeyValueMap = KeyValueMap,
   InvocationParameters extends SerializedJSONValue = SerializedJSONValue
-> = Omit<BaseAppSDK<InstallationParameters, never, InvocationParameters>, 'ids'> & {```
+> = Omit<BaseAppSDK<InstallationParameters, never, InvocationParameters>, 'ids'> & {
   /** A set of IDs for the app */
   ids: Omit<IdsAPI, EntryScopedIds>
   /** Closes the dialog and resolves openCurrentApp promise with data */
@@ -332,28 +332,28 @@ export type KnownAppSDK<
   | HomeAppSDK<InstallationParameters>
 
 /** @deprecated consider using {@link BaseAppSDK} */
-export type BaseExtensionSDK = BaseAppSDK<KeyValueMap, KeyValueMap, never>
+export type BaseExtensionSDK = BaseAppSDK
 
 /** @deprecated consider using {@link EditorAppSDK} */
-export type EditorExtensionSDK = EditorAppSDK<KeyValueMap, KeyValueMap>
+export type EditorExtensionSDK = EditorAppSDK
 
 /** @deprecated consider using {@link SidebarAppSDK} */
-export type SidebarExtensionSDK = SidebarAppSDK<KeyValueMap, KeyValueMap>
+export type SidebarExtensionSDK = SidebarAppSDK
 
 /** @deprecated consider using {@link FieldAppSDK} */
-export type FieldExtensionSDK = FieldAppSDK<KeyValueMap, KeyValueMap>
+export type FieldExtensionSDK = FieldAppSDK
 
 /** @deprecated consider using {@link DialogAppSDK} */
-export type DialogExtensionSDK = DialogAppSDK<KeyValueMap, KeyValueMap>
+export type DialogExtensionSDK = DialogAppSDK
 
 /** @deprecated consider using {@link PageAppSDK} */
-export type PageExtensionSDK = PageAppSDK<KeyValueMap, KeyValueMap, { path: string }>
+export type PageExtensionSDK = PageAppSDK
 
 /** @deprecated consider using {@link HomeAppSDK} */
-export type HomeExtensionSDK = HomeAppSDK<KeyValueMap, KeyValueMap>
+export type HomeExtensionSDK = HomeAppSDK
 
 /** @deprecated consider using {@link ConfigAppSDK} */
-export type AppExtensionSDK = ConfigAppSDK<KeyValueMap, KeyValueMap>
+export type AppExtensionSDK = ConfigAppSDK
 
 /** @deprecated consider using {@link KnownAppSDK} */
 export type KnownSDK = KnownAppSDK


### PR DESCRIPTION
# Purpose of PR
In TypeScript projects, a lot of errors can be prevented via types. Our parameters API (installation, instance, invocation) use fixed types (KeyValueMap, SerializedJSONValue) that cannot be customized by the developer. The developer knows exactly which values will be persisted for each of these parameters, so we should allow the developer to build perfect types.

Currently, when using the parameters API, you see a lot of @ts-expect-error, @ts-ignore or type assignments.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required

## Screenshots:
![Screenshot 2023-06-21 at 2 38 41 PM](https://github.com/contentful/ui-extensions-sdk/assets/492573/6d757d52-75a3-4c91-9d44-c15c7a896224)
![Screenshot 2023-06-21 at 2 40 17 PM](https://github.com/contentful/ui-extensions-sdk/assets/492573/4cadd05b-a23e-4749-a6dd-96c9cda39018)

## Example usage:

#### ConfigAppSDK:

```
const sdk = useSDK<ConfigAppSDK<{ foo: string }>>();
const foo = sdk.parameters.installation.foo;
```

#### DialogAppSDK:

```
  const sdk = useSDK<DialogAppSDK<KeyValueMap, never, { foo: string }>>();
  const foo = sdk.parameters.invocation.bar;
```