### PR TITLE
fix: expand setInvalid JSDoc to document visual-only and same-field constraints [DX-1077]

### DIFF
--- a/lib/types/field-locale.types.ts
+++ b/lib/types/field-locale.types.ts
@@ -19,7 +19,17 @@ interface FieldAPIBase {
   setValue: <Value = any>(value: Value) => Promise<SerializedJSONValue | undefined>
   /** Removes the value for the field and locale. */
   removeValue: () => Promise<void>
-  /** Communicates to the web application if the field is in a valid state or not. */
+  /**
+   * Sets a visual invalid indicator (red error bar) on the field in the web app.
+   *
+   * **Constraints:**
+   * - Visual only — does NOT prevent publishing.
+   * - Only affects the field the app is assigned to. Calling this via
+   *   `sdk.entry.fields['otherField'].getForLocale(...).setInvalid()` from
+   *   a different field location has no effect.
+   * - To prevent publishing, use a built-in validation on a separate field and
+   *   control its value with `sdk.field.setValue()`.
+   */
   setInvalid: (value: boolean) => void
 
   /** Calls the callback every time the value of the field is changed by an external event or when setValue() is called.


### PR DESCRIPTION
## Purpose

The existing JSDoc for `setInvalid` was a single vague line:

> *Communicates to the web application if the field is in a valid state or not.*

This led developers to believe calling it cross-field would work (it doesn't) and that it would prevent publishing (it doesn't). Both misconceptions are tracked in [contentful/apps#3992](https://github.com/contentful/apps/issues/3992).

## Approach

Expanded the JSDoc comment to explicitly document two constraints:

- **Visual only** — adds/removes the red error bar but does not prevent publishing
- **Same-field only** — only affects the field the app is assigned to; calling it on another field via `sdk.entry.fields['otherField'].getForLocale(...).setInvalid()` is a no-op
- Points developers toward the correct pattern (`sdk.field.setValue()` + built-in validation) for blocking publishing

No functional changes — JSDoc only.

## Testing steps

- [ ] Verify the updated type definition appears correctly in IDE tooltips/autocomplete after consuming the updated package

## Breaking Changes

None.

## Dependencies and/or References

- [DX-1077](https://contentful.atlassian.net/browse/DX-1077)
- Companion PRs: [contentful/apps#10977](https://github.com/contentful/apps/pull/10977), [contentful/doc-app#3921](https://github.com/contentful/doc-app/pull/3921)
- Closes [contentful/apps#3992](https://github.com/contentful/apps/issues/3992)

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1077]: https://contentful.atlassian.net/browse/DX-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ