### PR TITLE
chore: require semantic PR titles (and ignore commmits)

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Only validate the PR title since we squash PRs
+titleOnly: true


### PR DESCRIPTION
# Purpose of PR

We use semantic releases which requires either semantic commit messages or PR titles.

However, because we squash PRs in this repo, commit message lost and are replaced by the PR title.

As a result. our Semantic Pull Requests checker gives us a pass when commit messages are valid even though those changes are lost, resulting in missed release.

## Approach

* The Semantic Pull Requests checker has a [configuration option](https://github.com/contentful/semantic-pull-requests?tab=readme-ov-file#configuration) for only PR titles.

## PR Checklist

- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Typescript typings are added/updated/not required
