### PR TITLE
Gary/ext 3597/remove extensions from ids api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [5.0.0](https://github.com/contentful/ui-extensions-sdk/compare/v4.22.0...v5.0.0) (2023-07-07)
+
+### Features
+
+- [EXT-3597] Remove extensions from IDs API
+
 # [4.22.0](https://github.com/contentful/ui-extensions-sdk/compare/v4.21.1...v4.22.0) (2023-06-29)
 
 ### Features

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -15,6 +15,7 @@ import {
   JSONPatchItem,
   BaseAppSDK,
   KnownAppSDK,
+  Locations,
 } from './types'
 import { Channel } from './channel'
 import { createAdapter } from './cmaAdapter'
@@ -62,12 +63,14 @@ function makeSharedAPI(
   data: ConnectMessage
 ): BaseAppSDK<KeyValueMap, KeyValueMap, never> {
   const { user, parameters, locales, ids, initialContentTypes } = data
-  const currentLocation = data.location || locations.LOCATION_ENTRY_FIELD
+  const currentLocation: Locations[keyof Locations] =
+    data.location || locations.LOCATION_ENTRY_FIELD
 
   return {
     cma: createCMAClient(ids, channel),
     cmaAdapter: createAdapter(channel),
     location: {
+      current: currentLocation,
       is: (tested: string) => currentLocation === tested,
     },
     user,

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -105,9 +105,8 @@ export interface ParametersAPI<
 
 export interface IdsAPI {
   user: string
-  extension?: string
   organization: string
-  app?: string
+  app: string
   space: string
   environment: string
   environmentAlias?: string
@@ -326,7 +325,7 @@ export type ConfigAppSDK<InstallationParameters extends KeyValueMap = KeyValueMa
   'ids'
 > & {
   /** A set of IDs actual for the app */
-  ids: Omit<IdsAPI, EntryScopedIds | 'extension' | 'app'> & { app: string }
+  ids: Omit<IdsAPI, EntryScopedIds | 'app'> & { app: string }
   app: AppConfigAPI
 }
 

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -72,8 +72,20 @@ export interface NotifierAPI {
 
 /* Location API */
 
+export interface Locations {
+  LOCATION_ENTRY_FIELD: 'entry-field'
+  LOCATION_ENTRY_FIELD_SIDEBAR: 'entry-field-sidebar'
+  LOCATION_ENTRY_SIDEBAR: 'entry-sidebar'
+  LOCATION_DIALOG: 'dialog'
+  LOCATION_ENTRY_EDITOR: 'entry-editor'
+  LOCATION_PAGE: 'page'
+  LOCATION_HOME: 'home'
+  LOCATION_APP_CONFIG: 'app-config'
+}
+
 export interface LocationAPI {
   /** Checks the location in which your app is running */
+  current: Locations[keyof Locations]
   is: (type: string) => boolean
 }
 
@@ -358,20 +370,9 @@ export type AppExtensionSDK = ConfigAppSDK
 /** @deprecated consider using {@link KnownAppSDK} */
 export type KnownSDK = KnownAppSDK
 
-export interface Locations {
-  LOCATION_ENTRY_FIELD: 'entry-field'
-  LOCATION_ENTRY_FIELD_SIDEBAR: 'entry-field-sidebar'
-  LOCATION_ENTRY_SIDEBAR: 'entry-sidebar'
-  LOCATION_DIALOG: 'dialog'
-  LOCATION_ENTRY_EDITOR: 'entry-editor'
-  LOCATION_PAGE: 'page'
-  LOCATION_HOME: 'home'
-  LOCATION_APP_CONFIG: 'app-config'
-}
-
 export interface ConnectMessage {
   id: string
-  location: Location[keyof Location]
+  location: Locations[keyof Locations]
   parameters: ParametersAPI<KeyValueMap, KeyValueMap, never>
   locales: LocalesAPI
   user: UserAPI

--- a/test/unit/api.spec.ts
+++ b/test/unit/api.spec.ts
@@ -71,8 +71,9 @@ function test(expected: string[], location: string | undefined, expectedLocation
   expect(api.notifier).to.have.all.keys(['success', 'error', 'warning'])
   expect(api.access).to.have.all.keys(['can', 'canEditAppConfig'])
 
-  // Test location methods (currently only `is`).
-  expect(Object.keys(api.location)).to.deep.equal(['is'])
+  // Test location API methods (`current` and `is`).
+  expect(Object.keys(api.location)).to.deep.equal(['current', 'is'])
+  expect(api.location.current).to.equal(expectedLocation)
   expect(api.location.is(expectedLocation as string)).to.equal(true)
   expect(api.location.is('wat?')).to.equal(false)
 

--- a/test/unit/cma.spec.ts
+++ b/test/unit/cma.spec.ts
@@ -9,7 +9,7 @@ describe('createCMAClient()', function () {
       environment: 'environment',
       environmentAlias: 'environmentAlias',
       organization: 'organization',
-      extension: 'extension',
+      app: 'app',
       user: 'user',
       field: 'field',
       entry: 'entry',


### PR DESCRIPTION
# Purpose of PR
Removes: `sdk.ids.extension`
Makes `sdk.ids.app` required

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
