### PR TITLE
feat(cma): add releaseId to CMAClient parameters [EXT-6580]

### DIFF
--- a/lib/cma.ts
+++ b/lib/cma.ts
@@ -13,7 +13,8 @@ export function createCMAClient(ids: IdsAPI, channel: Channel): CMAClient {
         environmentId: ids.environmentAlias ?? ids.environment,
         spaceId: ids.space,
         organizationId: ids.organization,
-        // releaseId: ids.release,
+        // @ts-expect-error releaseId will be part of DefaultParams in a future SDK version
+        releaseId: ids.release,
       },
     },
   )


### PR DESCRIPTION
- Introduced the `releaseId` parameter in the `createCMAClient` function, with a comment indicating that it will be part of `DefaultParams` in a future SDK version. This change prepares for upcoming enhancements while maintaining backward compatibility.
