### PR TITLE
feat: expose available Data Assemblies via DataAssemblyAPI.getMany() [EXT-7479]

### DIFF
--- a/lib/exo.ts
+++ b/lib/exo.ts
@@ -13,6 +13,7 @@ import {
   ExoSelectionAPI,
   DataAssemblyAPI,
   DataAssemblySnapshot,
+  DataAssemblySummary,
   DataAssemblyParameterDefinition,
   DataAssemblyParameterValue,
   ComponentPropertyDescriptor,
@@ -229,6 +230,9 @@ function createDataAssemblyAPI(channel: Channel): DataAssemblyAPI {
   return {
     get(): DataAssemblySnapshot {
       return dataAssemblySignal.getMemoizedArgs()[0]
+    },
+    getMany(): Promise<DataAssemblySummary[]> {
+      return channel.call('exo.getAvailableDataAssemblies')
     },
     getParameters(): Promise<Record<string, DataAssemblyParameterDefinition>> {
       return channel.call('exo.getDataAssemblyParameters')

--- a/lib/types/exo.types.ts
+++ b/lib/types/exo.types.ts
@@ -93,9 +93,26 @@ export interface DataAssemblySnapshot {
   parameters: Record<string, DataAssemblyParameterDefinition>
 }
 
+/**
+ * A Data Assembly available within the current experience/fragment, with its parameter
+ * definitions. Returned by {@link DataAssemblyAPI.getMany}. Definition-only — no GraphQL
+ * resolvers, `return` mapping, or nested DAs (consistent with the trimmed DA surface).
+ */
+export interface DataAssemblySummary {
+  id: string
+  name: string
+  description?: string
+  parameters: Record<string, DataAssemblyParameterDefinition>
+}
+
 export interface DataAssemblyAPI {
   /** Returns the current Data Assembly snapshot for the active experience/fragment. */
   get(): DataAssemblySnapshot
+  /**
+   * Resolves the Data Assemblies available in the current experience/fragment, each with its
+   * parameter definitions. Discovery counterpart to {@link get}, which returns only the active DA.
+   */
+  getMany(): Promise<DataAssemblySummary[]>
   /** Resolves all Data Assembly parameter definitions, keyed by parameter id. */
   getParameters(): Promise<Record<string, DataAssemblyParameterDefinition>>
   /** Resolves a single parameter definition, or `null` if no parameter has that id. */

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -156,6 +156,7 @@ export type {
   DataAssemblyParameterDefinition,
   DataAssemblyParameterValue,
   DataAssemblySnapshot,
+  DataAssemblySummary,
   DataAssemblyAPI,
   ExoNodeType,
   ExoNodeSnapshot,

--- a/test/unit/exo.spec.ts
+++ b/test/unit/exo.spec.ts
@@ -486,9 +486,10 @@ describe('createExo()', () => {
       })
 
       describe('.dataAssembly', () => {
-        it('exposes get, onChange, getParameters, getParameter, setParameter, setParameters', () => {
+        it('exposes get, getMany, onChange, getParameters, getParameter, setParameter, setParameters', () => {
           expect(exo!.experience.dataAssembly).to.have.all.keys([
             'get',
+            'getMany',
             'onChange',
             'getParameters',
             'getParameter',
@@ -545,6 +546,27 @@ describe('createExo()', () => {
           it('calls channel.call with "exo.getDataAssemblyParameters"', () => {
             exo!.experience.dataAssembly.getParameters()
             expect(channelStub.call).to.have.been.calledWith('exo.getDataAssemblyParameters')
+          })
+        })
+
+        describe('.getMany()', () => {
+          it('calls channel.call with "exo.getAvailableDataAssemblies"', () => {
+            exo!.experience.dataAssembly.getMany()
+            expect(channelStub.call).to.have.been.calledWith('exo.getAvailableDataAssemblies')
+          })
+
+          it('resolves with the available data assemblies from the channel', async () => {
+            const available = [
+              {
+                id: 'da-1',
+                name: 'Product Grid',
+                parameters: {},
+              },
+            ]
+            channelStub.call = sinon.stub().resolves(available)
+            const exoLocal = createExo(channelStub, mockExoInit)
+            const result = await exoLocal!.experience.dataAssembly.getMany()
+            expect(result).to.deep.equal(available)
           })
         })
 


### PR DESCRIPTION
[EXT-7479](https://contentful.atlassian.net/browse/EXT-7479)

## Summary
- Adds a `getMany(): Promise<DataAssemblySummary[]>` discovery method to `DataAssemblyAPI`, so ExO toolbar apps can enumerate the Data Assemblies **available** in the current experience/fragment (and their parameter definitions) — not just the single active DA exposed by `get()`.
- Adds the public `DataAssemblySummary` type (`{ id, name, description?, parameters }`) and re-exports it from the package barrel.
- Wires the runtime method to a new `exo.getAvailableDataAssemblies` host↔app channel call.
- Purely additive, non-breaking → `feat:` minor on top of `4.58.2`.

## Design decisions (rationale; flagged for review)
- **Scope:** experience-scoped — the host already resolves this set (`dataAssembliesByDefiningEntityId`), so enumeration exposes what's resolved rather than adding an environment-wide CMA registry query.
- **Placement:** method on the existing `DataAssemblyAPI`, **not** a new plural `dataAssemblies` namespace — consistent with CMA's singular-namespace + plural-getter pattern (`cma.entry.getMany`).
- **Name:** `getMany()` to match the CMA SDK convention.
- **Type name:** the ticket originally proposed `AvailableDataAssembly`; renamed to **`DataAssemblySummary`** to follow this repo's noun+suffix style (sits beside `DataAssemblySnapshot`; "summary" = lighter listing view). A docs sweep found no formal upstream precedent for either name, so this was a free choice. The channel protocol string stays `exo.getAvailableDataAssemblies` (host↔app verb, independent of the SDK type).
- **⚠️ Return shape — flagged for pushback:** returns a **bare `DataAssemblySummary[]`**, NOT a CMA-style `{ items, total, skip, limit }` collection wrapper. The wrapper exists for pagination, which can't happen on this small in-editor set, and a bare array is internally consistent with the other `DataAssemblyAPI` methods. If a reviewer wants forward-compat optionality, switching to `{ items }` is a cheap follow-up.

**Ownership note:** experience-assembly is busy and signed off on merge-and-iterate, so this is reviewable by team-extensibility. Downstream host bridge and widget-renderer forwarding will ship in follow-ups — this PR is the SDK-contract-first step.

## Test plan
- [x] `npm run check-types` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 531 passing (incl. 2 new `.getMany()` specs)
- [x] `npm run build` — bundle created
- [x] `npm run size` — 7984 bytes gzipped (negligible delta)
- [ ] Reviewer: confirm the bare-array return shape is acceptable vs. a CMA collection wrapper

Generated with [Claude Code](https://claude.com/claude-code)

[EXT-7479]: https://contentful.atlassian.net/browse/EXT-7479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ