### PR TITLE
fix: force new release with updated contentful-management []

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.29.5",
       "license": "MIT",
       "dependencies": {
-        "contentful-management": "^11.43.2"
+        "contentful-management": "^11.52.1"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.0",
@@ -3165,10 +3165,9 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "11.52.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.52.0.tgz",
-      "integrity": "sha512-9yRsKCxlcJc94hvNVorvJzyW7OpSVzIYYinlvZRG0HTENyIvhe6r8jMCKcGQTJIPhMe/5wocyUZjYUTJ5VP4ww==",
-      "license": "MIT",
+      "version": "11.52.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.52.1.tgz",
+      "integrity": "sha512-qYypa9HgFJJnRpaxbEeer10cv20QzO1Wo5FD4lGgtZoe2iNWcNObd1RqNYKq01e0KjxjaDB4F7f6J+Z/s6nggg==",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
         "axios": "^1.8.4",
@@ -15627,9 +15626,9 @@
       }
     },
     "contentful-management": {
-      "version": "11.52.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.52.0.tgz",
-      "integrity": "sha512-9yRsKCxlcJc94hvNVorvJzyW7OpSVzIYYinlvZRG0HTENyIvhe6r8jMCKcGQTJIPhMe/5wocyUZjYUTJ5VP4ww==",
+      "version": "11.52.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.52.1.tgz",
+      "integrity": "sha512-qYypa9HgFJJnRpaxbEeer10cv20QzO1Wo5FD4lGgtZoe2iNWcNObd1RqNYKq01e0KjxjaDB4F7f6J+Z/s6nggg==",
       "requires": {
         "@contentful/rich-text-types": "^16.6.1",
         "axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint-staged": "lint-staged"
   },
   "dependencies": {
-    "contentful-management": "^11.43.2"
+    "contentful-management": "^11.52.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.0",


### PR DESCRIPTION
# Purpose of PR

Bump CMA.js to latest release and force a new release of app-sdk with dependabot updates.

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
