### PR TITLE
[EXT-3204] refactor: Remove XXXExtensionSDK deprecated types

### DIFF
--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -342,33 +342,6 @@ export type KnownAppSDK<
   | ConfigAppSDK<InstallationParameters>
   | HomeAppSDK<InstallationParameters>
 
-/** @deprecated consider using {@link BaseAppSDK} */
-export type BaseExtensionSDK = BaseAppSDK
-
-/** @deprecated consider using {@link EditorAppSDK} */
-export type EditorExtensionSDK = EditorAppSDK
-
-/** @deprecated consider using {@link SidebarAppSDK} */
-export type SidebarExtensionSDK = SidebarAppSDK
-
-/** @deprecated consider using {@link FieldAppSDK} */
-export type FieldExtensionSDK = FieldAppSDK
-
-/** @deprecated consider using {@link DialogAppSDK} */
-export type DialogExtensionSDK = DialogAppSDK
-
-/** @deprecated consider using {@link PageAppSDK} */
-export type PageExtensionSDK = PageAppSDK
-
-/** @deprecated consider using {@link HomeAppSDK} */
-export type HomeExtensionSDK = HomeAppSDK
-
-/** @deprecated consider using {@link ConfigAppSDK} */
-export type AppExtensionSDK = ConfigAppSDK
-
-/** @deprecated consider using {@link KnownAppSDK} */
-export type KnownSDK = KnownAppSDK
-
 export interface ConnectMessage {
   id: string
   location: Locations[keyof Locations]

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,13 +1,4 @@
 export type {
-  AppExtensionSDK,
-  BaseExtensionSDK,
-  DialogExtensionSDK,
-  EditorExtensionSDK,
-  FieldExtensionSDK,
-  HomeExtensionSDK,
-  KnownSDK,
-  PageExtensionSDK,
-  SidebarExtensionSDK,
   ConfigAppSDK,
   BaseAppSDK,
   DialogAppSDK,


### PR DESCRIPTION
# Purpose of PR

Breaking change to remove the previously deprecated XXXExtensionSDK types

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
