### PR TITLE
feat: [EXT-7360] rename to ExperienceEditorToolbarAppSDK, add sdk.exo…

### DIFF
--- a/lib/exo.ts
+++ b/lib/exo.ts
@@ -2,6 +2,7 @@ import { Channel } from './channel'
 import { MemoizedSignal } from './signal'
 import {
   ExoSDK,
+  ExoContext,
   UiMode,
   Unsubscribe,
   ExperienceSnapshot,
@@ -28,11 +29,13 @@ import {
  */
 export default function createExo(
   channel: Channel,
-  exoInit?: { uiMode?: UiMode; experience?: ExperienceSnapshot },
+  exoInit?: { context?: ExoContext; uiMode?: UiMode; experience?: ExperienceSnapshot },
 ): ExoSDK | undefined {
   if (exoInit === undefined) {
     return undefined
   }
+
+  const context: ExoContext = exoInit.context ?? { type: 'experience', entityId: '' }
 
   const initialMode: UiMode = exoInit.uiMode ?? 'form'
   const uiModeSignal = new MemoizedSignal<[UiMode]>(initialMode)
@@ -44,6 +47,7 @@ export default function createExo(
   const experience = createExperienceAPI(channel, exoInit.experience)
 
   return {
+    context,
     getUiMode(): UiMode {
       return uiModeSignal.getMemoizedArgs()[0]
     },

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -23,7 +23,7 @@ import { EntryFieldInfo, FieldInfo } from './field.types'
 import { Adapter, KeyValueMap } from 'contentful-management'
 import { CMAClient } from './cmaClient.types'
 import { AgentAPI, AgentContext } from './agent.types'
-import { ExoSDK, UiMode, ExperienceSnapshot } from './exo.types'
+import { ExoSDK, ExoContext, UiMode, ExperienceSnapshot } from './exo.types'
 
 /* User API */
 
@@ -354,7 +354,7 @@ export type AgentAppSDK<InstallationParameters extends KeyValueMap = KeyValueMap
   window: WindowAPI
 }
 
-export type ExperienceToolbarAppSDK<InstallationParameters extends KeyValueMap = KeyValueMap> =
+export type ExperienceEditorToolbarAppSDK<InstallationParameters extends KeyValueMap = KeyValueMap> =
   Omit<BaseAppSDK<InstallationParameters, never, never>, 'ids'> & {
     ids: Omit<IdsAPI, EntryScopedIds>
     /** ExO (Experience Orchestration) SDK for experience-toolbar location */
@@ -374,7 +374,7 @@ export type KnownAppSDK<
   | ConfigAppSDK<InstallationParameters>
   | HomeAppSDK<InstallationParameters>
   | AgentAppSDK<InstallationParameters>
-  | ExperienceToolbarAppSDK<InstallationParameters>
+  | ExperienceEditorToolbarAppSDK<InstallationParameters>
 
 /** @deprecated consider using {@link BaseAppSDK} */
 export type BaseExtensionSDK = BaseAppSDK
@@ -447,6 +447,7 @@ export interface ConnectMessage {
   agent?: AgentContext
   /** ExO data; when present, SDK constructs sdk.exo */
   exo?: {
+    context?: ExoContext
     uiMode?: UiMode
     experience?: ExperienceSnapshot
   }

--- a/lib/types/exo.types.ts
+++ b/lib/types/exo.types.ts
@@ -180,7 +180,13 @@ export interface ExperienceAPI {
   dataAssembly: DataAssemblySDK
 }
 
+export interface ExoContext {
+  type: 'experience' | 'fragment'
+  entityId: string
+}
+
 export interface ExoSDK {
+  context: ExoContext
   getUiMode(): UiMode
   onUiModeChanged(cb: (mode: UiMode) => void): Unsubscribe
   experience: ExperienceAPI

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -35,7 +35,7 @@ export type {
   JSONPatchItem,
   HostnamesAPI,
   AgentAppSDK,
-  ExperienceToolbarAppSDK,
+  ExperienceEditorToolbarAppSDK,
 } from './api.types'
 
 export type {
@@ -141,6 +141,7 @@ export type { CMAClient } from './cmaClient.types'
 export type {
   Unsubscribe,
   UiMode,
+  ExoContext,
   ExoSDK,
   BindingSourceType,
   EntryBinding,

--- a/test/unit/api.spec.ts
+++ b/test/unit/api.spec.ts
@@ -6,7 +6,7 @@ import {
   AgentAppSDK,
   ConfigAppSDK,
   ConnectMessage,
-  ExperienceToolbarAppSDK,
+  ExperienceEditorToolbarAppSDK,
   ExoSDK,
   UiMode,
 } from '../../lib/types'
@@ -145,7 +145,7 @@ describe('createAPI()', () => {
 
     const api = test(expected, locations.LOCATION_EXPERIENCE_TOOLBAR) as any
     if (api.exo != null) {
-      expect(api.exo).to.have.all.keys('getUiMode', 'onUiModeChanged')
+      expect(api.exo).to.have.all.keys('context', 'getUiMode', 'onUiModeChanged')
     }
   })
 
@@ -253,18 +253,45 @@ describe('createAPI()', () => {
       expect(modes).to.deep.equal(['visual', 'form'])
     })
 
-    it('ExperienceToolbarAppSDK has exo: ExoSDK; getUiMode returns UiMode', () => {
+    it('ExperienceEditorToolbarAppSDK has exo: ExoSDK; getUiMode returns UiMode', () => {
       const channel = { addHandler: () => () => {} } as any
       const dom = makeDOM()
       mockMutationObserver(dom, () => {})
       mockResizeObserver(dom, () => {})
 
       const data: ConnectMessage = { ...baseData, exo: { uiMode: 'form' } } as any
-      const api = createAPI(channel, data, dom.window as any as Window) as ExperienceToolbarAppSDK
+      const api = createAPI(channel, data, dom.window as any as Window) as ExperienceEditorToolbarAppSDK
 
       const exo: ExoSDK = api.exo
       const mode: UiMode = exo.getUiMode()
       expect(mode).to.equal('form')
+    })
+
+    it('sdk.exo.context reflects the context from handshake', () => {
+      const channel = { addHandler: () => () => {} } as any
+      const dom = makeDOM()
+      mockMutationObserver(dom, () => {})
+      mockResizeObserver(dom, () => {})
+
+      const data: ConnectMessage = {
+        ...baseData,
+        exo: { context: { type: 'fragment', entityId: 'frag-456' }, uiMode: 'form' },
+      } as any
+      const api = createAPI(channel, data, dom.window as any as Window) as any
+
+      expect(api.exo.context).to.deep.equal({ type: 'fragment', entityId: 'frag-456' })
+    })
+
+    it('sdk.exo.context defaults when not provided in handshake', () => {
+      const channel = { addHandler: () => () => {} } as any
+      const dom = makeDOM()
+      mockMutationObserver(dom, () => {})
+      mockResizeObserver(dom, () => {})
+
+      const data: ConnectMessage = { ...baseData, exo: { uiMode: 'visual' } } as any
+      const api = createAPI(channel, data, dom.window as any as Window) as any
+
+      expect(api.exo.context).to.deep.equal({ type: 'experience', entityId: '' })
     })
   })
 

--- a/test/unit/exo.spec.ts
+++ b/test/unit/exo.spec.ts
@@ -33,8 +33,8 @@ describe('createExo()', () => {
       exo = createExo(channelStub, mockExoInit)
     })
 
-    it('returns an object with getUiMode, onUiModeChanged, and experience', () => {
-      expect(exo).to.have.all.keys(['getUiMode', 'onUiModeChanged', 'experience'])
+    it('returns an object with context, getUiMode, onUiModeChanged, and experience', () => {
+      expect(exo).to.have.all.keys(['context', 'getUiMode', 'onUiModeChanged', 'experience'])
     })
 
     it('registers handlers for uiModeChanged, experienceChanged, selectionChanged, and dataAssemblyChanged', () => {
@@ -55,6 +55,28 @@ describe('createExo()', () => {
         'exo.dataAssemblyChanged',
         sinon.match.func,
       )
+    })
+
+    describe('.context', () => {
+      it('defaults to { type: "experience", entityId: "" } when no context is provided', () => {
+        expect(exo!.context).to.deep.equal({ type: 'experience', entityId: '' })
+      })
+
+      it('returns the provided context from exoInit', () => {
+        const exoWithContext = createExo(channelStub, {
+          ...mockExoInit,
+          context: { type: 'fragment', entityId: 'frag-123' },
+        })
+        expect(exoWithContext!.context).to.deep.equal({ type: 'fragment', entityId: 'frag-123' })
+      })
+
+      it('returns experience context when explicitly provided', () => {
+        const exoWithContext = createExo(channelStub, {
+          ...mockExoInit,
+          context: { type: 'experience', entityId: 'exp-abc' },
+        })
+        expect(exoWithContext!.context).to.deep.equal({ type: 'experience', entityId: 'exp-abc' })
+      })
     })
 
     describe('.getUiMode()', () => {


### PR DESCRIPTION
# Purpose of PR

  - **Type rename**: `ExperienceToolbarAppSDK` → `ExperienceEditorToolbarAppSDK` across type def, `KnownAppSDK` union, barrel re-export, and tests. Clean break — no alias for the old name on this unreleased branch.
  - **`sdk.exo.context`**: Added `ExoContext` type (`{ type: 'experience' | 'fragment'; entityId: string }`), wired through `ConnectMessage.exo` → `createExo()` factory, defaults to `{ type: 'experience', entityId:
   '' }` when not provided by the host.

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
