### PR TITLE
fix(ci): work around npm self-upgrade regression on Node 22 [DX-945]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,7 +84,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install latest npm
-        run: npm install -g npm@latest
+        run: |
+          # Work around the npm self-upgrade regression on Node 22.22.2.
+          # See: https://github.com/npm/cli/issues/9151
+          npm install -g npm@11.11.1
+          npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
[DX-945](https://contentful.atlassian.net/browse/DX-945)

## Summary
- `npm install -g npm@latest` fails on Node 22.22.2 with a missing `promise-retry` module — upstream regression tracked at [npm/cli#9151](https://github.com/npm/cli/issues/9151)
- Applies the same two-step workaround used in [contentful-management.js#2976](https://github.com/contentful/contentful-management.js/pull/2976): install `npm@11.11.1` first, then upgrade to `npm@latest`
- Unblocks releases without dropping the npm upgrade step entirely

## Test plan
- [ ] Release workflow completes successfully on Node 22

Generated with [Claude Code](https://claude.com/claude-code)

[DX-945]: https://contentful.atlassian.net/browse/DX-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ