### PR TITLE
fix: remove .npmrc at root to fix publish registry [EXT-5905]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 # editors
 .vscode/
 .idea/
+
+# ignore .npmrc so that it does not conflict with setting the registry to publish to in CI
+.npmrc

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@contentful:registry=https://registry.npmjs.org


### PR DESCRIPTION
# Purpose of PR

Removes `.npmrc` at the root to see if the publish step in CI will respect the registry being set [here](https://github.com/contentful/ui-extensions-sdk/blob/main/.circleci/config.yml#L46).

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
