### PR TITLE
feat: streamline release handling in navigation methods [EXT-6551]

### DIFF
--- a/lib/navigator.ts
+++ b/lib/navigator.ts
@@ -13,22 +13,16 @@ export default function createNavigator(
     _onSlideInSignal.dispatch(data)
   })
 
+  const releaseId = release ? release.sys?.id : undefined
+
   return {
     openEntry: (entryId: string, opts: NavigatorAPIOptions | undefined) => {
-      let entityInRelease: boolean = false
-
-      if (release) {
-        entityInRelease = isEntityInRelease(entryId, release)
-      }
-
       return channel.call('navigateToContentEntity', {
         ...opts,
         entityType: 'Entry',
         // This is the id of the entry to open
         id: entryId,
-        entityInRelease,
-        // releaseId coming from user to open an entry in, not from release itself.
-        releaseId: opts?.releaseId,
+        releaseId,
       }) as Promise<any>
     },
     openNewEntry: (contentTypeId: string, opts) => {
@@ -46,18 +40,11 @@ export default function createNavigator(
       }) as Promise<any>
     },
     openAsset: (id, opts) => {
-      let entityInRelease: boolean = false
-
-      if (release) {
-        entityInRelease = isEntityInRelease(id, release)
-      }
       return channel.call('navigateToContentEntity', {
         ...opts,
         entityType: 'Asset',
         id,
-        entityInRelease,
-        // releaseId coming from user to open an asset in, not from release itself.
-        releaseId: opts?.releaseId,
+        releaseId,
       }) as Promise<any>
     },
     openNewAsset: (opts) => {
@@ -83,22 +70,17 @@ export default function createNavigator(
     openEntriesList: () => {
       return channel.call('navigateToSpaceEnvRoute', {
         route: 'entries',
-        releaseId: release?.sys?.id,
+        releaseId,
       }) as Promise<void>
     },
     openAssetsList: () => {
       return channel.call('navigateToSpaceEnvRoute', {
         route: 'assets',
-        releaseId: release?.sys?.id,
+        releaseId,
       }) as Promise<void>
     },
     onSlideInNavigation: (handler) => {
       return _onSlideInSignal.attach(handler)
     },
   }
-}
-
-function isEntityInRelease(entityId: string, release: Release | undefined): boolean {
-  const releaseEntityIds = release?.entities?.items?.map((entity) => entity.sys.id) ?? []
-  return releaseEntityIds.includes(entityId)
 }

--- a/lib/types/navigator.types.ts
+++ b/lib/types/navigator.types.ts
@@ -5,8 +5,6 @@ export interface NavigatorAPIOptions {
   slideIn?: boolean | { waitForClose: boolean }
   /** if provided, the entry will be opened in the release context with the given release id */
   releaseId?: string
-  /** indicates whether the entity is part of the current release */
-  entityInRelease?: boolean
 }
 
 export interface PageExtensionOptions {


### PR DESCRIPTION
- Updated `openEntry`, `openAsset`, `openEntriesList`, and `openAssetsList` methods to consistently use `releaseId` derived from the release context, removing the `entityInRelease` flag from the parameters.
- Simplified the `NavigatorAPIOptions` interface by removing the `entityInRelease` property.
- Adjusted unit tests to reflect these changes, ensuring correct behavior when navigating with and without a release context.


