### PR TITLE
fix: adds missing types for teamMemberships on UserAPI

### DIFF
--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -19,7 +19,7 @@ import { DialogsAPI } from './dialogs.types'
 import { AppConfigAPI } from './app.types'
 import { NavigatorAPI } from './navigator.types'
 import { EntryFieldInfo, FieldInfo } from './field.types'
-import { Adapter, KeyValueMap } from 'contentful-management/types'
+import { Adapter, KeyValueMap, TeamMembership } from 'contentful-management/types'
 import { CMAClient } from './cmaClient.types'
 
 /* User API */
@@ -41,6 +41,10 @@ export interface UserAPI {
     admin: SpaceMembership['admin']
     roles: Pick<Role, 'name' | 'description'>[]
   }
+  teamMemberships: {
+    admin: boolean
+    sys: Pick<TeamMembership['sys'], 'id' | 'type'>
+  }[]
 }
 
 /* Locales API */


### PR DESCRIPTION
# Purpose of PR

adds missing types for `teamMemberships` on UserAPI

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required

![image](https://github.com/contentful/ui-extensions-sdk/assets/492573/13ceb62e-2494-42b6-b3e9-f04772b4cfb2)
