### PR TITLE
feat: add ASSET_SIDEBAR location constants [Ext-6786]

### DIFF
--- a/lib/locations.ts
+++ b/lib/locations.ts
@@ -4,6 +4,7 @@ const locations: Locations = {
   LOCATION_ENTRY_FIELD: 'entry-field',
   LOCATION_ENTRY_FIELD_SIDEBAR: 'entry-field-sidebar',
   LOCATION_ENTRY_SIDEBAR: 'entry-sidebar',
+  LOCATION_ASSET_SIDEBAR: 'asset-sidebar',
   LOCATION_DIALOG: 'dialog',
   LOCATION_ENTRY_EDITOR: 'entry-editor',
   LOCATION_PAGE: 'page',

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -386,6 +386,7 @@ export interface Locations {
   LOCATION_ENTRY_FIELD: 'entry-field'
   LOCATION_ENTRY_FIELD_SIDEBAR: 'entry-field-sidebar'
   LOCATION_ENTRY_SIDEBAR: 'entry-sidebar'
+  LOCATION_ASSET_SIDEBAR: 'asset-sidebar'
   LOCATION_DIALOG: 'dialog'
   LOCATION_ENTRY_EDITOR: 'entry-editor'
   LOCATION_PAGE: 'page'


### PR DESCRIPTION
Why UI Extensions SDK Needs These Changes

1. Location Detection for Apps
Apps need to know where they're running. The UI Extensions SDK provides this through sdk.location.is():
Without the location constant, this check would fail because the SDK doesn't recognize 'asset-sidebar' as a valid location.

```
// In an app, developers write:
if (sdk.location.is('asset-sidebar')) {
  // Render asset-sidebar specific UI
}
```

2. Type Safety
The Locations interface provides TypeScript type safety:

```
// This ensures only valid locations can be used
sdk.location.is('asset-sidebar') // ✅ TypeScript knows this is valid
sdk.location.is('invalid-location') // ❌ TypeScript error
```

3. SDK API Consistency
The UI Extensions SDK is the central source of truth for all location constants. Other parts of the system (like the widget renderer) import and use these constants:


```

// In experience-packages, they import from ui-extensions-sdk:
import { locations } from '@contentful/ui-extensions-sdk'
// Then use: locations.LOCATION_ASSET_SIDEBAR
```

4. App Framework Integration
When an app is loaded in the asset-sidebar location, the UI Extensions SDK needs to:
- Recognize the location type
- Provide the appropriate APIs for that location
- Handle location-specific behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an Asset Sidebar location in the interface, allowing compatible apps or widgets to appear alongside asset details.
  * Users may now access contextual tools directly from the asset sidebar for a smoother workflow and quicker actions without leaving the asset view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->