### PR TITLE
feat: expose agentRun.resumeRun types for AI agent apps [DX-912]

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ for the Contentful Web App. Every Contentful App has to include the library in i
 
 ## Getting help
 
-Technical questions, feedback or feature request can be provided directly through the Github issues
+Technical questions, feedback, or feature requests can be provided directly through the GitHub issues
 for this repository. However, if you are a paying customer or at any point business sensitive
 information needs to be discussed, then the conversation should be handled via our
 [support system](https://www.contentful.com/support/).

--- a/lib/types/cmaClient.types.ts
+++ b/lib/types/cmaClient.types.ts
@@ -39,3 +39,4 @@ export type CMAClient = {
   workflowDefinition: PlainClientAPI['workflowDefinition']
   workflowsChangelog: PlainClientAPI['workflowsChangelog']
 }
+

--- a/lib/types/cmaClient.types.ts
+++ b/lib/types/cmaClient.types.ts
@@ -39,4 +39,3 @@ export type CMAClient = {
   workflowDefinition: PlainClientAPI['workflowDefinition']
   workflowsChangelog: PlainClientAPI['workflowsChangelog']
 }
-


### PR DESCRIPTION
## Summary
- Trigger a minor version bump (→ 4.56.0) to publish a clean release from the npm registry
- v4.55.0 npm publish failed (E401); v4.55.1 published but some registries cached stale metadata
- This gives consumers a clean `^4.56.0` to depend on with `agentRun.resumeRun` types

## Test plan
- [ ] Merge triggers semantic-release → v4.56.0
- [ ] Verify `@contentful/app-sdk@4.56.0` on npm includes `resumeRun` types

🤖 Generated with [Claude Code](https://claude.com/claude-code)