### PR TITLE
fix: rename team-tundra -> team-extensibility [EXT-6372]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @contentful/team-tundra @contentful/team-extensibility @contentful/team-marketplace
+* @contentful/team-extensibility @contentful/team-marketplace
 package.json
 package-lock.json

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -28,4 +28,4 @@ spec:
   lifecycle: production
   system: unknown #optional
   # your team name as it appears in github when tagging them for reviews
-  owner: group:team-tundra
+  owner: group:team-extensibility


### PR DESCRIPTION
# Purpose of PR

We recently renamed our team in work day and that finally synced in github.
team-tundra -> team-extensibility

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
