### PR TITLE
feat(navigator): add entityInRelease flag to NavigatorAPIOptions [EXT-6551]

### DIFF
--- a/lib/types/navigator.types.ts
+++ b/lib/types/navigator.types.ts
@@ -5,6 +5,8 @@ export interface NavigatorAPIOptions {
   slideIn?: boolean | { waitForClose: boolean }
   /** if provided, the entry will be opened in the release context with the given release id */
   releaseId?: string
+  /** indicates whether the entity is part of the current release */
+  entityInRelease?: boolean
 }
 
 export interface PageExtensionOptions {


### PR DESCRIPTION
- Introduced the `entityInRelease` optional property to the `NavigatorAPIOptions` interface, indicating whether an entity is part of the current release. This enhancement supports improved navigation context handling in relation to releases.

