### PR TITLE
feat: expose Content Semantics surface on App SDK CMAClient [EXT-7432]

### DIFF
--- a/lib/types/cmaClient.types.ts
+++ b/lib/types/cmaClient.types.ts
@@ -15,6 +15,7 @@ export type CMAClient = {
   appSignedRequest: Pick<PlainClientAPI['appSignedRequest'], 'create'>
   bulkAction: PlainClientAPI['bulkAction']
   comment: PlainClientAPI['comment']
+  contentSemanticsIndex: Pick<PlainClientAPI['contentSemanticsIndex'], 'getManyForEnvironment'>
   contentType: PlainClientAPI['contentType']
   editorInterface: PlainClientAPI['editorInterface']
   environment: Pick<PlainClientAPI['environment'], 'get'>
@@ -25,6 +26,10 @@ export type CMAClient = {
   releaseAction: PlainClientAPI['releaseAction']
   role: Pick<PlainClientAPI['role'], 'get' | 'getMany'>
   scheduledActions: PlainClientAPI['scheduledActions']
+  semanticDuplicates: PlainClientAPI['semanticDuplicates']
+  semanticRecommendations: PlainClientAPI['semanticRecommendations']
+  semanticReferenceSuggestions: PlainClientAPI['semanticReferenceSuggestions']
+  semanticSearch: PlainClientAPI['semanticSearch']
   snapshot: PlainClientAPI['snapshot']
   space: Pick<PlainClientAPI['space'], 'get'>
   upload: PlainClientAPI['upload']

--- a/test/unit/cma.spec.ts
+++ b/test/unit/cma.spec.ts
@@ -3,20 +3,47 @@ import { createCMAClient } from '../../lib/cma'
 import { IdsAPI } from '../../lib/types'
 
 describe('createCMAClient()', function () {
-  it('Creates a CMA client', function () {
-    const ids: IdsAPI = {
-      space: 'space',
-      environment: 'environment',
-      environmentAlias: 'environmentAlias',
-      organization: 'organization',
-      extension: 'extension',
-      user: 'user',
-      field: 'field',
-      entry: 'entry',
-      contentType: 'contentType',
-    }
+  const ids: IdsAPI = {
+    space: 'space',
+    environment: 'environment',
+    environmentAlias: 'environmentAlias',
+    organization: 'organization',
+    extension: 'extension',
+    user: 'user',
+    field: 'field',
+    entry: 'entry',
+    contentType: 'contentType',
+  }
 
+  it('Creates a CMA client', function () {
     const client = createCMAClient(ids, { addHandler: () => {} } as any)
     expect(client).to.be.an('object')
+  })
+
+  // Apps are space-env scoped per CMA Adapter Permissions
+  // (https://contentful.atlassian.net/l/cp/g8WtTjUT). Org-scoped surfaces
+  // (semanticSettings, contentSemanticsIndex.get/getMany) are intentionally
+  // excluded.
+  describe('Content Semantics surface', function () {
+    const semanticGetEntities = [
+      'semanticSearch',
+      'semanticDuplicates',
+      'semanticRecommendations',
+      'semanticReferenceSuggestions',
+    ] as const
+
+    semanticGetEntities.forEach((entity) => {
+      it(`exposes ${entity}.get`, function () {
+        const client = createCMAClient(ids, { addHandler: () => {} } as any)
+        expect(client[entity]).to.be.an('object')
+        expect(client[entity].get).to.be.a('function')
+      })
+    })
+
+    it('exposes contentSemanticsIndex.getManyForEnvironment (env-scoped only)', function () {
+      const client = createCMAClient(ids, { addHandler: () => {} } as any)
+      expect(client.contentSemanticsIndex).to.be.an('object')
+      expect(client.contentSemanticsIndex.getManyForEnvironment).to.be.a('function')
+    })
   })
 })


### PR DESCRIPTION
[EXT-7432](https://contentful.atlassian.net/browse/EXT-7432)

# Purpose of PR

Expose the space/environment-scoped [Content Semantics](https://www.contentful.com/developers/docs/content-management-api/) entity surface on the App SDK `CMAClient` type, so that apps can call these methods through `sdk.cma` without casting to `any`.

This unblocks work where SDK-based reference workflows need parity with the standard reference field UI's semantic suggestions.

## What this PR does

Adds the following to the `CMAClient` type:

- `semanticReferenceSuggestions.get`
- `semanticSearch.get`
- `semanticDuplicates.get`
- `semanticRecommendations.get`
- `contentSemanticsIndex.getManyForEnvironment`

## What this PR does NOT do

Apps are space-environment scoped. Org-scoped surfaces are intentionally excluded:

- `semanticSettings.get` (org-scoped)
- `contentSemanticsIndex.get` / `getMany` / `create` / `delete` (org-scoped)

This matches the precedent for `User` and `Usage`, which expose their space-scoped methods only.

## Companion PR

The host CMA adapter allowlist must also be updated for these calls to succeed at runtime. 

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EXT-7432]: https://contentful.atlassian.net/browse/EXT-7432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ