### PR TITLE
feat: ext 6788 asset sidebar location constants [EXT-6786]

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,6 +2,7 @@ import { makeField } from './field'
 import { makeFieldLocale } from './field-locale'
 import createWindow from './window'
 import createEntry from './entry'
+import createAsset from './asset'
 import createSpace from './space'
 import createDialogs from './dialogs'
 import createEditor from './editor'
@@ -38,6 +39,7 @@ const LOCATION_TO_API_PRODUCERS: { [location: string]: ProducerFunc[] } = {
   [locations.LOCATION_ENTRY_FIELD]: DEFAULT_API_PRODUCERS,
   [locations.LOCATION_ENTRY_FIELD_SIDEBAR]: DEFAULT_API_PRODUCERS,
   [locations.LOCATION_ENTRY_SIDEBAR]: [makeSharedAPI, makeEntryAPI, makeEditorAPI, makeWindowAPI],
+  [locations.LOCATION_ASSET_SIDEBAR]: [makeSharedAPI, makeAssetAPI, makeWindowAPI],
   [locations.LOCATION_ENTRY_EDITOR]: [makeSharedAPI, makeEntryAPI, makeEditorAPI],
   [locations.LOCATION_DIALOG]: [makeSharedAPI, makeDialogAPI, makeWindowAPI],
   [locations.LOCATION_PAGE]: [makeSharedAPI],
@@ -148,6 +150,12 @@ function makeFieldAPI(channel: Channel, { field }: ConnectMessage) {
 function makeDialogAPI(channel: Channel) {
   return {
     close: (data: any) => channel.send('closeDialog', data),
+  }
+}
+
+function makeAssetAPI(channel: Channel, { asset }: ConnectMessage) {
+  return {
+    asset: createAsset(channel, asset),
   }
 }
 

--- a/lib/asset.ts
+++ b/lib/asset.ts
@@ -43,7 +43,6 @@ export default function createAsset(
     onSysChanged(handler: (sys: AssetSys) => void) {
       return sysChanged.attach(handler)
     },
-    ...(metadata ? { metadata } : {}),
     getMetadata() {
       return metadata
     },

--- a/lib/asset.ts
+++ b/lib/asset.ts
@@ -1,0 +1,54 @@
+import { Channel } from './channel'
+import { MemoizedSignal } from './signal'
+import { ConnectMessage, Metadata } from './types'
+import { AssetAPI } from './types/asset.types'
+import { AssetSys } from './types/utils'
+
+export default function createAsset(
+  channel: Channel,
+  assetData: ConnectMessage['asset'],
+): AssetAPI {
+  if (!assetData) {
+    throw new Error('Asset data is required')
+  }
+
+  let sys: AssetSys = assetData.sys
+  const sysChanged = new MemoizedSignal<[AssetSys]>(sys)
+  let metadata = assetData.metadata
+  const metadataChanged = new MemoizedSignal<[Metadata | undefined]>(metadata)
+
+  channel.addHandler('sysChanged', (newSys: AssetSys) => {
+    sys = newSys
+    sysChanged.dispatch(sys)
+  })
+
+  channel.addHandler('metadataChanged', (newMetadata: Metadata) => {
+    metadata = newMetadata
+    metadataChanged.dispatch(metadata)
+  })
+
+  return {
+    getSys() {
+      return sys
+    },
+    publish(options?: { skipUiValidation?: boolean }) {
+      return channel.call<void>('callAssetMethod', 'publish', [options])
+    },
+    unpublish() {
+      return channel.call<void>('callAssetMethod', 'unpublish')
+    },
+    save() {
+      return channel.call<void>('callAssetMethod', 'save')
+    },
+    onSysChanged(handler: (sys: AssetSys) => void) {
+      return sysChanged.attach(handler)
+    },
+    ...(metadata ? { metadata } : {}),
+    getMetadata() {
+      return metadata
+    },
+    onMetadataChanged(handler: VoidFunction) {
+      return metadataChanged.attach(handler)
+    },
+  }
+}

--- a/lib/locations.ts
+++ b/lib/locations.ts
@@ -4,6 +4,7 @@ const locations: Locations = {
   LOCATION_ENTRY_FIELD: 'entry-field',
   LOCATION_ENTRY_FIELD_SIDEBAR: 'entry-field-sidebar',
   LOCATION_ENTRY_SIDEBAR: 'entry-sidebar',
+  LOCATION_ASSET_SIDEBAR: 'asset-sidebar',
   LOCATION_DIALOG: 'dialog',
   LOCATION_ENTRY_EDITOR: 'entry-editor',
   LOCATION_PAGE: 'page',

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -14,7 +14,7 @@ import {
 import { EntryAPI } from './entry.types'
 import { SpaceAPI } from './space.types'
 import { WindowAPI } from './window.types'
-import { EntrySys, Link, SerializedJSONValue } from './utils'
+import { EntrySys, AssetSys, Link, SerializedJSONValue } from './utils'
 import { FieldAPI } from './field-locale.types'
 import { DialogsAPI } from './dialogs.types'
 import { AppConfigAPI } from './app.types'
@@ -410,6 +410,10 @@ export interface ConnectMessage {
   }
   entry: {
     sys: EntrySys
+    metadata?: Metadata
+  }
+  asset?: {
+    sys: AssetSys
     metadata?: Metadata
   }
   fieldInfo: EntryFieldInfo[]

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -386,6 +386,7 @@ export interface Locations {
   LOCATION_ENTRY_FIELD: 'entry-field'
   LOCATION_ENTRY_FIELD_SIDEBAR: 'entry-field-sidebar'
   LOCATION_ENTRY_SIDEBAR: 'entry-sidebar'
+  LOCATION_ASSET_SIDEBAR: 'asset-sidebar'
   LOCATION_DIALOG: 'dialog'
   LOCATION_ENTRY_EDITOR: 'entry-editor'
   LOCATION_PAGE: 'page'

--- a/lib/types/asset.types.ts
+++ b/lib/types/asset.types.ts
@@ -12,11 +12,6 @@ export interface AssetAPI {
   save: () => Promise<void>
   /** Calls the callback with sys every time that sys changes. */
   onSysChanged: (callback: (sys: AssetSys) => void) => () => void
-  /**
-   * Optional metadata on an asset
-   * @deprecated
-   */
-  metadata?: Metadata
   getMetadata: () => Metadata | undefined
   onMetadataChanged: (callback: (metadata?: Metadata) => void) => VoidFunction
 }

--- a/lib/types/asset.types.ts
+++ b/lib/types/asset.types.ts
@@ -1,0 +1,22 @@
+import { Metadata } from './entities'
+import { AssetSys } from './utils'
+
+export interface AssetAPI {
+  /** Returns sys for an asset. */
+  getSys: () => AssetSys
+  /** Publish the asset */
+  publish: (options?: { skipUiValidation?: boolean }) => Promise<void>
+  /** Unpublish the asset */
+  unpublish: () => Promise<void>
+  /** Saves the current changes of the asset */
+  save: () => Promise<void>
+  /** Calls the callback with sys every time that sys changes. */
+  onSysChanged: (callback: (sys: AssetSys) => void) => () => void
+  /**
+   * Optional metadata on an asset
+   * @deprecated
+   */
+  metadata?: Metadata
+  getMetadata: () => Metadata | undefined
+  onMetadataChanged: (callback: (metadata?: Metadata) => void) => VoidFunction
+}

--- a/lib/types/utils.ts
+++ b/lib/types/utils.ts
@@ -70,6 +70,10 @@ export interface EntrySys extends ContentEntitySys {
   automationTags: Link<'Tag'>[]
 }
 
+export interface AssetSys extends ContentEntitySys {
+  type: 'Asset'
+}
+
 export type FieldType =
   | 'Symbol'
   | 'Text'


### PR DESCRIPTION
Add Asset Sidebar App Framework Location Support

Purpose
This PR implements the foundational support for the new asset-sidebar App Framework location, enabling apps to be installed and rendered in the asset editing sidebar. This addresses critical customer needs for asset-centric workflows including AI tagging, rights management, and publishing automation.

Background
As part of the asset-sidebar epic (EXT-6786, EXT-6788, EXT-6790, EXT-6793), this implementation provides the core SDK infrastructure needed to support apps in the asset editing context, similar to how entry-sidebar works for entries.

Changes
��️ Location Constants
lib/locations.ts: Added LOCATION_ASSET_SIDEBAR: 'asset-sidebar' to the locations object
lib/types/api.types.ts: Updated Locations interface to include the new location type

🔧 Asset API Implementation
lib/types/asset.types.ts: Created AssetAPI interface with asset-specific operations:
getSys(), publish(), unpublish(), save()
onSysChanged(), getMetadata(), onMetadataChanged()
lib/asset.ts: Implemented createAsset() function following same patterns as createEntry()
lib/types/utils.ts: Added AssetSys interface extending ContentEntitySys

🔌 API Producer Integration
lib/api.ts:
Added makeAssetAPI() function to provide asset context to apps
Added [locations.LOCATION_ASSET_SIDEBAR]: [makeSharedAPI, makeAssetAPI, makeWindowAPI] to LOCATION_TO_API_PRODUCERS
Imported and integrated createAsset() function

📡 Data Flow Support
lib/types/api.types.ts: Updated ConnectMessage interface to include optional asset property:

Impact
✅ Apps can now specify asset-sidebar as a supported location in their app definitions
✅ Apps running in asset-sidebar location receive sdk.asset API with full asset operations
✅ TypeScript compilation passes with new location and API types
✅ Foundation established for UI integration and widget rendering
✅ No breaking changes to existing functionality

Type: Feature
Scope: UI Extensions SDK
Breaking Change: No
Related Tickets: EXT-6786, EXT-6788, EXT-6790, EXT-6793



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Asset Sidebar location so apps can run in the asset sidebar.
  * Introduced an Asset API: access asset system fields and metadata, publish/unpublish/save, and subscribe to sys/metadata changes.
  * Connection payloads may include asset data to initialize the Asset API.

* **Types**
  * Added Asset-related types (Asset sys shape and Asset API signatures) to support the new capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->