### PR TITLE
docs: seed Golden Context [EXT-7431]

### DIFF
--- a/.bito.yaml
+++ b/.bito.yaml
@@ -1,0 +1,14 @@
+version: 1
+review:
+  guidelines:
+    - file: ./.bito/guidelines/architecture.md
+    - file: ./.bito/guidelines/quality.md
+    - file: ./.bito/guidelines/security.md
+  ignore_paths:
+    - dist/**
+    - docs/cf-extension-api.js*
+    - docs/cf-extension.css*
+    - docs/cf-widget-api.*
+    - docs/styleguide/**
+    - CHANGELOG.md
+    - package-lock.json

--- a/.bito/guidelines/architecture.md
+++ b/.bito/guidelines/architecture.md
@@ -1,0 +1,27 @@
+# Architecture review guidelines — `ui-extensions-sdk`
+
+Refer reviewers to [ARCHITECTURE.md](../../ARCHITECTURE.md) for the full picture. Flag PRs that violate these:
+
+## Boundaries
+
+- **PostMessage is the only host transport.** Flag any new `fetch`, `XMLHttpRequest`, direct `window.location` mutation, or DOM access for cross-frame use that bypasses `lib/channel.ts`. CMA calls must route through `lib/cmaAdapter.ts` (the channel-backed adapter), never a directly-instantiated `contentful-management` client.
+- **Public types are a contract.** Any change to `lib/types/index.ts` or its re-exports is a breaking change unless purely additive (new fields on existing interfaces are also breaking — they widen the producer side). Flag PRs that:
+  - Remove a public export
+  - Rename a public type, interface, or method
+  - Change a method signature in a non-additive way
+  - Add a required field to an interface that consumers implement
+  Without an accompanying `feat!:` commit and `BREAKING CHANGE:` footer in the squash-merge body.
+- **Locations are additive.** New locations require updates to all five touch points: `lib/locations.ts`, `lib/types/api.types.ts` (new SDK type + `Locations` interface + `KnownAppSDK` union), `lib/api.ts` (`LOCATION_TO_API_PRODUCERS`), a producer factory if needed, and a unit test. Flag any PR that updates fewer than these.
+- **`lib/space.ts` is frozen.** Flag any PR that adds methods to `lib/space.ts` — that API is deprecated since v4.0.0 (every method emits a `console.warn` recommending the CMA client). New CMA-backed work goes via `sdk.cma`.
+
+## Module patterns
+
+- **One module per public capability.** New top-level capabilities go in their own `lib/<name>.ts` with types in `lib/types/<name>.types.ts`. Don't extend `lib/api.ts` with new method bodies — `api.ts` is a router, not a hub.
+- **Memoized signals for state, plain signals for events.** Use `MemoizedSignal` in `lib/signal.ts` when subscribers need the latest value on subscribe; use `Signal` for one-shot events. Flag deviations.
+- **Producer functions get `(channel, data, currentGlobal)` only.** Don't pass additional state into producers — the channel is the source of truth. Flag any producer with a different signature.
+
+## Build / deps
+
+- **Bundle size budget.** PRs that change `lib/` must show a `npm run size` delta. Flag PRs that grow gzipped size without justification.
+- **No new runtime dependencies** without explicit team review of the size cost and alternatives considered. `contentful-management` is currently the only runtime dependency.
+- **No ESM-only deps.** The bundle is UMD-target ES5; ESM-only deps will fail at build time or require Rollup config gymnastics.

--- a/.bito/guidelines/quality.md
+++ b/.bito/guidelines/quality.md
@@ -1,0 +1,34 @@
+# Quality review guidelines — `ui-extensions-sdk`
+
+## Tests
+
+- **One unit test file per module.** `lib/foo.ts` ↔ `test/unit/foo.spec.ts`. Flag PRs adding a `lib/<file>.ts` without `test/unit/<file>.spec.ts`.
+- **Use shared helpers.** `test/helpers.ts` provides `mockMutationObserver`, `mockResizeObserver`, `describeAttachHandlerMember`, `describeChannelCallingMethod`. Reach for these before reimplementing patterns.
+- **Use mocks from `test/mocks/`.** `connectMessage.ts`, `agent.ts`, `entries.ts`, `environments.ts`, `releases.ts` are the canonical fixtures. Don't redefine `ConnectMessage` shapes inline.
+- **Assertion library is Chai.** Don't introduce `expect`-from-other-libraries. Don't use `chai`'s `should` style — `expect` is the convention.
+- **No skipped or `.only`'d tests.** Flag any `describe.only`, `it.only`, `describe.skip`, or `it.skip` outside of a draft PR.
+
+## TypeScript
+
+- **No `any` in public types.** `lib/types/**/*.ts` and any exported type from `lib/index.ts` must be explicit. `unknown` is acceptable when the value's shape is genuinely unknowable. Internal `any` for legacy seams is acceptable but should be commented.
+- **`strict: true`** is enforced. Don't disable strict per-file with `// @ts-nocheck` or per-line with `@ts-ignore`. Use `@ts-expect-error` with a comment if absolutely necessary (the codebase has a few in `lib/utils/deferred.ts`).
+- **Public types live in `lib/types/`** and are re-exported from `lib/types/index.ts` only. Don't add additional barrel files.
+
+## Style
+
+- **Prettier and ESLint are CI gates.** Don't disable rules without justification. The two notable enforced rules: `no-var: error`, `prefer-const: error`.
+- **One concern per PR.** Flag PRs that mix dependency bumps with feature work or refactors. Squash-merge means everything in the PR ships under one commit message.
+
+## Commits / PRs
+
+- **Conventional Commits at PR-title level.** `.github/semantic.yml` enforces this. Common prefixes: `feat:`, `fix:`, `chore:`, `docs:`. Use `chore:` only for changes that should NOT trigger a release (tooling, config); use `fix:` or `feat:` for any user-facing change so semantic-release does not skip it.
+- **Jira key in the title.** Pattern: `feat: short summary [EXT-1234]`. Look for it; flag if missing on a non-trivial PR.
+- **`BREAKING CHANGE:` footer for breaking changes.** The `feat!:` shorthand is *not* sufficient with the current `conventional-commits-parser` v6 + `commit-analyzer` v13 — the footer is required. Flag any PR that signals breaking-ness with `!` alone.
+
+## Files reviewers should ignore
+
+- `dist/**`, `docs/cf-*`, `docs/styleguide/**` — generated and legacy artifacts
+- `package-lock.json` — review-noise
+- `CHANGELOG.md` — semantic-release owns it
+
+(These are also in `.bito.yaml#review.ignore_paths`.)

--- a/.bito/guidelines/security.md
+++ b/.bito/guidelines/security.md
@@ -15,10 +15,8 @@ This SDK ships to thousands of customer apps via npm and CDN. Treat security fee
 
 ## PostMessage / iframe boundary
 
-- **Don't widen the host trust surface.** The SDK currently treats *any* `connect` message from any origin as authoritative (`lib/channel.ts:waitForConnect`) — the security model relies on the iframe sandbox + the host's PostMessage hygiene. Flag any change that:
-  - Adds new `params` fields without input shape validation in TypeScript types
-  - Sends sensitive data outbound on `postMessage(*, '*')` without verifying the destination
-  - Introduces eval'd or `Function`-constructed code on the SDK side
+- **Maintain TypeScript types as the contract for any new `params` fields** added to channel messages. New host-driven message shapes belong in `lib/types/api.types.ts` `ConnectMessage`.
+- **No dynamically-evaluated code** on the SDK side (no `eval`, no runtime code construction).
 - **`DataCloneError` handling is intentional.** `channel.ts:111-116` catches DataCloneError specifically for `openDialog` and emits a customer-helpful message. Don't replace with generic error suppression.
 
 ## CI / branch protection

--- a/.bito/guidelines/security.md
+++ b/.bito/guidelines/security.md
@@ -1,0 +1,28 @@
+# Security review guidelines — `ui-extensions-sdk`
+
+This SDK ships to thousands of customer apps via npm and CDN. Treat security feedback as priority.
+
+## Dependencies
+
+- **No new runtime dependency without strong justification.** Every runtime dep extends the supply-chain reach to every consumer. Flag any PR that adds to `package.json#dependencies` without explicit team review (see `.bito/guidelines/architecture.md`).
+- **Dev dependencies are also supply chain.** Dependabot has a 15-day cooldown configured (`.github/dependabot.yml`) precisely to give time to detect compromised packages. Flag dev-dep additions that pin a version under that 15-day window.
+- **`.npmrc` security stance is locked.** Specifically `ignore-scripts=true` (supply-chain hardening — prevents lifecycle scripts in transitive deps from running on install). Flag any PR that touches `.npmrc` to ensure this is preserved.
+
+## Secrets / tokens
+
+- **No hardcoded secrets.** The repo does not use any secrets at runtime — release tokens come from HashiCorp Vault during the publish workflow. Flag any commit that introduces literal API keys, tokens, or webhook URLs.
+- **Release pipeline uses trusted publishing.** Don't replace the Vault-action with long-lived tokens (`secrets.NPM_TOKEN`-style). The current pipeline uses `hashicorp/vault-action` to mint short-lived tokens (`.github/workflows/release.yaml`).
+
+## PostMessage / iframe boundary
+
+- **Don't widen the host trust surface.** The SDK currently treats *any* `connect` message from any origin as authoritative (`lib/channel.ts:waitForConnect`) — the security model relies on the iframe sandbox + the host's PostMessage hygiene. Flag any change that:
+  - Adds new `params` fields without input shape validation in TypeScript types
+  - Sends sensitive data outbound on `postMessage(*, '*')` without verifying the destination
+  - Introduces eval'd or `Function`-constructed code on the SDK side
+- **`DataCloneError` handling is intentional.** `channel.ts:111-116` catches DataCloneError specifically for `openDialog` and emits a customer-helpful message. Don't replace with generic error suppression.
+
+## CI / branch protection
+
+- **Branch protection on `main`.** 1 required approving review, code-owner review required, stale reviews dismissed on push, strict status checks. Flag any PR that proposes loosening these.
+- **CODEOWNERS is enforced.** Both `team-extensibility` and `team-marketplace` are listed. PRs touching `.github/CODEOWNERS` should be reviewed for ownership impact.
+- **No `--no-verify` on commits.** Pre-commit `lint-staged` is part of the security/quality gate. Flag PRs whose body or commit messages indicate `--no-verify` was used.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,54 +1,95 @@
-# Agent Guide — contentful-ui-extensions-sdk / @contentful/app-sdk
+# Agent Guide — `ui-extensions-sdk`
 
-## What This Repo Does
-The App SDK (published as both `@contentful/app-sdk` and the legacy `contentful-ui-extensions-sdk`) is the core runtime library every Contentful app must use. It provides the `init()` entry point, PostMessage-based communication with the Contentful host application, and TypeScript types for all SDK locations.
+## Identity
+This is the **`ui-extensions-sdk`** repository (`github.com/contentful/ui-extensions-sdk`). It builds and publishes the **App SDK** to npm under two package names: **`@contentful/app-sdk`** (preferred — use this in all new code, examples, and documentation) and **`contentful-ui-extensions-sdk`** (legacy alias retained for installed-base compatibility). Repo name and package names diverged for historical reasons; do not rename the repo.
 
 ## Ownership
-`@contentful/team-marketplace` (full, co-owned with `@contentful/team-extensibility`)
+`@contentful/team-extensibility` and `@contentful/team-marketplace` (co-owned per [`.github/CODEOWNERS`](./.github/CODEOWNERS)).
 
-## Structure
+## Where to look
+| You want to… | Read this |
+|---|---|
+| Understand the runtime + build pipeline | [ARCHITECTURE.md](./ARCHITECTURE.md) |
+| Develop locally / run tests / open a PR | [CONTRIBUTING.md](./CONTRIBUTING.md) |
+| See the consumer-facing reference | [Contentful Docs — App SDK Reference](https://www.contentful.com/developers/docs/extensibility/app-framework/sdk/) |
 
+## Sharp edges (do not violate)
+
+1. **Public types are a contract.** Changing or removing any export from `lib/types/index.ts` is a breaking change. Hundreds of customer apps and many internal Contentful repos consume these types. A breaking change requires a `feat!:` commit + `BREAKING CHANGE:` footer (the major bump is otherwise silently dropped without the footer).
+
+2. **Bundle size is policed by CI.** `npm run size` reports gzipped bytes of `dist/cf-extension-api.js` after every build. Adding a runtime dependency or a heavy utility is *almost always* the wrong move — `contentful-management` is currently the **only** runtime dep. Re-implementing a small helper inline beats pulling in a package.
+
+3. **PostMessage is the only transport.** All host communication routes through [`lib/channel.ts`](./lib/channel.ts). Do not add direct DOM, `fetch`, or global-window access for host operations. If you need a new capability from the host, add a method on the channel and contract its protocol with the web app team.
+
+4. **Space API is deprecated since v4.0.0.** Every call in `lib/space.ts` emits a `console.warn` recommending the CMA client. Do not add new methods. There is no current timeline for removal — the deprecation persists indefinitely; new CMA-backed work goes via `sdk.cma`.
+
+5. **Two npm packages, one source.** `scripts/publish.js` mutates `package.json#name` between publishes (it's reset in a `try/finally` once the publish run finishes). Never edit `name` directly in `package.json` — there is no general-purpose auto-restore for unrelated manual edits, only the per-publish cleanup in `scripts/shared.js#restorePackageJson`.
+
+6. **Canary is not a feature branch.** The `canary` branch publishes alpha versions under the `canary` dist-tag (`X.Y.Z-alpha.N`). Reset `canary` to `main` before starting alpha work. Forward-port a canary-tested fix to `main` via a fresh PR — don't direct-merge the `canary` branch into `main`, since that drags every prior alpha commit's history along.
+
+7. **`globalThis.contentfulExtension` is a compatibility alias** for `globalThis.contentfulApp` (set in `rollup.config.js`). Do not reference `contentfulExtension` in new code; it exists only to keep CDN script-tag installs working.
+
+8. **Treat security-related Dependabot PRs as priority** — the SDK ships to many installations and a vulnerable transitive dependency reaches all of them.
+
+9. **`LOCATION_AGENT` ships in code but is host-flagged.** The SDK exports `AgentAppSDK` and `LOCATION_AGENT` from v4.46.0 onward, but customers cannot render an agent app until the host enables the corresponding feature flag for their space. When making changes here, remember that the SDK is only half the contract — host-side flag and rendering changes coordinate through the relevant host team.
+
+10. **`LOCATION_HOME` apps must NOT use auto-resizer behavior.** `sdk.window` isn't on `HomeAppSDK` (the type omits it — see `lib/types/api.types.ts`), so `sdk.window.startAutoResizer()` is a TypeScript error and won't compile. The real footgun is `useAutoResizer()` from `@contentful/react-apps-toolkit` — it accepts the home SDK but produces no effect because the host manages sizing for the home location at the platform level.
+
+## Locations the SDK supports
+
+These are the values of `data.location` that `lib/api.ts` knows how to compose an SDK for. Defined in `lib/locations.ts`.
+
+| Location constant | String value | SDK type | Notes |
+|---|---|---|---|
+| `LOCATION_ENTRY_FIELD` | `entry-field` | `FieldAppSDK` | |
+| `LOCATION_ENTRY_FIELD_SIDEBAR` | `entry-field-sidebar` | `FieldAppSDK` | |
+| `LOCATION_ENTRY_SIDEBAR` | `entry-sidebar` | `SidebarAppSDK` | |
+| `LOCATION_ASSET_SIDEBAR` | `asset-sidebar` | `SidebarAppSDK` (asset variant) | |
+| `LOCATION_ENTRY_EDITOR` | `entry-editor` | `EditorAppSDK` | |
+| `LOCATION_DIALOG` | `dialog` | `DialogAppSDK` | |
+| `LOCATION_PAGE` | `page` | `PageAppSDK` | |
+| `LOCATION_HOME` | `home` | `HomeAppSDK` | Host manages sizing — do **not** call `useAutoResizer()` here. |
+| `LOCATION_APP_CONFIG` | `app-config` | `ConfigAppSDK` | |
+| `LOCATION_AGENT` | `agent` | `AgentAppSDK` | Ships in SDK from **v4.46.0**. Host rendering is gated by a feature flag — coordinate with the host team to enable. |
+
+When adding a new location: update `lib/types/api.types.ts` (`Locations` interface, new `<Name>AppSDK` type, **and** add it to the `KnownAppSDK` union — easily missed), `lib/locations.ts` (constant), `lib/api.ts` (`LOCATION_TO_API_PRODUCERS` mapping + a producer factory if needed), and add a unit test in `test/unit/api.spec.ts`. CLAUDE.md expands on each step.
+
+## Type aliases (deprecated)
+
+Every legacy `*ExtensionSDK` type (`FieldExtensionSDK`, `SidebarExtensionSDK`, `AppExtensionSDK`, etc.) is `@deprecated` in `lib/types/api.types.ts`. They alias to their `*AppSDK` equivalents and exist for backward compatibility only. Do not introduce new code that uses or extends the deprecated names.
+
+## High-traffic areas (extra caution)
+
+These three modules are touched by every SDK consumer on every page load. A regression here propagates to thousands of customer apps within a release window. Treat changes in these files as having outsized blast radius:
+
+- **`lib/channel.ts`** — the PostMessage transport. Every host call routes through it. Changes here can break every API method simultaneously and are not testable without exercising the full handshake (see `test/helpers.ts` for the jsdom + mockMutationObserver setup the test suite relies on).
+- **`lib/types/index.ts`** — the public type contract barrel. A removed or renamed export is a breaking change for every customer app and every internal Contentful repo importing the SDK.
+- **`lib/api.ts`** — the location-specific producer mapping. A typo in `LOCATION_TO_API_PRODUCERS` falls back to `DEFAULT_API_PRODUCERS` silently, causing the wrong SDK shape to ship for the affected location.
+
+**Mitigations** for non-trivial changes here:
+1. Run the full local verification suite (below) plus `npm run size` to catch bundle regressions.
+2. Cut a `canary` release and exercise it through downstream consumers before merging to `main` — see ARCHITECTURE.md "Cross-repo testing for non-trivial SDK changes" for the observed playbook.
+3. For type-surface changes specifically: open the PR, then identify likely-affected consumers via `gh search code 'from "@contentful/app-sdk"' --owner contentful`. `git grep` is local-only and won't find cross-repo consumers.
+
+## Verification commands
+
+Run before opening a PR — these match what CI runs.
+
+```bash
+npm ci
+npm run lint
+npm run check-types
+npm test
+npm run build
+npm run size
 ```
-lib/              # TypeScript source — one file per API module
-lib/types/        # All public TypeScript types and interfaces
-test/unit/        # Mocha test specs — one per module
-dist/             # Built UMD output (generated — do not edit)
-scripts/          # Custom dual-publish scripts
-```
-
-See [ARCHITECTURE.md](ARCHITECTURE.md) for the full picture.
-
-## Key Exports
-
-| Export | Description |
-|--------|-------------|
-| `init(callback, options?)` | Entry point — connects app to host frame |
-| `locations` | Enum of all valid app locations |
-| `FieldAppSDK`, `SidebarAppSDK`, `PageAppSDK`, etc. | Location-specific SDK types |
-| `AppExtensionSDK` | Config screen SDK type |
-| `HomeExtensionSDK` | Home location SDK type |
-| `DialogAppSDK` | Dialog SDK type |
-
-## Published as Two Package Names
-Same code, two npm packages:
-- `@contentful/app-sdk` — modern scoped name (use this in new code)
-- `contentful-ui-extensions-sdk` — legacy name (still live, do not remove)
-
-Custom publish scripts in `scripts/publish.js` handle both. Semantic-release drives versioning.
-
-## Sharp Edges & Invariants
-
-- **UMD output, not ESM** — build target is UMD via Rollup. Do not assume tree-shaking; keep the bundle small.
-- **Mocha, not Vitest** — tests use `ts-mocha` + Chai + Sinon + jsdom. Do not introduce Vitest.
-- **No `any` in public types** — every exported type must be explicit. `unknown` is acceptable internally.
-- **Breaking changes require major version** — this SDK has thousands of app consumers. Removing or renaming any public export is a breaking change.
-- **Canary releases** from the `canary` branch publish as `X.Y.Z-alpha.N` under the `canary` dist-tag. Do not merge canary work to master until stable.
-- **PostMessage channel only** — all SDK calls go through `channel.ts`. Do not add direct DOM access or `window` globals.
 
 ## Never / Always
 
-- **Never** access `window.contentfulExtension` directly — that is the pre-SDK legacy pattern.
-- **Never** remove or rename a public type export without bumping the major version.
-- **Always** add a test in `test/unit/` for any new module or API surface.
-- **Always** run `npm run check-types` before opening a PR — type errors in a types library are blocking.
-- **Always** run `npm run size` after build changes — the gzip size limit is enforced in CI.
+- **Never** reference `window.contentfulExtension` directly in new code or examples.
+- **Never** introduce a runtime dependency without explicit team review of the size cost and necessity.
+- **Never** add a method to `lib/space.ts` — that API is freezing toward removal.
+- **Never** change a public type signature without a `feat!:` commit + `BREAKING CHANGE:` footer.
+- **Always** add a unit test in `test/unit/<module>.spec.ts` for any new module — one spec per module is the convention.
+- **Always** update `lib/types/api.types.ts` `ConnectMessage` when adding a host-driven message field.
+- **Always** keep `lib/types/index.ts` as the single export point — don't introduce additional barrel files.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,103 +1,224 @@
-# Architecture — contentful-ui-extensions-sdk / @contentful/app-sdk
+# Architecture — `ui-extensions-sdk`
+
+This repository builds the **App SDK** and publishes it to npm as `@contentful/app-sdk` (preferred) and `contentful-ui-extensions-sdk` (legacy alias). Everything below describes the codebase in this repo and the runtime it ships.
 
 ## Overview
 
-The App SDK is the **communication bridge** between a Contentful app (running in an iframe) and the Contentful host application. It uses a PostMessage-based channel to expose Contentful data and actions to app code in a safe, sandboxed way.
+The App SDK is the **bridge** between an app running in a sandboxed iframe (the *child frame*, customer code) and the Contentful Web App (the *parent frame*, host). It exposes a typed, Promise-based JavaScript API that wraps PostMessage interactions with the host. Apps call `init()`, receive a location-specific SDK object, and use it to read/write content, open dialogs, navigate, and (in newer surfaces) interact with AI agents.
 
-## How It Works
+Inception: 2015-11-02 (`d21d1f9` `Initial commit`). Core transport pattern is unchanged; new locations and APIs are layered on top.
+
+## System Context
+
+```mermaid
+graph LR
+  CWA["Contentful Web App<br/>(parent frame)"]
+  WR["Widget Renderer"]
+  IF["Customer App iframe<br/>(child frame)"]
+  SDK["@contentful/app-sdk<br/>(this repo)"]
+  CMA["Contentful Management API"]
+  IF -.uses.-> SDK
+  CWA --> WR
+  WR -- "postMessage(connect)" --> IF
+  IF -- "postMessage(call/send)" --> CWA
+  CWA -- "postMessage(response/event)" --> IF
+  SDK -- "via channel" --> CMA
+```
+
+The SDK never talks to Contentful APIs directly. CMA calls flow through the channel: `app code → sdk.cma.<method>() → cmaAdapter → channel.call('CMAAdapterCall', opts) → web app → CMA`. This indirection lets the host inject auth, environment, and release context without the app handling tokens.
+
+## Module Map (`lib/`)
+
+| Module | Role | Key surface |
+|---|---|---|
+| `index.ts` | Public entry: re-exports types and exposes `init` + `locations` | `init`, `locations`, all public types |
+| `initialize.ts` | Listens for the host's `connect` message, builds the SDK, and hands it to the user's callback | `createInitializer` |
+| `channel.ts` | PostMessage send/receive; correlates request IDs to response promises; dispatches host events to handlers | `Channel`, `connect`, `sendInitMessage` |
+| `signal.ts` | Tiny event emitter; `MemoizedSignal` replays the latest value to new subscribers | `Signal`, `MemoizedSignal` |
+| `api.ts` | Composes the location-specific SDK by reducing a list of "producer" functions | `createAPI`, `LOCATION_TO_API_PRODUCERS` |
+| `locations.ts` | The `locations` runtime enum exported to consumers | `LOCATION_*` keys |
+| `entry.ts` | Entry-level API (`getSys`, `publish`, `save`, `onSysChanged`, fields, tasks, metadata) | `createEntry` |
+| `field.ts` | Per-content-type field; multi-locale wrapper | `makeField` |
+| `field-locale.ts` | Single field+locale: `getValue`, `setValue`, `onValueChanged`, validation/disabled signals | `makeFieldLocale` |
+| `editor.ts` | Entry editor settings: locale settings, hidden-field visibility | `createEditor` |
+| `space.ts` | Legacy CRUD wrappers (deprecated since v4.0.0) — every method warns and delegates to channel | `createSpace` |
+| `dialogs.ts` | System dialogs (alert/confirm/prompt) and entity selectors (entries, assets, experiences, patterns, component definitions) | `createDialogs` |
+| `navigator.ts` | Open/navigate to entries, assets, app pages, app config; release-aware | `createNavigator` |
+| `app.ts` | App lifecycle hooks for the config screen: `setReady`, `onConfigure` (preInstall), `onConfigurationCompleted` (postInstall) | `createApp` |
+| `agent.ts` | AI agent location: context updates, toolbar actions, layout variant control | `createAgent` |
+| `asset.ts` | Asset-side methods on the asset sidebar location | `createAsset` |
+| `cma.ts` | Wraps `contentful-management` `createClient` with the channel-backed adapter | `createCMAClient` |
+| `cmaAdapter.ts` | The channel-backed `Adapter` for `contentful-management` | `createAdapter` |
+| `window.ts` | iframe height management: `MutationObserver`-driven auto-resize + manual `updateHeight` | `createWindow` |
+| `types/` | Public TypeScript surface — no runtime code | All `*AppSDK` types, `ConnectMessage`, `IdsAPI`, etc. |
+| `utils/deferred.ts` | Promise-with-external-resolve helper used by `initialize.ts` | `createDeferred` |
+
+## Data Flow: Initialization Handshake
 
 ```
-Contentful Host App (parent frame)
-        │
-        │  window.postMessage (structured messages)
-        ▼
-App iframe (app code calls sdk.field.getValue(), etc.)
-        │
-        └── lib/channel.ts       (PostMessage send/receive abstraction)
-                └── lib/signal.ts    (event subscription over a channel)
-                        └── lib/initialize.ts  (creates SDK instance)
-                                └── lib/api.ts     (routes to location-specific API objects)
+[Host]                                                [App iframe]
+  │                                                          │
+  │                              ◄─── connect listener ──────│  channel.ts:waitForConnect
+  │                                                          │  installs message listener
+  │                              ◄── postMessage(init) ──────│  channel.ts:sendInitMessage
+  │                                                          │
+  │── postMessage("connect", [params, queue]) ─►            │  initialize.ts:connectDeferred resolves
+  │                                                          │  api.ts:createAPI builds SDK
+  │                                                          │  user's init callback invoked
+  │                                                          │
+  │── postMessage(<event/method/response>) ────────────────►│  channel.ts:_handleMessage routes
 ```
 
-## Module Structure
+The SDK *connects immediately on import*, before `init()` is called, so it doesn't lose host messages that arrive before the app is ready (`initialize.ts:21-32`). User callback fires after the connect handshake completes.
 
-| Module | Role |
-|--------|------|
-| `lib/initialize.ts` | Connects to host frame; creates the SDK instance passed to `init()` callback |
-| `lib/channel.ts` | PostMessage send/receive abstraction |
-| `lib/signal.ts` | Event subscription over a channel |
-| `lib/api.ts` | Factory — builds the correct SDK object for the current location |
-| `lib/field.ts` | Field-level API (get/set value, validate) |
-| `lib/field-locale.ts` | Field API with locale selection |
-| `lib/entry.ts` | Entry-level API |
-| `lib/editor.ts` | Entry editor API |
-| `lib/app.ts` | App lifecycle hooks (`setReady`, `onConfigure`, `getParameters`) |
-| `lib/window.ts` | Window/size control (`updateHeight`, `startAutoResizer`) |
-| `lib/space.ts` | Space read/write API (wraps CMA calls through the channel) |
-| `lib/dialogs.ts` | System dialog management |
-| `lib/navigator.ts` | Host navigation API |
-| `lib/cma.ts` + `lib/cmaAdapter.ts` | CMA adapter (passes CMA calls through the channel to the host) |
-| `lib/locations.ts` | `locations` enum |
-| `lib/types/` | All public TypeScript types — no runtime code |
+## Data Flow: A Field Read
 
-## Location SDK Variants
+```
+app code             field-locale.ts        channel.ts          host
+   │ getValue() ────►│                         │                  │
+   │                 │ returns memoized value  │                  │
+   │◄────────────────│                         │                  │
+                                              ...
+host emits valueChanged event
+   │                 │ ◄── addHandler ─────────│                  │
+   │ onValueChanged ─│                         │                  │
+   │   (handler)     │                         │ ◄── postMessage ─│
+   │                 │  signal.dispatch        │                  │
+   │◄── handler ─────│                         │                  │
+```
 
-`lib/api.ts` builds a different SDK object depending on which Contentful location the app is rendering in:
-
-| Location | SDK Type |
-|----------|----------|
-| `entry-field` | `FieldAppSDK` |
-| `entry-sidebar` | `SidebarAppSDK` |
-| `entry-editor` | `EditorAppSDK` |
-| `app-config` | `AppExtensionSDK` |
-| `dialog` | `DialogAppSDK` |
-| `page` | `PageAppSDK` |
-| `home` | `HomeExtensionSDK` |
+Reads of "current value" are local (memoized in `MemoizedSignal`); writes (`setValue`) and most other operations round-trip through the channel.
 
 ## Build Pipeline
 
 ```
 lib/**/*.ts
-  → Rollup (rollup.config.js)
-      → dist/cf-extension-api.js          (UMD, minified)
-      → dist/cf-extension-api.bundled.js  (CDN self-contained bundle)
-  → tsc
-      → dist/index.d.ts                   (TypeScript declarations)
+   │
+   ├─► tsc --noEmit                       (npm run check-types — gate)
+   │
+   └─► rollup (rollup.config.js)
+         ├─► dist/cf-extension-api.js          UMD, target=ES5, terser-minified
+         ├─► dist/cf-extension-api.bundled.js  UMD with deps inlined for CDN consumption
+         ├─► dist/index.d.ts                   tsc-emitted ambient types
+         └─► dist/cf-extension.css             (legacy stylesheet, kept for back-compat)
 ```
 
-- Target: ES5 (broad browser compatibility)
-- Format: UMD (works in CommonJS and browser globals)
-- Minification: Terser (production); source maps available via `build:debug`
+- **Target ES5** for broadest browser compatibility (`tsconfig.json#target`); customers loading via `<script>` from jsdelivr/unpkg may serve to old browsers.
+- **UMD** so the bundle works as a CommonJS export in Node-y bundlers, an AMD module, or a browser global.
+- **Two outputs** — `cf-extension-api.js` keeps `contentful-management` external (the dependent expects to provide it), `cf-extension-api.bundled.js` inlines everything for CDN script-tag use.
+- **`globalThis.contentfulApp` and `globalThis.contentfulExtension`** are both set as browser globals (`rollup.config.js:25`) so old `<script>` integrations continue to work.
 
-## Dual-Package Publish
+## Dual-Package Publishing
 
-The same build is published under two npm package names:
+Same `dist/` is published under two npm package names, in this order, by `scripts/publish.js`:
 
-1. `@contentful/app-sdk` — modern scoped name
-2. `contentful-ui-extensions-sdk` — legacy name
+1. `contentful-ui-extensions-sdk`
+2. `@contentful/app-sdk`
 
-`scripts/publish.js` temporarily mutates `package.json` `name` field and runs `npm publish` twice. Semantic-release triggers this on `master` and `canary` branches.
+`scripts/shared.js` rewrites `package.json#name` between publishes and runs `npm install` to refresh metadata before each `npm publish`. `restorePackageJson` resets the file at the end. Versions are kept in lock-step — both packages always release the same version.
+
+Driven by `semantic-release` via the `@semantic-release/exec` plugin (`package.json#release.plugins`), which calls `verify.js` for `verifyConditions` and `publish-all` for `publishCmd`. Trusted publishing via HashiCorp Vault provides short-lived npm tokens (`.github/workflows/release.yaml`).
+
+## Branches & Release Channels
+
+| Branch | npm dist-tag | Version pattern |
+|---|---|---|
+| `main` | `latest` | `X.Y.Z` |
+| `canary` | `canary` | `X.Y.Z-alpha.N` |
+
+Per `package.json#release.branches`. Canary is "reset to main, branch, PR into canary, merge."
 
 ## CI / Release
 
 ```
-Every commit (CircleCI):
-  unit → lint + test + build + size check
+PR or push to main/canary  ─►  .github/workflows/ci.yaml
+                                  matrix: Node 22, Node 24
+                                  install → lint → test → build → size → upload reports → cache dist (main only)
 
-master/canary branches (after unit):
-  semantic-release → version bump → dual npm publish
+push to main (CI green) ──────►  .github/workflows/release.yaml
+                                  Vault → checkout → semantic-release → publish to npmjs.org × 2
+
+dependabot PR ────────────────►  .github/workflows/dependabot-approve-and-request-merge.yml
+                                  contentful/github-auto-merge@v1
 ```
 
-- **`master`**: publishes `latest` tag
-- **`canary`**: publishes `X.Y.Z-alpha.N` under `canary` dist-tag
+- **Branch protection on:** 1 required approving review, code-owner review required, stale reviews dismissed on push, strict status checks, no force-push, no branch deletion based on the repo's GitHub branch-protection settings.
+- **Semantic PR titles required** — `.github/semantic.yml` enforces title-only validation (PRs are squash-merged).
+- **Release runs after CI succeeds** via `workflow_run` trigger; the manual `workflow_dispatch` path also accepts `canary` for ad-hoc alpha cuts.
 
 ## Key Dependencies
 
-| Package | Role |
-|---------|------|
-| `contentful-management` | Only production dependency — CMA adapter types |
-| `rollup` + `terser` | Bundler + minifier |
-| `ts-mocha` + `mocha` | Test runner |
-| `chai` + `sinon` | Assertions + mocking |
-| `jsdom` | Browser DOM simulation in tests |
-| `semantic-release` | Automated versioning + publish |
+| Package | Role | Type |
+|---|---|---|
+| `contentful-management` (^12.3.1) | CMA types + `createClient` adapter point | **Runtime — only one** |
+| `rollup` (2.80) + `@rollup/plugin-commonjs` + `@rollup/plugin-node-resolve` + `rollup-plugin-typescript2` + `rollup-plugin-terser` | Bundler chain | Build |
+| `typescript` (5.9) | Type-check + `.d.ts` emit | Build |
+| `mocha` + `ts-mocha` + `chai` + `sinon` + `sinon-chai` + `chai-as-promised` + `jsdom` | Test stack | Test |
+| `eslint` (8.57) + `eslint-config-standard` + `eslint-config-prettier` + `@typescript-eslint/*` | Linting | Tooling |
+| `husky` + `lint-staged` | Pre-commit `prettier --write` + `eslint --fix` on staged TS/MD files | Tooling |
+| `semantic-release` (^25) + `@semantic-release/changelog` + `@semantic-release/exec` + `@semantic-release/git` | Release automation | Release |
+
+## Configuration & Conventions
+
+- **`.npmrc`**: `ignore-scripts=true` (security; install-time scripts in transitive deps cannot run); `@contentful` registry is npmjs.org (not GitHub Packages).
+- **`.nvmrc`**: `v24.11.0` is the recommended local Node version. CI runs Node 22 and 24 in matrix.
+- **`tsconfig.json`**: strict mode on; ES5 target; ESNext module; declaration emit on; `noEmit` is set in `tsconfig.test.json`.
+- **`eslint.config`** extends `standard` + `prettier/recommended` + `@typescript-eslint/eslint-recommended`; `no-var` and `prefer-const` are errors; the deprecated `babel-eslint` is still pulled in but not configured as a parser.
+- **`prettier`**: 100-col, single quotes, no semis, JSX bracket same line.
+
+## Operational Knowledge
+
+This repo publishes a library — there are no SLOs, runbooks, or alert routes bound to it directly. Library bugs surface in consuming services, so escalation flows through *those* runbooks. Internal escalation paths (on-call rotations, alert routing) are documented separately in internal Contentful resources.
+
+- **CI/release breakage**: routed via the alert channel configured in `catalog-info.yaml#contentful.com/ci-alert-slack`.
+- **Security alerts**: monitor Dependabot continuously and treat security-relevant updates as priority — the SDK ships to many installations.
+
+### Broken-release recovery (forward-fix, not rollback)
+
+If a published SDK version is broken (e.g., npm publish corruption, a regression in app code that customers fetch via `<script src="https://cdn.jsdelivr.net/npm/@contentful/app-sdk@4">`):
+
+1. **`npm unpublish` is not a valid recovery path.** Per [npm's unpublish policy](https://docs.npmjs.com/policies/unpublish), versions older than 72 hours cannot be unpublished, and `npm deprecate` does not stop CDN fetches — customers still receive the broken version.
+2. **Ship a forward-fix version.** Cut a new patch release. All CDN consumers immediately move forward; bundled consumers move on their next deploy.
+3. **Trigger:** `workflow_dispatch` of `release.yaml` (manual run from the Actions UI) is the documented escape hatch. Use the `main` branch for a `latest`-tag fix, the `canary` branch for an alpha-tag fix.
+4. **Detection:** there is no proactive monitoring of CDN bundle integrity. Breakage is typically reported by customers.
+
+### CDN dependency surface
+
+The SDK has hard dependencies on `npmjs.org` and `cdn.jsdelivr.net` / `unpkg.com` for CDN consumers. Both can fail independently of Contentful infrastructure. Mitigations:
+
+- Subscribe to npm status (`https://status.npmjs.org/`)
+- Periodically check unpkg/jsdelivr endpoints
+
+**Behavior during a CDN outage:**
+- **Bundled installs** (customer ran `npm install @contentful/app-sdk` and bundled the SDK into their app): unaffected — the SDK is already in their build artifact.
+- **Script-tag installs** (`<script src="https://cdn.jsdelivr.net/npm/@contentful/app-sdk@4">`): hard-fail on app load. The customer's app iframe will not initialize until the CDN is reachable again. There is no SDK-side retry or fallback CDN.
+- **CMA outage** (Contentful Management API unavailable): SDK methods that call through `sdk.cma.*` reject with the underlying CMA error. Cached values (`field.getValue()`, `entry.getSys()`) continue to return their last-known values from `MemoizedSignal` state.
+
+### Production breakage triage
+
+This repo has no SDK-bound dashboards (no Datadog, Grafana, or other monitor specific to this repo — `kind: library` entities are not bound to runtime monitoring). Diagnostic signal lives in:
+
+1. **GitHub Actions** for CI/release breakage: `https://github.com/contentful/ui-extensions-sdk/actions`
+2. **npm package page** for publish state: `https://www.npmjs.com/package/@contentful/app-sdk`
+3. **Consuming-service dashboards** for downstream effect — owned by the respective consuming-service teams.
+
+| Symptom | First place to look |
+|---|---|
+| Suspected bad SDK version on npm | Run `npm view @contentful/app-sdk versions --json` and compare against `git log --oneline` of release commits; if a bad version shipped, follow "Broken-release recovery" above |
+| CI/release pipeline failure | `release.yaml` and `ci.yaml` runs in GitHub Actions; alert channel configured in `catalog-info.yaml#contentful.com/ci-alert-slack` |
+| Customer reports app rendering empty / not loading | Escalate via the consuming service's standard support path — this repo is not the right place to triage it |
+| Customer reports rate-limit errors | Falls back to the consuming Web App's monitoring; SDK has no rate-limit telemetry of its own |
+
+The "primary alarm" question doesn't apply to this repo — there isn't one. When something looks wrong, *escalate to the consuming service's on-call*, not respond directly here.
+
+### Cross-repo testing for non-trivial SDK changes
+
+The SDK is consumed by other internal Contentful packages and by the host web app itself. For wide-blast-radius changes, the observed practice is:
+
+1. Branch in `ui-extensions-sdk`; run `lint`, `check-types`, `build`, `test` locally.
+2. If a local-package link is enough → link the branch into the relevant downstream package and verify there; otherwise push to `canary` and cut a real `X.Y.Z-alpha.N` release.
+3. Bump the linked or canary version in each downstream package and run its CI.
+4. For host-flagged surfaces (e.g., the agent location), coordinate with the host team to verify the relevant feature flags are configured in the test environment before running through to the web app.
+
+This is intentionally captured as *observed practice* rather than a canonical playbook — the cross-repo flow evolves over time, and freezing it at CONTRIBUTING-level prescription invites drift.
+

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -142,7 +142,7 @@ dependabot PR ────────────────►  .github/workf
                                   contentful/github-auto-merge@v1
 ```
 
-- **Branch protection on:** 1 required approving review, code-owner review required, stale reviews dismissed on push, strict status checks, no force-push, no branch deletion based on the repo's GitHub branch-protection settings.
+- **Branch protection on:** 1 required approving review, code-owner review required, stale reviews dismissed on push, strict status checks, no force-push, no branch deletion.
 - **Semantic PR titles required** — `.github/semantic.yml` enforces title-only validation (PRs are squash-merged).
 - **Release runs after CI succeeds** via `workflow_run` trigger; the manual `workflow_dispatch` path also accepts `canary` for ad-hoc alpha cuts.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# Claude Project Instructions — `ui-extensions-sdk`
+
+You are working in the **`ui-extensions-sdk`** repo (`github.com/contentful/ui-extensions-sdk`). It builds the **App SDK** and publishes it to npm as `@contentful/app-sdk` (preferred) and the legacy `contentful-ui-extensions-sdk` alias. Read [AGENTS.md](./AGENTS.md) and [ARCHITECTURE.md](./ARCHITECTURE.md) before making non-trivial changes.
+
+## Identity & Scope
+
+- This is a public, customer-facing TypeScript library. Public types are a contract: thousands of customer apps and many internal repos consume `lib/types/index.ts`.
+- Co-owned by `@contentful/team-extensibility` and `@contentful/team-marketplace`.
+- Bundle size is policed by CI. Adding a runtime dependency is almost always wrong — `contentful-management` is currently the only one.
+
+## Working style
+
+- **Conventional Commits** at PR-title level. Use `feat:`, `fix:`, `chore:` (no release), `docs:` (no release), `refactor:` (no release).
+- **Breaking changes** require a `BREAKING CHANGE:` footer — `feat!:` alone does not bump major reliably.
+- **One unit test per module** under `test/unit/<module>.spec.ts`.
+- **No `any`** in public types. `unknown` is acceptable internally.
+- **Squash merge.** PR title becomes the commit message.
+
+## Sharp edges
+
+1. Do not edit `package.json#name` — `scripts/publish.js` mutates it during dual-publish.
+2. Do not add methods to `lib/space.ts` — it is deprecated since v4.0.0.
+3. Do not reference `globalThis.contentfulExtension` in new code; it's a back-compat alias only.
+4. Do not run `npm install` if you don't have to — `npm ci` is the source of truth and CI uses it.
+5. Do not skip the husky pre-commit hook with `--no-verify` unless the hook itself is broken.
+6. Do not introduce ESM-only dependencies — the bundle is UMD-target ES5.
+
+## Verification before claiming done
+
+```bash
+npm run check-types
+npm run lint
+npm test
+npm run build
+npm run size
+```
+
+If any of these fail, the work is not done. Fix the root cause; do not bypass.
+
+## When adding a new location
+
+1. Add the constant to `lib/locations.ts`.
+2. Add the SDK type to `lib/types/api.types.ts` (a new `<Name>AppSDK` and the `Locations` interface).
+3. Add the location to `LOCATION_TO_API_PRODUCERS` in `lib/api.ts`.
+4. Add a producer factory in a new `lib/<name>.ts` if the location needs a unique surface.
+5. Add a unit test in `test/unit/<name>.spec.ts`.
+6. Add the new SDK type to the `KnownAppSDK` union.
+
+The newest examples to model on are `lib/agent.ts` (the AI agent location) and the `Agent*` types.
+
+## Tool boundaries
+
+- **Edit**: source code in `lib/`, tests in `test/`, configs in repo root.
+- **Don't edit**: `dist/` (generated), `docs/` (legacy GitHub Pages CDN — see `docs/WARNING.txt`), `CHANGELOG.md` (semantic-release owns it).
+- **Don't run**: `npm publish`, `npm version`, manual git tags. Releases are automated.
+
+## Reference
+
+- Contentful Docs: https://www.contentful.com/developers/docs/extensibility/app-framework/sdk/
+- CI alerts: `#prd-extensibility-bots`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,90 +1,144 @@
-# Contributing to contentful-ui-extensions-sdk / @contentful/app-sdk
+# Contributing to `ui-extensions-sdk`
+
+This repo builds the **App SDK** and publishes it as `@contentful/app-sdk` (preferred) and `contentful-ui-extensions-sdk` (legacy alias). Local development, tests, and PR conventions below all describe work *in this repo*.
 
 ## Prerequisites
 
-| Tool | Version |
-|------|---------|
-| Node.js | 18 (`.nvmrc`) |
-| npm | bundled with Node |
+| Tool | Version | Source |
+|---|---|---|
+| Node.js | 24.11.0 (local), 22 or 24 (CI matrix) | `.nvmrc`, `.github/workflows/ci.yaml` |
+| npm | bundled with Node | — |
+| Git | any recent | — |
 
-## Setup
+If you use `nvm`, `nvm use` picks up `.nvmrc`.
+
+## Getting started
 
 ```bash
-git clone https://github.com/contentful/ui-extensions-sdk.git
+git clone git@github.com:contentful/ui-extensions-sdk.git
 cd ui-extensions-sdk
 npm ci
 ```
 
-## Running Tests
+`npm ci` (not `install`) because the lockfile is the source of truth and CI uses `ci`.
+
+The repo has an `.npmrc` with `ignore-scripts=true` for security — postinstall scripts in transitive dependencies will not run. This is intentional. Do not change it.
+
+## Dev workflow
+
+| Want to… | Run |
+|---|---|
+| Run unit tests | `npm test` |
+| Type-check only | `npm run check-types` |
+| Lint | `npm run lint` |
+| Lint + autofix | `npm run lint:fix` |
+| Build a release bundle | `npm run build` |
+| Build with sourcemaps | `npm run build:debug` |
+| Check gzipped bundle size | `npm run size` (requires a prior `build`) |
+
+CI runs `lint → test → build → size` in that order on every PR (`.github/workflows/ci.yaml`). Match that locally before opening a PR.
+
+A pre-commit hook (`.husky/pre-commit`) runs `lint-staged` over your staged files: `prettier --write` + `eslint --fix` on `.ts`, `prettier --write` on `.md`. Don't bypass with `--no-verify` unless the hook itself is broken.
+
+## Testing
 
 ```bash
 npm test
 ```
 
-Tests use **Mocha + ts-mocha** (not Vitest). Test files are in `test/unit/*.spec.ts`. Results are written to `test/unit/reports/` as JUnit XML.
+- Runner: **Mocha** via `ts-mocha` (NOT Jest, NOT Vitest)
+- Assertions: **Chai** + `chai-as-promised`
+- Mocking: **Sinon** + `sinon-chai`
+- DOM simulation: **jsdom** (used heavily in `channel`, `signal`, `window` tests)
+- Test files live at `test/unit/<module>.spec.ts` — one file per `lib/<module>.ts`
+- Reusable test helpers: `test/helpers.ts` (`makeDOM`, `mockMutationObserver`, `mockResizeObserver`, `describeAttachHandlerMember`, `describeChannelCallingMethod`)
+- Mock fixtures: `test/mocks/connectMessage.ts` for the host's connect-message shape
 
-## Building
+Reports are written to `test/unit/reports/test-results.xml` (JUnit XML, configured in `mocha.unit-reporters.json`). CI uploads them as the `test-results-node-{version}` artifact.
 
-```bash
-npm run build
+## Code style
+
+- **TypeScript only** in `lib/`. No `.js` files there.
+- **`strict: true`** is on (`tsconfig.json`). Don't introduce `any` in public types — use `unknown` if necessary, and explicit types everywhere else.
+- **No new runtime dependencies** without strong justification. The repo currently has exactly one (`contentful-management`); adding another should be a deliberate, reviewed decision.
+- **Prettier**: 100-col, single quotes, no semicolons, JSX bracket same line. Config in `.prettierrc`.
+- **ESLint**: `standard` + Prettier integration + `@typescript-eslint`. Notable rules: `no-var: error`, `prefer-const: error`, `@typescript-eslint/no-unused-vars: error`.
+- **One test file per module**: `lib/foo.ts` ↔ `test/unit/foo.spec.ts`.
+- **Public types are exported from `lib/types/index.ts` only** — don't add additional barrel re-exports elsewhere.
+
+## Commit conventions
+
+Conventional Commits, validated at PR-title level (`.github/semantic.yml#titleOnly: true` — PRs are squash-merged so only the title matters). Examples in CHANGELOG.md.
+
+| Prefix | Use for | Triggers release? |
+|---|---|---|
+| `feat:` | new public API or capability | minor |
+| `fix:` | bug fix in published code | patch |
+| `chore:` | tooling, config, CI, docs-only | **no** (skipped by semantic-release) |
+| `docs:` | README/CONTRIBUTING/etc. | **no** |
+| `refactor:` | internal-only restructuring | **no** |
+
+**Breaking changes:** include a `BREAKING CHANGE:` footer in the squash-merge body. The `feat!:` shorthand alone is *not* sufficient — the analyzer needs the footer to bump major. Public types are part of the contract; renaming or removing an export is a breaking change.
+
+## Branch strategy
+
+- **`main`** — default branch; `latest` releases come from here.
+- **`canary`** — alpha pre-release branch. Reset to `main`, branch off, PR into `canary`. Publishes `X.Y.Z-alpha.N` under the `canary` dist-tag.
+- **Feature branches** — open against `main`, name freely. PRs are squash-merged.
+
+Branch protection on `main`:
+- 1 required approving review
+- CODEOWNERS review required
+- Stale reviews dismissed on new pushes
+- Strict status-check matching
+- No force-push, no branch deletion
+
+## Pull requests
+
+1. PR title is the squash-merge commit message — write a Conventional Commits title with a Jira key in brackets where applicable, e.g. `feat: short summary of the change [TICKET-1234]`.
+2. Body follows `.github/PULL_REQUEST_TEMPLATE.md` (purpose + checklist).
+3. Two approvers may be required if your change crosses both team-extensibility and team-marketplace concerns (CODEOWNERS lists both).
+4. CI must be green; size check is part of CI.
+
+## Release process
+
+Fully automated via `semantic-release`. Do not hand-edit `package.json#version`, the changelog, or git tags.
+
+```
+PR merged to main
+  → ci.yaml runs (Node 22 + 24)
+  → if green, release.yaml triggers
+    → HashiCorp Vault provisions a short-lived npm token (trusted publishing)
+    → semantic-release calculates next version from commit messages
+    → scripts/publish.js publishes contentful-ui-extensions-sdk
+    → scripts/publish.js publishes @contentful/app-sdk (same version)
+    → CHANGELOG.md updated, tag pushed, GitHub release created
 ```
 
-Compiles TypeScript and bundles with Rollup. Output goes to `dist/`. Run `npm run build:debug` for a build with source maps.
+Pre-publish dry-run runs in `verifyConditions` via `scripts/verify.js`, which uses a unique `0.0.0-verify.<timestamp>` version to avoid clashing with already-published versions during the dry-run.
 
-## Type Checking
+**Canary releases:** push to `canary`. The same release pipeline runs but emits `X.Y.Z-alpha.N` under the `canary` dist-tag. Install with `npm install @contentful/app-sdk@canary`.
 
-```bash
-npm run check-types
-```
+## Dependabot
 
-Run this before every PR — type errors in a types library are blocking. It's faster to catch locally than in CI.
+- Schedule: daily, with a 15-day cooldown before merging a freshly published version (defense against compromised packages).
+- Groups: `production-dependencies` and `dev-dependencies`, both for minor/patch updates.
+- Auto-merge: dev minor/patch via `contentful/github-auto-merge@v1`.
+- Pinned ignores: `framer-motion >=8.0.0` (not used here, inherited config), `semantic-release >=25.0.0` was previously pinned but the repo is now on 25.x.
 
-## Linting
+## Getting help
 
-```bash
-npm run lint
-```
-
-ESLint on `lib/` and `test/`.
-
-## Bundle Size Check
-
-```bash
-npm run size
-```
-
-Checks gzip size of `dist/cf-extension-api.js`. CI fails if the size limit is exceeded. Run after adding new code or dependencies.
-
-## Code Conventions
-
-- **TypeScript only** — no plain `.js` files in `lib/`
-- **No `any`** — use explicit types or `unknown`
-- **No new production dependencies** without strong justification — the SDK must stay lean
-- **Conventional Commits** — `feat:`, `fix:`, `chore:`, `docs:`
-- **One test file per module** — `lib/foo.ts` → `test/unit/foo.spec.ts`
-
-## Releasing
-
-Releases are fully automated via semantic-release on the `master` branch. Do not manually bump versions or publish.
-
-**Canary releases**: Merge to the `canary` branch. CI publishes `X.Y.Z-alpha.N` under the `canary` npm dist-tag. Install with:
-```bash
-npm install @contentful/app-sdk@canary
-```
-
-## Branch Strategy
-
-- **`master`** — production; triggers semantic-release on merge
-- **`canary`** — prerelease; publishes canary versions
-- **Feature branches** — PR against `master`
+- **CI alerts** route to `#prd-extensibility-bots` (per `catalog-info.yaml`).
+- **Owning teams**: `@contentful/team-extensibility` and `@contentful/team-marketplace` (per CODEOWNERS).
+- **Customer-facing reference**: [Contentful Docs — App SDK Reference](https://www.contentful.com/developers/docs/extensibility/app-framework/sdk/).
 
 ## Troubleshooting
 
-**Type errors after pulling**
-Run `npm ci` — a dependency may have been updated.
-
-**`dist/` is stale**
-Run `npm run build` to regenerate.
-
-**Test failures in `channel` or `signal` modules**
-These depend on jsdom for PostMessage simulation. Ensure `npm ci` has been run and jsdom is installed.
+| Symptom | Likely cause / fix |
+|---|---|
+| `npm ci` fails with peer-dep errors | `contentful-management` major may have shifted — check git log for recent `feat: bump contentful-management` commits |
+| Type errors after pull | A dep updated; run `npm ci` |
+| `dist/` is stale or missing | Run `npm run build` |
+| Tests in `channel.spec.ts` / `signal.spec.ts` / `window.spec.ts` fail with `MutationObserver is not defined` | jsdom isn't set up — check `test/helpers.ts` import or run `npm ci` |
+| Bundle size CI check fails | `npm run size` locally to see the gzipped bytes — likely an unintentional dep import in `lib/` |
+| Pre-commit hook hangs | `lint-staged` is iterating large staged files; commit smaller diffs |

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 The App SDK (formerly known as UI Extensions SDK) is a JavaScript library that allows developers to create custom Contentful Apps
 for the Contentful Web App. Every Contentful App has to include the library in its source.
 
+## For agents and contributors
+
+If you're an AI agent or a new contributor, start here:
+
+- [AGENTS.md](./AGENTS.md) — routing table, sharp edges, and never/always rules
+- [ARCHITECTURE.md](./ARCHITECTURE.md) — module map, data flows, build/release pipeline
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — local setup, tests, commit conventions, release process
+
 ## Resources
 
 - [App SDK reference](https://www.contentful.com/developers/docs/extensibility/app-framework/sdk/)

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,31 +1,25 @@
-# Backstage documentation
-# https://backstage.io/docs/features/software-catalog/descriptor-format/
-
-# !!! WARNING !!!
-# This is a template file with a number of fields that need to be filled before merging this to the default branch
 apiVersion: backstage.io/v1alpha1
-# Component, API, Template, Group, User, Resource, System, Domain, Location
 kind: Component
 metadata:
-  name: ui-extensions-sdk 
-  description: unknown
+  name: ui-extensions-sdk
+  description: JavaScript SDK that bridges Contentful Apps (running in iframes) and the Contentful Web App via a PostMessage channel. Published to npm as @contentful/app-sdk and the legacy contentful-ui-extensions-sdk.
   annotations:
-    github.com/project-slug: contentful/ui-extensions-sdk 
-    contentful.com/service-tier: "unknown" #1, 2, 3, 4
+    github.com/project-slug: contentful/ui-extensions-sdk
+    contentful.com/service-tier: "2"
     contentful.com/ci-alert-slack: prd-extensibility-bots
-
   tags:
-    - update-me
-    #need to add sast.yaml to .github/workflows and enable it in polaris dashboard
-    #once that is done this can be changed to sast-enabled
+    - app-framework
+    - sdk
+    - typescript
+    - library
+    # SAST workflow not yet enabled — needs sast.yaml in .github/workflows and Polaris config
     - sast-disabled
-    #make this match the value from service-tier above
-    - tier-unknown
+    - tier-2
 spec:
-  #cli, component, contentful.com/template, documentation, function, library, service, template, website
   type: library
-  #deprecated, experimental, production, unknown
   lifecycle: production
-  system: unknown #optional
-  # your team name as it appears in github when tagging them for reviews
+  system: app-framework
+  # owner: takes a single group; co-ownership with team-marketplace is enforced via CODEOWNERS.
   owner: group:team-extensibility
+  dependsOn:
+    - component:default/contentful-management.js


### PR DESCRIPTION
# Purpose of PR

Seeds Golden Context documentation for `ui-extensions-sdk` so contributors and AI agents can navigate the repo without a human tour guide.

The existing `AGENTS.md`, `ARCHITECTURE.md`, and `CONTRIBUTING.md` (added in #2555) carry factual drift — Node 18 instead of the actual 24.11, `master` instead of `main`, CircleCI instead of GitHub Actions, and missing `LOCATION_AGENT` / `LOCATION_HOME` from the locations table. This PR replaces those three files with corrected versions and adds the rest of the canonical Golden Context set (`CLAUDE.md`, Bito review configuration), plus aligns `catalog-info.yaml` metadata.

Ticket: [EXT-7431](https://contentful.atlassian.net/browse/EXT-7431).

## What's in this PR

- `README.md` — appends a "For agents and contributors" pointer block. Existing customer-facing content unchanged.
- `AGENTS.md` — restructured ~95-line routing table covering identity, ownership, sharp edges, the full locations table (including `LOCATION_AGENT` and `LOCATION_HOME`), high-traffic areas with mitigations, the "when adding a location" recipe, verification commands, and never/always rules.
- `ARCHITECTURE.md` — module map for all 19 `lib/` files, system context and data flow diagrams, build pipeline, dual-package publishing, CI/release, key dependencies, configuration conventions, and operational knowledge (broken-release recovery, CDN dependency surface, breakage triage, cross-repo testing).
- `CONTRIBUTING.md` — prerequisites (Node 24.11.0 / matrix 22+24), setup, dev workflow, testing, code style, commit conventions, branch strategy, PR guidance, release process, dependabot, troubleshooting.
- `CLAUDE.md` — project instructions for Claude Code agents working in this repo.
- `.bito.yaml` + `.bito/guidelines/` — Bito automated review configuration with architecture, quality, and security guidelines.
- `catalog-info.yaml` — replaces template placeholders with researched values: real description, `service-tier: 2`, `system: app-framework`, semantic tags, and `dependsOn: [contentful-management.js]`.

## PR Checklist

- [x] Tests are added/updated/not required — not required (documentation only)
- [x] Tests are passing — CI runs `lint`, `check-types`, `test`, `build`, and `size` on every PR
- [x] Typescript typings are added/updated/not required — not required (no source changes)

[EXT-7431]: https://contentful.atlassian.net/browse/EXT-7431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ