### PR TITLE
refactor:  removes extensions from Dialog API [EXT-3595]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# [4.22.0](https://github.com/contentful/ui-extensions-sdk/compare/v4.21.1...v4.22.0) (2023-06-29)
+# [5.0.0](https://github.com/contentful/ui-extensions-sdk/compare/v4.22.0...v5.0.0) (2023-07-07)
 
 ### Features
 
-- [EXT-3599] Bundle contentful-management with app-sdk. (Third attempt) ([#1560](https://github.com/contentful/ui-extensions-sdk/issues/1560)) ([78780b7](https://github.com/contentful/ui-extensions-sdk/commit/78780b715d7e7b4e94a3360a8cf339819c3789ab)), closes [#1548](https://github.com/contentful/ui-extensions-sdk/issues/1548)
+- [EXT-3595] Remove extensions from Dialog API
 
 # [4.22.0-alpha.1](https://github.com/contentful/ui-extensions-sdk/compare/v4.21.1...v4.22.0-alpha.1) (2023-06-29)
 

--- a/lib/dialogs.ts
+++ b/lib/dialogs.ts
@@ -15,9 +15,7 @@ export default function createDialogs(channel: Channel, ids: IdsAPI): DialogsAPI
     openAlert: openSimpleDialog.bind(null, 'alert'),
     openConfirm: openSimpleDialog.bind(null, 'confirm'),
     openPrompt: openSimpleDialog.bind(null, 'prompt'),
-    openExtension: openExtensionDialog,
-    openCurrentApp: openCurrentAppDialog,
-    openCurrent: openCurrentDialog,
+    open: open,
     selectSingleEntry: openEntitySelector.bind(null, 'Entry', false),
     selectSingleAsset: openEntitySelector.bind(null, 'Asset', false),
     selectMultipleEntries: openEntitySelector.bind(null, 'Entry', true),
@@ -28,30 +26,7 @@ export default function createDialogs(channel: Channel, ids: IdsAPI): DialogsAPI
     return channel.call('openDialog', type, prepareOptions(options)) as Promise<any>
   }
 
-  function openExtensionDialog(optionsInput?: OpenCustomWidgetOptions) {
-    let options = prepareOptions(optionsInput)
-
-    // Use provided ID, default to the current extension.
-    options = { ...options, id: options.id || ids.extension }
-    if (options.id) {
-      return channel.call('openDialog', 'extension', options)
-    } else {
-      throw new Error('Extension ID not provided.')
-    }
-  }
-
-  function openCurrentDialog(options?: Omit<OpenCustomWidgetOptions, 'id'>) {
-    if (ids.app) {
-      return openCurrentAppDialog(options)
-    } else {
-      return openExtensionDialog({
-        ...options,
-        id: ids.extension,
-      })
-    }
-  }
-
-  function openCurrentAppDialog(options?: Omit<OpenCustomWidgetOptions, 'id'>) {
+  function open(options?: Omit<OpenCustomWidgetOptions, 'id'>) {
     options = prepareOptions(options)
     if (ids.app) {
       // Force ID of the current app.

--- a/lib/types/dialogs.types.ts
+++ b/lib/types/dialogs.types.ts
@@ -42,14 +42,8 @@ export interface DialogsAPI {
       defaultValue?: string
     }
   ) => Promise<string | boolean>
-  /** Opens an extension in a dialog. */
-  openExtension: (options: OpenCustomWidgetOptions) => Promise<any>
   /** Opens the current app in a dialog */
-  openCurrentApp: (options?: Omit<OpenCustomWidgetOptions, 'id'>) => Promise<any>
-  /** Opens the current app or extension in a dialog */
-  openCurrent: (
-    options?: Omit<OpenCustomWidgetOptions, 'id'> | OpenCustomWidgetOptions
-  ) => Promise<any>
+  open: (options?: Omit<OpenCustomWidgetOptions, 'id'>) => Promise<any>
   /** Opens a dialog for selecting a single entry. */
   selectSingleEntry: <T = Object>(options?: {
     locale?: string

--- a/test/unit/dialogs.spec.ts
+++ b/test/unit/dialogs.spec.ts
@@ -1,4 +1,4 @@
-import { expect, describeChannelCallingMethod } from '../helpers'
+import { describeChannelCallingMethod } from '../helpers'
 
 import createDialogs from '../../lib/dialogs'
 import { Channel } from '../../lib/channel'
@@ -39,36 +39,8 @@ describe('createDialogs()', () => {
     })
 
     describeChannelCallingMethod({
-      creator: (channelStub: Channel) =>
-        createDialogs(channelStub, { extension: 'test-id' } as any),
-      methodName: 'openExtension',
-      channelMethod: 'openDialog',
-      args: [{ test: true }],
-      expectedCallArgs: ['extension', { id: 'test-id', test: true }],
-    })
-
-    describeChannelCallingMethod({
-      creator: (channelStub: Channel) =>
-        createDialogs(channelStub, { extension: 'test-id' } as any),
-      methodName: 'openExtension',
-      channelMethod: 'openDialog',
-      args: [{ test: true, id: 'custom-test-id' }],
-      expectedCallArgs: ['extension', { id: 'custom-test-id', test: true }],
-    })
-
-    describe('.openExtension()', () => {
-      it('throws if no extension ID is provided (no ID option, app location)', () => {
-        const dialogs = createDialogs({ call: () => {} } as any, { app: 'some-app-id' } as any)
-
-        expect(() => {
-          dialogs.openExtension({ test: true } as any)
-        }).to.throw(/Extension ID not provided/)
-      })
-    })
-
-    describeChannelCallingMethod({
       creator: (channelStub: Channel) => createDialogs(channelStub, { app: 'app-id' } as any),
-      methodName: 'openCurrentApp',
+      methodName: 'open',
       channelMethod: 'openDialog',
       args: [{ test: true }],
       expectedCallArgs: ['app', { id: 'app-id', test: true }],
@@ -76,20 +48,10 @@ describe('createDialogs()', () => {
 
     describeChannelCallingMethod({
       creator: (channelStub: Channel) => createDialogs(channelStub, { app: 'app-id' } as any),
-      methodName: 'openCurrentApp',
+      methodName: 'open',
       channelMethod: 'openDialog',
       args: [{ test: true, id: 'try-to-overwrite' }],
       expectedCallArgs: ['app', { id: 'app-id', test: true }],
-    })
-
-    describe('.openCurrentApp()', () => {
-      it('throws if not in app context', () => {
-        const dialogs = createDialogs({ call: () => {} } as any, { extension: 'some-ext' } as any)
-
-        expect(() => {
-          dialogs.openCurrentApp()
-        }).to.throw(/Not in the app context/)
-      })
     })
   })
 })


### PR DESCRIPTION
# Purpose of PR
Removes:

- `dialogs.openExtension`
- `dialogs.openCurrent`

Renames:

- `dialogs.openCurrentApp` to `dialogs.open`

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
