### PR TITLE
chore(ci): [SECURITY-1117] Enable CodeQL scans for GitHub workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,5 @@
 ---
-name: "CodeQL Scan for GitHub Actions Workflow"
+name: "CodeQL Scan for GitHub Actions Workflows"
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze GitHub Actions workflow
+    name: Analyze GitHub Actions workflows
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
Enable CodeQL scans for GitHub workflow.

For more details on why we do this, please refer to https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

After the merge, navigate to the code-scanning findings available under the security tab --> code-scanning