### PR TITLE
refactor(navigator): remove releaseId from navigation methods [EXT-6551]

### DIFF
--- a/lib/navigator.ts
+++ b/lib/navigator.ts
@@ -27,7 +27,7 @@ export default function createNavigator(
         // This is the id of the entry to open
         id: entryId,
         entityInRelease,
-        // releaseId coming from user to open from entry in, not from release itself
+        // releaseId coming from user to open an entry in, not from release itself
         releaseId: opts?.releaseId,
       }) as Promise<any>
     },
@@ -37,7 +37,6 @@ export default function createNavigator(
         entityType: 'Entry',
         id: null,
         contentTypeId,
-        releaseId: release?.sys?.id,
       }) as Promise<any>
     },
     openBulkEditor: (entryId: string, opts) => {
@@ -57,7 +56,7 @@ export default function createNavigator(
         entityType: 'Asset',
         id,
         entityInRelease,
-        // releaseId coming from user to open from asset in, not from release itself
+        // releaseId coming from user to open an asset in, not from release itself
         releaseId: opts?.releaseId,
       }) as Promise<any>
     },
@@ -66,7 +65,6 @@ export default function createNavigator(
         ...opts,
         entityType: 'Asset',
         id: null,
-        releaseId: release?.sys?.id,
       }) as Promise<any>
     },
     openPageExtension: (opts) => {

--- a/test/unit/navigator.spec.ts
+++ b/test/unit/navigator.spec.ts
@@ -34,7 +34,7 @@ const SCENARIOS = [
   {
     method: 'openNewEntry',
     args: ['ct-id'],
-    expected: { entityType: 'Entry', id: null, contentTypeId: 'ct-id', releaseId: undefined },
+    expected: { entityType: 'Entry', id: null, contentTypeId: 'ct-id' },
   },
   {
     method: 'openNewEntry',
@@ -44,7 +44,6 @@ const SCENARIOS = [
       id: null,
       contentTypeId: 'ct-id',
       slideIn: true,
-      releaseId: undefined,
     },
   },
   {
@@ -76,12 +75,12 @@ const SCENARIOS = [
   {
     method: 'openNewAsset',
     args: [],
-    expected: { entityType: 'Asset', id: null, releaseId: undefined },
+    expected: { entityType: 'Asset', id: null },
   },
   {
     method: 'openNewAsset',
     args: [{ slideIn: true }],
-    expected: { entityType: 'Asset', id: null, slideIn: true, releaseId: undefined },
+    expected: { entityType: 'Asset', id: null, slideIn: true },
   },
   {
     method: 'openPageExtension',
@@ -312,52 +311,6 @@ describe('createNavigator()', () => {
         id: 'asset-id',
         entityInRelease: false,
         releaseId: 'custom-release-id',
-      })
-    })
-
-    it('should include releaseId in openNewEntry when release is provided', () => {
-      const navigator = createNavigator(channel, ids, mockRelease)
-
-      navigator.openNewEntry('ct-id')
-      expect(channel.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Entry',
-        id: null,
-        contentTypeId: 'ct-id',
-        releaseId: 'release-123',
-      })
-    })
-
-    it('should not include releaseId in openNewEntry when release is undefined', () => {
-      const navigator = createNavigator(channel, ids, undefined)
-
-      navigator.openNewEntry('ct-id')
-      expect(channel.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Entry',
-        id: null,
-        contentTypeId: 'ct-id',
-        releaseId: undefined,
-      })
-    })
-
-    it('should include releaseId in openNewAsset when release is provided', () => {
-      const navigator = createNavigator(channel, ids, mockRelease)
-
-      navigator.openNewAsset()
-      expect(channel.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Asset',
-        id: null,
-        releaseId: 'release-123',
-      })
-    })
-
-    it('should not include releaseId in openNewAsset when release is undefined', () => {
-      const navigator = createNavigator(channel, ids, undefined)
-
-      navigator.openNewAsset()
-      expect(channel.call).to.have.been.calledWith('navigateToContentEntity', {
-        entityType: 'Asset',
-        id: null,
-        releaseId: undefined,
       })
     })
 


### PR DESCRIPTION
- Removed the `releaseId` parameter from the `openEntry` and `openAsset` methods in the navigator api since the UX for this method is the same regardless of release context 
