### PR TITLE
feat: bump contentful-management to ^12.3.1 [DX-912]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.53.1",
       "license": "MIT",
       "dependencies": {
-        "contentful-management": "^12.0.0"
+        "contentful-management": "^12.3.1"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^29.0.0",
@@ -3246,13 +3246,13 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.1.0.tgz",
-      "integrity": "sha512-QieEOom70IF50j1LkVnj3m1g1knsCBwSDKGBLio4GHhJCnDHg7LnqaoYqsnGTYMGwmsITUNqB/hTg1mTvgEzpQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.3.1.tgz",
+      "integrity": "sha512-Lnx6ieod2z88AhZwcV2kDhN5stctq+0ifflX+xepphPJ1a2RsPNonCAcySabPETuoNox8G0kXo5ebNybrPjOYw==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "contentful-sdk-core": "^9.4.4",
         "fast-copy": "^3.0.0",
         "globals": "^15.15.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint-staged": "lint-staged"
   },
   "dependencies": {
-    "contentful-management": "^12.0.0"
+    "contentful-management": "^12.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^29.0.0",


### PR DESCRIPTION
[DX-912](https://contentful.atlassian.net/browse/DX-912)

## Summary
- Bump `contentful-management` from `^12.0.0` to `^12.3.1` to pick up the latest v12 patch releases
- Update `package-lock.json` to reflect the resolved version

## Test plan
- [ ] CI passes
- [ ] `npm install` resolves cleanly from public npm registry

Generated with [Claude Code](https://claude.com/claude-code)

[DX-912]: https://contentful.atlassian.net/browse/DX-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ