### PR TITLE
feat(navigator): enhance navigation methods to include releaseId [EXT_6551]

### DIFF
--- a/lib/navigator.ts
+++ b/lib/navigator.ts
@@ -27,6 +27,7 @@ export default function createNavigator(
         // This is the id of the entry to open
         id: entryId,
         entityInRelease,
+        // releaseId coming from user to open from entry in, not from release itself
         releaseId: opts?.releaseId,
       }) as Promise<any>
     },
@@ -56,6 +57,7 @@ export default function createNavigator(
         entityType: 'Asset',
         id,
         entityInRelease,
+        // releaseId coming from user to open from asset in, not from release itself
         releaseId: opts?.releaseId,
       }) as Promise<any>
     },

--- a/lib/navigator.ts
+++ b/lib/navigator.ts
@@ -36,6 +36,7 @@ export default function createNavigator(
         entityType: 'Entry',
         id: null,
         contentTypeId,
+        releaseId: release?.sys?.id,
       }) as Promise<any>
     },
     openBulkEditor: (entryId: string, opts) => {
@@ -45,10 +46,17 @@ export default function createNavigator(
       }) as Promise<any>
     },
     openAsset: (id, opts) => {
+      let entityInRelease: boolean = false
+
+      if (release) {
+        entityInRelease = isEntityInRelease(id, release)
+      }
       return channel.call('navigateToContentEntity', {
         ...opts,
         entityType: 'Asset',
         id,
+        entityInRelease,
+        releaseId: opts?.releaseId,
       }) as Promise<any>
     },
     openNewAsset: (opts) => {
@@ -56,6 +64,7 @@ export default function createNavigator(
         ...opts,
         entityType: 'Asset',
         id: null,
+        releaseId: release?.sys?.id,
       }) as Promise<any>
     },
     openPageExtension: (opts) => {
@@ -72,10 +81,16 @@ export default function createNavigator(
       return channel.call('navigateToAppConfig') as Promise<void>
     },
     openEntriesList: () => {
-      return channel.call('navigateToSpaceEnvRoute', { route: 'entries' }) as Promise<void>
+      return channel.call('navigateToSpaceEnvRoute', {
+        route: 'entries',
+        releaseId: release?.sys?.id,
+      }) as Promise<void>
     },
     openAssetsList: () => {
-      return channel.call('navigateToSpaceEnvRoute', { route: 'assets' }) as Promise<void>
+      return channel.call('navigateToSpaceEnvRoute', {
+        route: 'assets',
+        releaseId: release?.sys?.id,
+      }) as Promise<void>
     },
     onSlideInNavigation: (handler) => {
       return _onSlideInSignal.attach(handler)


### PR DESCRIPTION
…entityInRelease

- Updated `createNavigator` to pass `releaseId` and `entityInRelease` to various navigation methods, including `openEntry`, `openAsset`, `openNewEntry`, `openNewAsset`, `openEntriesList`, and `openAssetsList`.

- Enhanced unit tests to validate the behavior of these methods with respect to the release context, ensuring correct handling of entries and assets in relation to the provided release.

- Added scenarios to test the inclusion of `releaseId` and the determination of `entityInRelease` based on the presence of the release.
