### PR TITLE
feat: [EXT-3593] Do not publish `contentful-ui-extensions-sdk` to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,7 @@ A new package version is automatically published to npm using [semantic-release]
 
 To manually publish the package, run `npm run publish-all`.
 
-This repository is published as two packages with identical data. We recommend using `@contentful/app-sdk`.
-
-- `@contentful/app-sdk`
-- `contentful-ui-extensions-sdk`
+This repository is published as `@contentful/app-sdk` package.
 
 #### Canary releases
 

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -3,36 +3,34 @@ const {
   isCanary,
   restorePackageJson,
   setPackageName,
-  PACKAGES,
+  PACKAGE_NAME,
   MODULE_MAIN_PATH,
   getVersion,
   getTag,
 } = require('./shared')
 
 try {
-  for (const package of PACKAGES) {
-    console.log('')
-    console.log(`📦 Deploying package: ${package}`)
+  console.log('')
+  console.log(`📦 Deploying package: ${PACKAGE_NAME}`)
 
-    const version = getVersion()
-    const tag = getTag(isCanary(version))
+  const version = getVersion()
+  const tag = getTag(isCanary(version))
 
-    console.log(` > 📝 Updating package name...`)
-    setPackageName(package)
+  console.log(` > 📝 Updating package name...`)
+  setPackageName(PACKAGE_NAME)
 
-    console.log(` > 📚 Publishing ${package} on the registry...`)
-    const { status } = spawn.sync('npm', ['publish', '--access', 'public', '--tag', tag], {
-      stdio: 'inherit',
-      cwd: MODULE_MAIN_PATH,
-    })
+  console.log(` > 📚 Publishing ${PACKAGE_NAME} on the registry...`)
+  const { status } = spawn.sync('npm', ['publish', '--access', 'public', '--tag', tag], {
+    stdio: 'inherit',
+    cwd: MODULE_MAIN_PATH,
+  })
 
-    if (status !== 0) {
-      throw new Error(`Failed to publish ${package}`)
-    }
-
-    console.log(`✅ Successfully published ${package}@${getVersion()} on ${tag}!`)
-    console.log('')
+  if (status !== 0) {
+    throw new Error(`Failed to publish ${PACKAGE_NAME}`)
   }
+
+  console.log(`✅ Successfully published ${PACKAGE_NAME}@${getVersion()} on ${tag}!`)
+  console.log('')
 } catch (err) {
   throw new Error(err)
 } finally {

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -2,7 +2,7 @@ const path = require('path')
 const spawn = require('cross-spawn')
 const fs = require('fs')
 
-const PACKAGES = ['contentful-ui-extensions-sdk', '@contentful/app-sdk']
+const PACKAGE_NAME = '@contentful/app-sdk'
 const MODULE_MAIN_PATH = path.resolve(__dirname, '..')
 const PACKAGE_JSON_PATH = path.resolve(MODULE_MAIN_PATH, 'package.json')
 
@@ -33,7 +33,7 @@ function setPackageName(name) {
 }
 
 module.exports = {
-  PACKAGES,
+  PACKAGE_NAME,
   MODULE_MAIN_PATH,
   PACKAGE_JSON_PATH,
   getVersion,

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -4,7 +4,7 @@ const {
   getVersion,
   restorePackageJson,
   setPackageName,
-  PACKAGES,
+  PACKAGE_NAME,
   MODULE_MAIN_PATH,
   getTag,
 } = require('./shared')
@@ -14,33 +14,31 @@ if (!process.env.NPM_TOKEN) {
 }
 
 try {
-  for (const package of PACKAGES) {
-    console.log('')
-    console.log(`📦 Deploying package: ${package} (dry run)`)
+  console.log('')
+  console.log(`📦 Deploying package: ${PACKAGE_NAME} (dry run)`)
 
-    const version = getVersion()
-    const tag = getTag(isCanary(version))
+  const version = getVersion()
+  const tag = getTag(isCanary(version))
 
-    console.log(` > 📝 Updating package name...`)
-    setPackageName(package)
+  console.log(` > 📝 Updating package name...`)
+  setPackageName(PACKAGE_NAME)
 
-    console.log(` > 📚 Publishing ${package} on the registry... (dry run)`)
-    const { status } = spawn.sync(
-      'npm',
-      ['publish', '--access', 'public', '--dry-run', '--tag', tag],
-      {
-        stdio: 'inherit',
-        cwd: MODULE_MAIN_PATH,
-      }
-    )
-
-    if (status !== 0) {
-      throw new Error(`Failed to publish ${package}`)
+  console.log(` > 📚 Publishing ${PACKAGE_NAME} on the registry... (dry run)`)
+  const { status } = spawn.sync(
+    'npm',
+    ['publish', '--access', 'public', '--dry-run', '--tag', tag],
+    {
+      stdio: 'inherit',
+      cwd: MODULE_MAIN_PATH,
     }
+  )
 
-    console.log(`✅ Dry run for ${package} on ${tag} successful!`)
-    console.log('')
+  if (status !== 0) {
+    throw new Error(`Failed to publish ${PACKAGE_NAME}`)
   }
+
+  console.log(`✅ Dry run for ${PACKAGE_NAME} on ${tag} successful!`)
+  console.log('')
 } catch (err) {
   throw new Error(err)
 } finally {


### PR DESCRIPTION
# Purpose of PR
App SDK v5 won't support UI Extensions support and here we are removing related naming from npm package.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
