### PR TITLE
feat: removes legacy UI extension `entry-field-sidebar` location

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -36,7 +36,6 @@ type ProducerFunc = (
 ) => any
 const LOCATION_TO_API_PRODUCERS: { [location: string]: ProducerFunc[] } = {
   [locations.LOCATION_ENTRY_FIELD]: DEFAULT_API_PRODUCERS,
-  [locations.LOCATION_ENTRY_FIELD_SIDEBAR]: DEFAULT_API_PRODUCERS,
   [locations.LOCATION_ENTRY_SIDEBAR]: [makeSharedAPI, makeEntryAPI, makeEditorAPI, makeWindowAPI],
   [locations.LOCATION_ENTRY_EDITOR]: [makeSharedAPI, makeEntryAPI, makeEditorAPI],
   [locations.LOCATION_DIALOG]: [makeSharedAPI, makeDialogAPI, makeWindowAPI],

--- a/lib/locations.ts
+++ b/lib/locations.ts
@@ -2,7 +2,6 @@ import { Locations } from './types'
 
 const locations: Locations = {
   LOCATION_ENTRY_FIELD: 'entry-field',
-  LOCATION_ENTRY_FIELD_SIDEBAR: 'entry-field-sidebar',
   LOCATION_ENTRY_SIDEBAR: 'entry-sidebar',
   LOCATION_DIALOG: 'dialog',
   LOCATION_ENTRY_EDITOR: 'entry-editor',

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -73,7 +73,6 @@ export interface NotifierAPI {
 
 export interface Locations {
   LOCATION_ENTRY_FIELD: 'entry-field'
-  LOCATION_ENTRY_FIELD_SIDEBAR: 'entry-field-sidebar'
   LOCATION_ENTRY_SIDEBAR: 'entry-sidebar'
   LOCATION_DIALOG: 'dialog'
   LOCATION_ENTRY_EDITOR: 'entry-editor'

--- a/test/unit/api.spec.ts
+++ b/test/unit/api.spec.ts
@@ -80,7 +80,7 @@ function test(expected: string[], location: string | undefined, expectedLocation
 }
 
 describe('createAPI()', () => {
-  it('returns correct shape of the default API (entry-field and entry-field-sidebar)', () => {
+  it('returns correct shape of the default API (entry-field)', () => {
     const expected = ['contentType', 'entry', 'field', 'editor', 'window']
 
     // No location, `entry-field` is the default.
@@ -88,9 +88,6 @@ describe('createAPI()', () => {
 
     // `entry-field` provided explicitly.
     test(expected, locations.LOCATION_ENTRY_FIELD)
-
-    // Legacy sidebar extension, has the `entry-field` API.
-    test(expected, locations.LOCATION_ENTRY_FIELD_SIDEBAR)
   })
 
   it('returns correct shape of the sidebar API (entry-sidebar)', () => {


### PR DESCRIPTION
# Purpose of PR

removes legacy UI extension `entry-field-sidebar` location

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
