### PR TITLE
feat: [] add taxonomy entities in CMA client

### DIFF
--- a/lib/types/cmaClient.types.ts
+++ b/lib/types/cmaClient.types.ts
@@ -14,6 +14,8 @@ export type CMAClient = {
   bulkAction: PlainClientAPI['bulkAction']
   comment: PlainClientAPI['comment']
   contentType: PlainClientAPI['contentType']
+  concept: PlainClientAPI['concept']
+  conceptScheme: PlainClientAPI['conceptScheme']
   editorInterface: PlainClientAPI['editorInterface']
   environment: Pick<PlainClientAPI['environment'], 'get'>
   environmentAlias: Pick<PlainClientAPI['environmentAlias'], 'get'>

--- a/test/unit/cma.spec.ts
+++ b/test/unit/cma.spec.ts
@@ -19,4 +19,11 @@ describe('createCMAClient()', function () {
     const client = createCMAClient(ids, { addHandler: () => {} } as any)
     expect(client).to.be.an('object')
   })
+
+  it('should have taxonomy methods', () => {
+    const client = createCMAClient({} as any, { addHandler: () => {} } as any)
+
+    expect(client.concept).to.haveOwnProperty('getMany')
+    expect(client.conceptScheme).to.haveOwnProperty('getMany')
+  })
 })


### PR DESCRIPTION
# Purpose of PR

Adds taxonomy entities types in `CMAClient` interface so it properly reflects CMA methods that should be accessible in `BaseAppSDK['cma']`.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
