### PR TITLE
feat: Add entityInRelease back to navigateToContentEntity channel message object  [EXT-6551]

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -83,7 +83,7 @@ function makeSharedAPI(
     space: createSpace(channel, initialContentTypes),
     dialogs: createDialogs(channel, ids),
     // Typecast because promises returned by navigator methods aren't typed
-    navigator: createNavigator(channel, ids, release || undefined) as NavigatorAPI,
+    navigator: createNavigator(channel, ids, release) as NavigatorAPI,
     notifier: {
       success: (message: string) => channel.send('notify', { type: 'success', message }),
       error: (message: string) => channel.send('notify', { type: 'error', message }),

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -83,7 +83,7 @@ function makeSharedAPI(
     space: createSpace(channel, initialContentTypes),
     dialogs: createDialogs(channel, ids),
     // Typecast because promises returned by navigator methods aren't typed
-    navigator: createNavigator(channel, ids, release) as NavigatorAPI,
+    navigator: createNavigator(channel, ids) as NavigatorAPI,
     notifier: {
       success: (message: string) => channel.send('notify', { type: 'success', message }),
       error: (message: string) => channel.send('notify', { type: 'error', message }),

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -83,7 +83,7 @@ function makeSharedAPI(
     space: createSpace(channel, initialContentTypes),
     dialogs: createDialogs(channel, ids),
     // Typecast because promises returned by navigator methods aren't typed
-    navigator: createNavigator(channel, ids) as NavigatorAPI,
+    navigator: createNavigator(channel, ids, release || undefined) as NavigatorAPI,
     notifier: {
       success: (message: string) => channel.send('notify', { type: 'success', message }),
       error: (message: string) => channel.send('notify', { type: 'error', message }),

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -83,7 +83,7 @@ function makeSharedAPI(
     space: createSpace(channel, initialContentTypes),
     dialogs: createDialogs(channel, ids),
     // Typecast because promises returned by navigator methods aren't typed
-    navigator: createNavigator(channel, ids) as NavigatorAPI,
+    navigator: createNavigator(channel, ids, release) as NavigatorAPI,
     notifier: {
       success: (message: string) => channel.send('notify', { type: 'success', message }),
       error: (message: string) => channel.send('notify', { type: 'error', message }),

--- a/lib/navigator.ts
+++ b/lib/navigator.ts
@@ -84,6 +84,6 @@ export default function createNavigator(
 }
 
 function isEntityInRelease(entityId: string, release: Release | undefined): boolean {
-  const releaseEntities = release?.entities?.items?.map((entity) => entity.sys.id) ?? []
-  return releaseEntities.includes(entityId)
+  const releaseEntityIds = release?.entities?.items?.map((entity) => entity.sys.id) ?? []
+  return releaseEntityIds.includes(entityId)
 }

--- a/lib/navigator.ts
+++ b/lib/navigator.ts
@@ -1,8 +1,13 @@
 import { NavigatorAPI, IdsAPI, NavigatorSlideInfo } from './types'
 import { Channel } from './channel'
 import { Signal } from './signal'
+import { ReleaseProps } from 'contentful-management'
 
-export default function createNavigator(channel: Channel, ids: IdsAPI): NavigatorAPI {
+export default function createNavigator(
+  channel: Channel,
+  ids: IdsAPI,
+  release?: ReleaseProps,
+): NavigatorAPI {
   const _onSlideInSignal = new Signal<[NavigatorSlideInfo]>()
 
   channel.addHandler('navigateSlideIn', (data: any) => {
@@ -11,10 +16,15 @@ export default function createNavigator(channel: Channel, ids: IdsAPI): Navigato
 
   return {
     openEntry: (id, opts) => {
+      let entryInRelease: boolean = false
+      if (release) {
+        entryInRelease = isEntryInRelease(id, release)
+      }
       return channel.call('navigateToContentEntity', {
         ...opts,
         entityType: 'Entry',
         id,
+        entryInRelease,
       }) as Promise<any>
     },
     openNewEntry: (contentTypeId: string, opts) => {
@@ -68,4 +78,9 @@ export default function createNavigator(channel: Channel, ids: IdsAPI): Navigato
       return _onSlideInSignal.attach(handler)
     },
   }
+}
+
+function isEntryInRelease(entryId: string, release: ReleaseProps) {
+  const entryIdsInRelease = release.entities.items.map((item) => item.sys.id)
+  return entryIdsInRelease.includes(entryId)
 }

--- a/lib/navigator.ts
+++ b/lib/navigator.ts
@@ -1,13 +1,8 @@
-import { NavigatorAPI, IdsAPI, NavigatorSlideInfo } from './types'
+import { NavigatorAPI, IdsAPI, NavigatorSlideInfo, NavigatorAPIOptions } from './types'
 import { Channel } from './channel'
 import { Signal } from './signal'
-import { ReleaseProps } from 'contentful-management'
 
-export default function createNavigator(
-  channel: Channel,
-  ids: IdsAPI,
-  release?: ReleaseProps,
-): NavigatorAPI {
+export default function createNavigator(channel: Channel, ids: IdsAPI): NavigatorAPI {
   const _onSlideInSignal = new Signal<[NavigatorSlideInfo]>()
 
   channel.addHandler('navigateSlideIn', (data: any) => {
@@ -15,16 +10,13 @@ export default function createNavigator(
   })
 
   return {
-    openEntry: (id, opts) => {
-      let entryInRelease: boolean = false
-      if (release) {
-        entryInRelease = isEntryInRelease(id, release)
-      }
+    openEntry: (entryId: string, opts: NavigatorAPIOptions | undefined) => {
       return channel.call('navigateToContentEntity', {
         ...opts,
         entityType: 'Entry',
-        id,
-        entryInRelease,
+        // This is the id of the entry to open
+        id: entryId,
+        releaseId: opts?.releaseId,
       }) as Promise<any>
     },
     openNewEntry: (contentTypeId: string, opts) => {
@@ -78,9 +70,4 @@ export default function createNavigator(
       return _onSlideInSignal.attach(handler)
     },
   }
-}
-
-function isEntryInRelease(entryId: string, release: ReleaseProps) {
-  const entryIdsInRelease = release.entities.items.map((item) => item.sys.id)
-  return entryIdsInRelease.includes(entryId)
 }

--- a/lib/types/navigator.types.ts
+++ b/lib/types/navigator.types.ts
@@ -3,8 +3,8 @@ import { Asset, Entry, KeyValueMap } from './entities'
 export interface NavigatorAPIOptions {
   /** use `waitForClose` if you want promise to be resolved only after slide in editor is closed */
   slideIn?: boolean | { waitForClose: boolean }
-  /** If true, the entry will be opened in the release context. */
-  entryInRelease?: boolean
+  /** if provided, the entry will be opened in the release context with the given release id */
+  releaseId?: string
 }
 
 export interface PageExtensionOptions {

--- a/lib/types/navigator.types.ts
+++ b/lib/types/navigator.types.ts
@@ -3,6 +3,8 @@ import { Asset, Entry, KeyValueMap } from './entities'
 export interface NavigatorAPIOptions {
   /** use `waitForClose` if you want promise to be resolved only after slide in editor is closed */
   slideIn?: boolean | { waitForClose: boolean }
+  /** If true, the entry will be opened in the release context. */
+  entryInRelease?: boolean
 }
 
 export interface PageExtensionOptions {

--- a/test/unit/navigator.spec.ts
+++ b/test/unit/navigator.spec.ts
@@ -3,18 +3,22 @@ import { describeChannelCallingMethod, sinon, expect } from '../helpers'
 import createNavigator from '../../lib/navigator'
 import { Channel } from '../../lib/channel'
 import { IdsAPI } from '../../lib/types'
-import { mockRelease, mockReleaseWithoutEntities } from '../mocks/releases'
 
 const SCENARIOS = [
   {
     method: 'openEntry',
     args: ['entry-id'],
-    expected: { entityType: 'Entry', id: 'entry-id', entryInRelease: false },
+    expected: { entityType: 'Entry', id: 'entry-id', releaseId: undefined },
   },
   {
     method: 'openEntry',
     args: ['entry-id', { slideIn: true }],
-    expected: { entityType: 'Entry', id: 'entry-id', slideIn: true, entryInRelease: false },
+    expected: { entityType: 'Entry', id: 'entry-id', slideIn: true, releaseId: undefined },
+  },
+  {
+    method: 'openEntry',
+    args: ['entry-id', { releaseId: 'release-123' }],
+    expected: { entityType: 'Entry', id: 'entry-id', releaseId: 'release-123' },
   },
   {
     method: 'openNewEntry',
@@ -110,7 +114,7 @@ describe('createNavigator()', () => {
     })
   })
 
-  describe('release-aware navigation', () => {
+  describe('releaseId handling', () => {
     let channelStub: any
     let navigator: any
 
@@ -119,347 +123,42 @@ describe('createNavigator()', () => {
         call: sinon.stub(),
         addHandler: sinon.spy(),
       }
-    })
-
-    describe('when release is provided', () => {
-      beforeEach(() => {
-        navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, mockRelease)
-      })
-
-      it('should set entryInRelease to true when entry is in release', () => {
-        navigator.openEntry('entry-1')
-
-        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-          entityType: 'Entry',
-          id: 'entry-1',
-          entryInRelease: true,
-        })
-      })
-
-      it('should set entryInRelease to false when entry is not in release', () => {
-        navigator.openEntry('entry-not-in-release')
-
-        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-          entityType: 'Entry',
-          id: 'entry-not-in-release',
-          entryInRelease: false,
-        })
-      })
-
-      it('should preserve existing options when setting entryInRelease', () => {
-        navigator.openEntry('entry-1', { slideIn: true, customOption: 'value' })
-
-        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-          entityType: 'Entry',
-          id: 'entry-1',
-          slideIn: true,
-          customOption: 'value',
-          entryInRelease: true,
-        })
-      })
-
-      it('should not set entryInRelease for assets', () => {
-        navigator.openAsset('asset-1')
-
-        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-          entityType: 'Asset',
-          id: 'asset-1',
-        })
-      })
-
-      it('should not set entryInRelease for new entries', () => {
-        navigator.openNewEntry('ct-id')
-
-        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-          entityType: 'Entry',
-          id: null,
-          contentTypeId: 'ct-id',
-        })
-      })
-    })
-
-    describe('when release is provided but has no entities', () => {
-      beforeEach(() => {
-        navigator = createNavigator(
-          channelStub,
-          'test-id' as unknown as IdsAPI,
-          mockReleaseWithoutEntities,
-        )
-      })
-
-      it('should set entryInRelease to false for any entry', () => {
-        navigator.openEntry('any-entry-id')
-
-        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-          entityType: 'Entry',
-          id: 'any-entry-id',
-          entryInRelease: false,
-        })
-      })
-    })
-
-    describe('when no release is provided', () => {
-      beforeEach(() => {
-        navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI)
-      })
-
-      it('should set entryInRelease to false for entries', () => {
-        navigator.openEntry('entry-1')
-
-        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-          entityType: 'Entry',
-          id: 'entry-1',
-          entryInRelease: false,
-        })
-      })
-
-      it('should not set entryInRelease for assets', () => {
-        navigator.openAsset('asset-1')
-
-        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-          entityType: 'Asset',
-          id: 'asset-1',
-        })
-      })
-    })
-  })
-
-  describe('isEntryInRelease function', () => {
-    let channelStub: any
-    let navigator: any
-
-    beforeEach(() => {
-      channelStub = {
-        call: sinon.stub(),
-        addHandler: sinon.spy(),
-      }
-    })
-
-    it('should correctly identify entries in release', () => {
-      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, mockRelease)
-
-      // Test with entry that exists in release
-      navigator.openEntry('entry-1')
-      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Entry',
-        id: 'entry-1',
-        entryInRelease: true,
-      })
-    })
-
-    it('should correctly identify entries not in release', () => {
-      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, mockRelease)
-
-      // Test with entry that doesn't exist in release
-      navigator.openEntry('non-existent-entry')
-      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Entry',
-        id: 'non-existent-entry',
-        entryInRelease: false,
-      })
-    })
-
-    it('should handle case-sensitive entry IDs', () => {
-      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, mockRelease)
-
-      // Test with case variation
-      navigator.openEntry('ENTRY-1')
-      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Entry',
-        id: 'ENTRY-1',
-        entryInRelease: false,
-      })
-    })
-  })
-
-  describe('release parameter handling', () => {
-    let channelStub: any
-    let navigator: any
-
-    beforeEach(() => {
-      channelStub = {
-        call: sinon.stub(),
-        addHandler: sinon.spy(),
-      }
-    })
-
-    it('should work with undefined release', () => {
       navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI)
+    })
 
+    it('should pass releaseId when provided in options', () => {
+      navigator.openEntry('entry-1', { releaseId: 'release-123' })
+
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Entry',
+        id: 'entry-1',
+        releaseId: 'release-123',
+      })
+    })
+
+    it('should set releaseId to undefined when not provided', () => {
       navigator.openEntry('entry-1')
-      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Entry',
-        id: 'entry-1',
-        entryInRelease: false,
-      })
-    })
-
-    it('should work with null release', () => {
-      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, null as any)
-
-      navigator.openEntry('entry-1')
-      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Entry',
-        id: 'entry-1',
-        entryInRelease: false,
-      })
-    })
-
-    it('should work with empty release entities', () => {
-      navigator = createNavigator(
-        channelStub,
-        'test-id' as unknown as IdsAPI,
-        mockReleaseWithoutEntities,
-      )
-
-      navigator.openEntry('any-entry')
-      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Entry',
-        id: 'any-entry',
-        entryInRelease: false,
-      })
-    })
-  })
-
-  describe('method-specific behavior', () => {
-    let channelStub: any
-    let navigator: any
-
-    beforeEach(() => {
-      channelStub = {
-        call: sinon.stub(),
-        addHandler: sinon.spy(),
-      }
-      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, mockRelease)
-    })
-
-    it('should only set entryInRelease for openEntry method', () => {
-      // openEntry should have entryInRelease
-      navigator.openEntry('entry-1')
-      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Entry',
-        id: 'entry-1',
-        entryInRelease: true,
-      })
-
-      // Reset stub
-      channelStub.call.reset()
-
-      // openNewEntry should not have entryInRelease
-      navigator.openNewEntry('ct-id')
-      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Entry',
-        id: null,
-        contentTypeId: 'ct-id',
-      })
-
-      // Reset stub
-      channelStub.call.reset()
-
-      // openAsset should not have entryInRelease
-      navigator.openAsset('asset-1')
-      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Asset',
-        id: 'asset-1',
-      })
-
-      // Reset stub
-      channelStub.call.reset()
-
-      // openNewAsset should not have entryInRelease
-      navigator.openNewAsset()
-      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Asset',
-        id: null,
-      })
-    })
-
-    it('should preserve all existing options when adding entryInRelease', () => {
-      const options = {
-        slideIn: { waitForClose: true },
-        customOption: 'test-value',
-        anotherOption: 123,
-      }
-
-      navigator.openEntry('entry-1', options)
 
       expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
         entityType: 'Entry',
         id: 'entry-1',
-        slideIn: { waitForClose: true },
-        customOption: 'test-value',
-        anotherOption: 123,
-        entryInRelease: true,
+        releaseId: undefined,
       })
     })
-  })
 
-  describe('edge cases', () => {
-    let channelStub: any
-    let navigator: any
+    it('should preserve existing options when setting releaseId', () => {
+      navigator.openEntry('entry-1', {
+        slideIn: true,
+        releaseId: 'release-123',
+        customOption: 'value',
+      })
 
-    beforeEach(() => {
-      channelStub = {
-        call: sinon.stub(),
-        addHandler: sinon.spy(),
-      }
-    })
-
-    it('should handle malformed release data gracefully', () => {
-      const malformedRelease = {
-        ...mockRelease,
-        entities: {
-          sys: { type: 'Array' },
-          items: [
-            { sys: { type: 'Link', linkType: 'Entry', id: 'entry-1' } },
-            { sys: { type: 'Link', linkType: 'Entry' } }, // Missing id
-            { sys: { type: 'Link', linkType: 'Entry', id: null } }, // Null id
-          ],
-        },
-      }
-
-      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, malformedRelease)
-
-      // Should still work with valid entry
-      navigator.openEntry('entry-1')
       expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
         entityType: 'Entry',
         id: 'entry-1',
-        entryInRelease: true,
-      })
-
-      // Reset stub
-      channelStub.call.reset()
-
-      // Should handle invalid entries gracefully
-      navigator.openEntry('valid-entry')
-      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Entry',
-        id: 'valid-entry',
-        entryInRelease: false,
-      })
-    })
-
-    it('should handle release with non-entry entities', () => {
-      const releaseWithAssets = {
-        ...mockRelease,
-        entities: {
-          sys: { type: 'Array' },
-          items: [
-            { sys: { type: 'Link', linkType: 'Asset', id: 'asset-1' } },
-            { sys: { type: 'Link', linkType: 'Entry', id: 'entry-1' } },
-          ],
-        },
-      }
-
-      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, releaseWithAssets)
-
-      // Entry should still be detected
-      navigator.openEntry('entry-1')
-      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Entry',
-        id: 'entry-1',
-        entryInRelease: true,
+        slideIn: true,
+        releaseId: 'release-123',
+        customOption: 'value',
       })
     })
   })

--- a/test/unit/navigator.spec.ts
+++ b/test/unit/navigator.spec.ts
@@ -1,19 +1,20 @@
-import { describeChannelCallingMethod } from '../helpers'
+import { describeChannelCallingMethod, sinon, expect } from '../helpers'
 
 import createNavigator from '../../lib/navigator'
 import { Channel } from '../../lib/channel'
 import { IdsAPI } from '../../lib/types'
+import { mockRelease, mockReleaseWithoutEntities } from '../mocks/releases'
 
 const SCENARIOS = [
   {
     method: 'openEntry',
     args: ['entry-id'],
-    expected: { entityType: 'Entry', id: 'entry-id' },
+    expected: { entityType: 'Entry', id: 'entry-id', entryInRelease: false },
   },
   {
     method: 'openEntry',
     args: ['entry-id', { slideIn: true }],
-    expected: { entityType: 'Entry', id: 'entry-id', slideIn: true },
+    expected: { entityType: 'Entry', id: 'entry-id', slideIn: true, entryInRelease: false },
   },
   {
     method: 'openNewEntry',
@@ -105,6 +106,360 @@ describe('createNavigator()', () => {
         channelMethod,
         args,
         expectedCallArgs: expected,
+      })
+    })
+  })
+
+  describe('release-aware navigation', () => {
+    let channelStub: any
+    let navigator: any
+
+    beforeEach(() => {
+      channelStub = {
+        call: sinon.stub(),
+        addHandler: sinon.spy(),
+      }
+    })
+
+    describe('when release is provided', () => {
+      beforeEach(() => {
+        navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, mockRelease)
+      })
+
+      it('should set entryInRelease to true when entry is in release', () => {
+        navigator.openEntry('entry-1')
+
+        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+          entityType: 'Entry',
+          id: 'entry-1',
+          entryInRelease: true,
+        })
+      })
+
+      it('should set entryInRelease to false when entry is not in release', () => {
+        navigator.openEntry('entry-not-in-release')
+
+        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+          entityType: 'Entry',
+          id: 'entry-not-in-release',
+          entryInRelease: false,
+        })
+      })
+
+      it('should preserve existing options when setting entryInRelease', () => {
+        navigator.openEntry('entry-1', { slideIn: true, customOption: 'value' })
+
+        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+          entityType: 'Entry',
+          id: 'entry-1',
+          slideIn: true,
+          customOption: 'value',
+          entryInRelease: true,
+        })
+      })
+
+      it('should not set entryInRelease for assets', () => {
+        navigator.openAsset('asset-1')
+
+        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+          entityType: 'Asset',
+          id: 'asset-1',
+        })
+      })
+
+      it('should not set entryInRelease for new entries', () => {
+        navigator.openNewEntry('ct-id')
+
+        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+          entityType: 'Entry',
+          id: null,
+          contentTypeId: 'ct-id',
+        })
+      })
+    })
+
+    describe('when release is provided but has no entities', () => {
+      beforeEach(() => {
+        navigator = createNavigator(
+          channelStub,
+          'test-id' as unknown as IdsAPI,
+          mockReleaseWithoutEntities,
+        )
+      })
+
+      it('should set entryInRelease to false for any entry', () => {
+        navigator.openEntry('any-entry-id')
+
+        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+          entityType: 'Entry',
+          id: 'any-entry-id',
+          entryInRelease: false,
+        })
+      })
+    })
+
+    describe('when no release is provided', () => {
+      beforeEach(() => {
+        navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI)
+      })
+
+      it('should set entryInRelease to false for entries', () => {
+        navigator.openEntry('entry-1')
+
+        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+          entityType: 'Entry',
+          id: 'entry-1',
+          entryInRelease: false,
+        })
+      })
+
+      it('should not set entryInRelease for assets', () => {
+        navigator.openAsset('asset-1')
+
+        expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+          entityType: 'Asset',
+          id: 'asset-1',
+        })
+      })
+    })
+  })
+
+  describe('isEntryInRelease function', () => {
+    let channelStub: any
+    let navigator: any
+
+    beforeEach(() => {
+      channelStub = {
+        call: sinon.stub(),
+        addHandler: sinon.spy(),
+      }
+    })
+
+    it('should correctly identify entries in release', () => {
+      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, mockRelease)
+
+      // Test with entry that exists in release
+      navigator.openEntry('entry-1')
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Entry',
+        id: 'entry-1',
+        entryInRelease: true,
+      })
+    })
+
+    it('should correctly identify entries not in release', () => {
+      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, mockRelease)
+
+      // Test with entry that doesn't exist in release
+      navigator.openEntry('non-existent-entry')
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Entry',
+        id: 'non-existent-entry',
+        entryInRelease: false,
+      })
+    })
+
+    it('should handle case-sensitive entry IDs', () => {
+      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, mockRelease)
+
+      // Test with case variation
+      navigator.openEntry('ENTRY-1')
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Entry',
+        id: 'ENTRY-1',
+        entryInRelease: false,
+      })
+    })
+  })
+
+  describe('release parameter handling', () => {
+    let channelStub: any
+    let navigator: any
+
+    beforeEach(() => {
+      channelStub = {
+        call: sinon.stub(),
+        addHandler: sinon.spy(),
+      }
+    })
+
+    it('should work with undefined release', () => {
+      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI)
+
+      navigator.openEntry('entry-1')
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Entry',
+        id: 'entry-1',
+        entryInRelease: false,
+      })
+    })
+
+    it('should work with null release', () => {
+      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, null as any)
+
+      navigator.openEntry('entry-1')
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Entry',
+        id: 'entry-1',
+        entryInRelease: false,
+      })
+    })
+
+    it('should work with empty release entities', () => {
+      navigator = createNavigator(
+        channelStub,
+        'test-id' as unknown as IdsAPI,
+        mockReleaseWithoutEntities,
+      )
+
+      navigator.openEntry('any-entry')
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Entry',
+        id: 'any-entry',
+        entryInRelease: false,
+      })
+    })
+  })
+
+  describe('method-specific behavior', () => {
+    let channelStub: any
+    let navigator: any
+
+    beforeEach(() => {
+      channelStub = {
+        call: sinon.stub(),
+        addHandler: sinon.spy(),
+      }
+      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, mockRelease)
+    })
+
+    it('should only set entryInRelease for openEntry method', () => {
+      // openEntry should have entryInRelease
+      navigator.openEntry('entry-1')
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Entry',
+        id: 'entry-1',
+        entryInRelease: true,
+      })
+
+      // Reset stub
+      channelStub.call.reset()
+
+      // openNewEntry should not have entryInRelease
+      navigator.openNewEntry('ct-id')
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Entry',
+        id: null,
+        contentTypeId: 'ct-id',
+      })
+
+      // Reset stub
+      channelStub.call.reset()
+
+      // openAsset should not have entryInRelease
+      navigator.openAsset('asset-1')
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Asset',
+        id: 'asset-1',
+      })
+
+      // Reset stub
+      channelStub.call.reset()
+
+      // openNewAsset should not have entryInRelease
+      navigator.openNewAsset()
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Asset',
+        id: null,
+      })
+    })
+
+    it('should preserve all existing options when adding entryInRelease', () => {
+      const options = {
+        slideIn: { waitForClose: true },
+        customOption: 'test-value',
+        anotherOption: 123,
+      }
+
+      navigator.openEntry('entry-1', options)
+
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Entry',
+        id: 'entry-1',
+        slideIn: { waitForClose: true },
+        customOption: 'test-value',
+        anotherOption: 123,
+        entryInRelease: true,
+      })
+    })
+  })
+
+  describe('edge cases', () => {
+    let channelStub: any
+    let navigator: any
+
+    beforeEach(() => {
+      channelStub = {
+        call: sinon.stub(),
+        addHandler: sinon.spy(),
+      }
+    })
+
+    it('should handle malformed release data gracefully', () => {
+      const malformedRelease = {
+        ...mockRelease,
+        entities: {
+          sys: { type: 'Array' },
+          items: [
+            { sys: { type: 'Link', linkType: 'Entry', id: 'entry-1' } },
+            { sys: { type: 'Link', linkType: 'Entry' } }, // Missing id
+            { sys: { type: 'Link', linkType: 'Entry', id: null } }, // Null id
+          ],
+        },
+      }
+
+      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, malformedRelease)
+
+      // Should still work with valid entry
+      navigator.openEntry('entry-1')
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Entry',
+        id: 'entry-1',
+        entryInRelease: true,
+      })
+
+      // Reset stub
+      channelStub.call.reset()
+
+      // Should handle invalid entries gracefully
+      navigator.openEntry('valid-entry')
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Entry',
+        id: 'valid-entry',
+        entryInRelease: false,
+      })
+    })
+
+    it('should handle release with non-entry entities', () => {
+      const releaseWithAssets = {
+        ...mockRelease,
+        entities: {
+          sys: { type: 'Array' },
+          items: [
+            { sys: { type: 'Link', linkType: 'Asset', id: 'asset-1' } },
+            { sys: { type: 'Link', linkType: 'Entry', id: 'entry-1' } },
+          ],
+        },
+      }
+
+      navigator = createNavigator(channelStub, 'test-id' as unknown as IdsAPI, releaseWithAssets)
+
+      // Entry should still be detected
+      navigator.openEntry('entry-1')
+      expect(channelStub.call).to.have.been.calledWith('navigateToContentEntity', {
+        entityType: 'Entry',
+        id: 'entry-1',
+        entryInRelease: true,
       })
     })
   })


### PR DESCRIPTION
add back entityInRelease to make user_interface know if the entity should be opened in release context or not.
