### PR TITLE
fix: node 18.18 for semantic release to work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   unit:
     docker:
-      - image: cimg/node:18.16.1
+      - image: cimg/node:18.18.0
         environment:
           ## this enables colors in the output
           TERM: xterm
@@ -32,11 +32,11 @@ jobs:
 
   semantic-release:
     docker:
-      - image: cimg/node:18.16.1
+      - image: cimg/node:18.18.0
     steps:
       - checkout
       - vault/get-secrets:
-          template-preset: "semantic-release-ecosystem"
+          template-preset: 'semantic-release-ecosystem'
       - run:
           name: Setup NPM
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   unit:
     docker:
-      - image: cimg/node:18.18.0
+      - image: cimg/node:20.6.1
         environment:
           ## this enables colors in the output
           TERM: xterm
@@ -32,7 +32,7 @@ jobs:
 
   semantic-release:
     docker:
-      - image: cimg/node:18.18.0
+      - image: cimg/node:20.6.1
     steps:
       - checkout
       - vault/get-secrets:


### PR DESCRIPTION
# Purpose of PR

Semantic release [has been unhappy](https://app.circleci.com/pipelines/github/contentful/ui-extensions-sdk/15579/workflows/9f634436-58da-45db-a284-7611d80343f2/jobs/26466) about our node version on circle for a week[ and is blocking releases](https://github.com/contentful/ui-extensions-sdk/commits/master)

