### PR TITLE
Feat/release id [EXT-6547]

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -64,6 +64,8 @@ function makeSharedAPI(
   const { user, parameters, locales, ids, initialContentTypes, hostnames, release } = data
   const currentLocation = data.location || locations.LOCATION_ENTRY_FIELD
 
+  const idsWithRelease = release ? { ...ids, release: release.sys.id } : ids
+
   return {
     cma: createCMAClient(ids, channel),
     cmaAdapter: createAdapter(channel),
@@ -89,7 +91,7 @@ function makeSharedAPI(
       error: (message: string) => channel.send('notify', { type: 'error', message }),
       warning: (message: string) => channel.send('notify', { type: 'warning', message }),
     },
-    ids,
+    ids: idsWithRelease,
     hostnames,
     release,
     access: {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -64,7 +64,7 @@ function makeSharedAPI(
   const { user, parameters, locales, ids, initialContentTypes, hostnames, release } = data
   const currentLocation = data.location || locations.LOCATION_ENTRY_FIELD
 
-  const idsWithRelease = release ? { ...ids, release: release.sys.id } : ids
+  const effectiveIds = release ? { ...ids, release: release.sys.id } : ids
 
   return {
     cma: createCMAClient(ids, channel),
@@ -91,7 +91,7 @@ function makeSharedAPI(
       error: (message: string) => channel.send('notify', { type: 'error', message }),
       warning: (message: string) => channel.send('notify', { type: 'warning', message }),
     },
-    ids: idsWithRelease,
+    ids: effectiveIds,
     hostnames,
     release,
     access: {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -64,8 +64,6 @@ function makeSharedAPI(
   const { user, parameters, locales, ids, initialContentTypes, hostnames, release } = data
   const currentLocation = data.location || locations.LOCATION_ENTRY_FIELD
 
-  const effectiveIds = release ? { ...ids, release: release.sys.id } : ids
-
   return {
     cma: createCMAClient(ids, channel),
     cmaAdapter: createAdapter(channel),
@@ -91,7 +89,7 @@ function makeSharedAPI(
       error: (message: string) => channel.send('notify', { type: 'error', message }),
       warning: (message: string) => channel.send('notify', { type: 'warning', message }),
     },
-    ids: effectiveIds,
+    ids,
     hostnames,
     release,
     access: {

--- a/lib/cma.ts
+++ b/lib/cma.ts
@@ -13,7 +13,6 @@ export function createCMAClient(ids: IdsAPI, channel: Channel): CMAClient {
         environmentId: ids.environmentAlias ?? ids.environment,
         spaceId: ids.space,
         organizationId: ids.organization,
-        // TODO: Shipped in the CMA
         // releaseId: ids.release,
       },
     },

--- a/lib/cma.ts
+++ b/lib/cma.ts
@@ -13,6 +13,8 @@ export function createCMAClient(ids: IdsAPI, channel: Channel): CMAClient {
         environmentId: ids.environmentAlias ?? ids.environment,
         spaceId: ids.space,
         organizationId: ids.organization,
+        // TODO: Shipped in the CMA
+        // releaseId: ids.release,
       },
     },
   )

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -103,6 +103,7 @@ export interface IdsAPI {
   field: string
   entry: string
   contentType: string
+  release?: Release['sys']['id']
 }
 
 /** Hostnames */

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -103,7 +103,7 @@ export interface IdsAPI {
   field: string
   entry: string
   contentType: string
-  release?: Release['sys']['id']
+  release: string
 }
 
 /** Hostnames */


### PR DESCRIPTION
# Purpose of PR

This pull request enhances the `ui-extensions-sdk` to support the "Releases v2" project by ensuring apps are aware of the release context they are operating in. This change specifically addresses ticket [EXT-6547](https://contentful.atlassian.net/browse/EXT-6547).

We are adding the `releaseId` to the `sdk.ids` object when an application is running within a release. This provides developers with a straightforward way to access the current release's ID, enabling them to build release-aware features.

A primary use case for this is to allow an app to fetch data or modify its behavior based on the specific release it's interacting with. This is a foundational requirement for many of the planned features in Releases v2.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required


[EXT-6547]: https://contentful.atlassian.net/browse/EXT-6547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ