### PR TITLE
refactor: removes extensions from IDs API [EXT-3597]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 - [EXT-3498] Adds `location.current` to Locations API
 - [EXT-3595] Remove extensions from Dialog API
+- [EXT-3597] Remove extensions from IDs API
 
-# [4.22.0-alpha.1](https://github.com/contentful/ui-extensions-sdk/compare/v4.21.1...v4.22.0-alpha.1) (2023-06-29)
+# [4.22.0](https://github.com/contentful/ui-extensions-sdk/compare/v4.21.1...v4.22.0) (2023-06-29)
 
 ### Features
 

--- a/lib/navigator.ts
+++ b/lib/navigator.ts
@@ -48,7 +48,7 @@ export default function createNavigator(channel: Channel, ids: IdsAPI): Navigato
     openPageExtension: (opts) => {
       return channel.call('navigateToPage', {
         type: 'extension',
-        id: ids.extension,
+        id: ids.app,
         ...opts,
       }) as Promise<any>
     },

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -105,9 +105,8 @@ export interface ParametersAPI<
 
 export interface IdsAPI {
   user: string
-  extension?: string
   organization: string
-  app?: string
+  app: string
   space: string
   environment: string
   environmentAlias?: string
@@ -326,7 +325,7 @@ export type ConfigAppSDK<InstallationParameters extends KeyValueMap = KeyValueMa
   'ids'
 > & {
   /** A set of IDs actual for the app */
-  ids: Omit<IdsAPI, EntryScopedIds | 'extension' | 'app'> & { app: string }
+  ids: Omit<IdsAPI, EntryScopedIds | 'app'> & { app: string }
   app: AppConfigAPI
 }
 

--- a/test/unit/cma.spec.ts
+++ b/test/unit/cma.spec.ts
@@ -9,7 +9,7 @@ describe('createCMAClient()', function () {
       environment: 'environment',
       environmentAlias: 'environmentAlias',
       organization: 'organization',
-      extension: 'extension',
+      app: 'app',
       user: 'user',
       field: 'field',
       entry: 'entry',


### PR DESCRIPTION
# Purpose of PR
Removes: `sdk.ids.extension`
Makes `sdk.ids.app` required

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
