### PR TITLE
refactor: rename navigator.openCurrentAppPage

### DIFF
--- a/lib/navigator.ts
+++ b/lib/navigator.ts
@@ -52,7 +52,7 @@ export default function createNavigator(channel: Channel, ids: IdsAPI): Navigato
         ...opts,
       }) as Promise<any>
     },
-    openCurrentAppPage: (opts) => {
+    openPage: (opts) => {
       return channel.call('navigateToPage', { type: 'app', id: ids.app, ...opts }) as Promise<any>
     },
     openAppConfig: () => {

--- a/lib/types/navigator.types.ts
+++ b/lib/types/navigator.types.ts
@@ -57,7 +57,7 @@ export interface NavigatorAPI {
   /** Navigates to a page extension in the current Web App session. Calling without `options` will navigate to the home route of your page extension. */
   openPageExtension: (options?: PageExtensionOptions) => Promise<NavigatorPageResponse>
   /** Navigates to the app's page location. */
-  openCurrentAppPage: (options?: AppPageLocationOptions) => Promise<NavigatorPageResponse>
+  openPage: (options?: AppPageLocationOptions) => Promise<NavigatorPageResponse>
   /** Navigates to a bulk entry editor */
   openBulkEditor: (
     entryId: string,

--- a/test/unit/navigator.spec.ts
+++ b/test/unit/navigator.spec.ts
@@ -70,7 +70,7 @@ const SCENARIOS = [
     channelMethod: 'navigateToPage',
   },
   {
-    method: 'openCurrentAppPage',
+    method: 'openPage',
     args: [{ id: 'app-id', page: '/something', type: 'app' }],
     expected: { id: 'app-id', page: '/something', type: 'app' },
     channelMethod: 'navigateToPage',


### PR DESCRIPTION
# Purpose of PR
Renames `navigator.openCurrentAppPage` to `navigator.openPage`

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
