### PR TITLE
refactor: use entry data to discriminate release entries in sdk.entry [EXT-6548]

### DIFF
--- a/lib/entry.ts
+++ b/lib/entry.ts
@@ -25,7 +25,7 @@ export default function createEntry(
   let metadata = entryData.metadata
   const metadataChanged = new MemoizedSignal<[Metadata | undefined]>(metadata)
 
-  channel.addHandler('sysChanged', (newSys: EntrySys) => {
+  channel.addHandler('sysChanged', (newSys: EntrySys | ReleaseEntrySys) => {
     sys = newSys
     isReleaseEntry = isReleaseEntrySys(sys)
     sysChanged.dispatch(sys)
@@ -82,5 +82,5 @@ export default function createEntry(
 }
 
 function isReleaseEntrySys(entrySys: EntrySys): entrySys is ReleaseEntrySys {
-  return !!(entrySys as any)?.release?.sys?.id
+  return !!(entrySys as ReleaseEntrySys)?.release?.sys?.id
 }

--- a/lib/entry.ts
+++ b/lib/entry.ts
@@ -1,6 +1,7 @@
 import { Channel } from './channel'
 import { MemoizedSignal } from './signal'
-import { EntryAPI, EntryFieldInfo, EntrySys, Metadata, Release, TaskAPI } from './types'
+import { ConnectMessage, EntryAPI, EntryFieldInfo, EntrySys, Metadata, TaskAPI } from './types'
+import { ReleaseEntrySys } from './types/entry.types'
 import { ExhaustiveEntryFieldAPI } from './types/field.types'
 
 const taskMethods: Array<keyof TaskAPI> = [
@@ -13,18 +14,20 @@ const taskMethods: Array<keyof TaskAPI> = [
 
 export default function createEntry(
   channel: Channel,
-  entryData: any,
+  entryData: ConnectMessage['entry'],
   fieldInfo: EntryFieldInfo[],
   createEntryField: (info: EntryFieldInfo) => ExhaustiveEntryFieldAPI,
-  release?: Release, // It's not possible to determine if an entry is a release entry by inspecting its data alone, so we need to pass the release context here
 ): EntryAPI {
-  let sys = entryData.sys
+  let sys: EntrySys | ReleaseEntrySys = entryData.sys
+  let isReleaseEntry = isReleaseEntrySys(sys)
+
   const sysChanged = new MemoizedSignal<[EntrySys]>(sys)
   let metadata = entryData.metadata
   const metadataChanged = new MemoizedSignal<[Metadata | undefined]>(metadata)
 
-  channel.addHandler('sysChanged', (newSys: Metadata) => {
+  channel.addHandler('sysChanged', (newSys: EntrySys) => {
     sys = newSys
+    isReleaseEntry = isReleaseEntrySys(sys)
     sysChanged.dispatch(sys)
   })
 
@@ -46,13 +49,13 @@ export default function createEntry(
       return sys
     },
     publish(options?: { skipUiValidation?: boolean }) {
-      if (release) {
+      if (isReleaseEntry) {
         throw new Error('SDK method "publish" is not supported in release context')
       }
       return channel.call<void>('callEntryMethod', 'publish', [options])
     },
     unpublish() {
-      if (release) {
+      if (isReleaseEntry) {
         throw new Error('SDK method "unpublish" is not supported in release context')
       }
       return channel.call<void>('callEntryMethod', 'unpublish')
@@ -76,4 +79,8 @@ export default function createEntry(
     },
     ...taskApi,
   }
+}
+
+function isReleaseEntrySys(entrySys: EntrySys): entrySys is ReleaseEntrySys {
+  return !!(entrySys as any)?.release?.sys?.id
 }

--- a/lib/types/entry.types.ts
+++ b/lib/types/entry.types.ts
@@ -25,9 +25,13 @@ export interface TaskAPI {
   deleteTask(task: Task): Promise<void>
 }
 
+export type ReleaseEntrySys = EntrySys & { release: { sys: { id: string } } }
+
 export interface EntryAPI extends TaskAPI {
   /** Returns sys for an entry. */
-  getSys: () => EntrySys
+  // eventually, EntrySys might already provide an optional `release` property, at which point
+  // we can remove ReleaseEntrySys
+  getSys: () => EntrySys | ReleaseEntrySys
   /** Publish the entry */
   publish: (options?: { skipUiValidation?: boolean }) => Promise<void>
   /** Unpublish the entry */

--- a/test/unit/entry.spec.ts
+++ b/test/unit/entry.spec.ts
@@ -6,11 +6,12 @@ import {
 } from '../helpers'
 
 import createEntry from '../../lib/entry'
-import { EntryAPI, EntryFieldInfo, Release } from '../../lib/types'
+import { EntryAPI, EntryFieldInfo, EntrySys } from '../../lib/types'
+import { ReleaseEntrySys } from '../../lib/types/entry.types'
 
 describe('createEntry()', () => {
   describe('returned "entry" object', () => {
-    const entryData = { sys: {} }
+    const entryData = { sys: {} as EntrySys }
     const fieldInfo = [
       {
         id: 'field1',
@@ -129,7 +130,7 @@ describe('createEntry()', () => {
     })
 
     describe('in release context', () => {
-      const release = { sys: { id: 'release-id', type: 'Release' } } as Release
+      const releaseEntryData = { sys: { release: { sys: { id: 'releaseid' } } } as ReleaseEntrySys }
       let releaseEntry: EntryAPI
       let releaseChannelStub: any
       let releaseCreateEntryFieldSpy: any
@@ -143,15 +144,14 @@ describe('createEntry()', () => {
 
         releaseEntry = createEntry(
           releaseChannelStub,
-          entryData,
+          releaseEntryData,
           fieldInfo,
           releaseCreateEntryFieldSpy,
-          release,
         )
       })
 
       it('still returns the sys object', () => {
-        expect(releaseEntry.getSys()).to.equal(entryData.sys)
+        expect(releaseEntry.getSys()).to.equal(releaseEntryData.sys)
       })
 
       it('throws an error when calling publish', () => {


### PR DESCRIPTION
# Purpose of PR

Our initial implementation of ensuring `sdk.entry` behaved "correctly" when used in the context of a release entry depended upon extrinsic context (i.e. the presence of absence of a separate `release` in an additional parameter) vs. intrinsic data (i.e. inspecting `entry` itself and looking for `entry.sys.release.sys.id`. This decision was based partly on an (incorrect) assumption that the entry data provided did not include this data, and using the extra `release` parameter was the only option.

Further research uncovered that the entry data passed to this function _does_ include sys.release, and thus the opportunity exists to provide a more correct implementation.

## Approach

* Update implementation of `createEntry` to use entry data to determine release state vs. `release` param
* Update types to incorporate the concept of a entry sys for release entry that includes the a `Release` link object at `sys.release`.
* Fix a few types that were incorrect

## Learnings

* Several class here -- especially the `Field` class -- have problematic typing. The polymorphic class implementation doesn't play nicely with the discriminated union type of the return type for the entry field function that instantiates the class. A refactor would make things cleaner and allow us type the result more correctly

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
