### PR TITLE
fix(ci): work around the npm self-upgrade regression on Node 22.22.2 [EXT-00]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,7 +84,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install latest npm
-        run: npm install -g npm@latest
+        run: |
+          # Work around the npm self-upgrade regression on Node 22.22.2.
+          npm install -g npm@11.11.1
+          npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
There is an upstream npm self-upgrade regression on Node 22.22.2: direct npm install -g npm@latest fails with the missing promise-retry module. That’s tracked in https://github.com/npm/cli/issues/9151, with the underlying fix described in https://github.com/npm/cli/pull/9152.

## Description
I reproduced the failure in an isolated temp install of Node v22.22.2: direct npm install -g npm@latest failed with the same promise-retry stack trace.

I then verified the workaround in that same isolated environment: npm@11.11.1 installed successfully, then npm@latest upgraded successfully to 11.12.1.

## Motivation and Context
This is preventing releases from going out. We need to keep the npm upgrade because the release path is using trusted publishing guidance from semantic-release’s [GitHub Actions recipe](https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions), dropping the upgrade entirely would be a riskier change.
## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
