### PR TITLE
fix: trim non-functional ExoNodeAPI methods and collapse Binding [EXT-7495]

### DIFF
--- a/lib/exo.ts
+++ b/lib/exo.ts
@@ -17,7 +17,6 @@ import {
   DataAssemblyParameterValue,
   ComponentPropertyDescriptor,
   DesignValue,
-  Binding,
   SlotDescriptor,
 } from './types'
 
@@ -167,22 +166,6 @@ function createNodeAPI(
     },
     getProperties(): Promise<ComponentPropertyDescriptor[]> {
       return channel.call<ComponentPropertyDescriptor[]>('exo.getNodeProperties', nodeId)
-    },
-    updateProperty<T = unknown>(key: string, value: T): Promise<void> {
-      return channel.call<void>('exo.updateNodeProperty', nodeId, key, value)
-    },
-    getBinding(key: string): Promise<Binding | null> {
-      return channel.call<Binding | null>('exo.getNodeBinding', nodeId, key)
-    },
-    setBinding(key: string, binding: Binding): Promise<void> {
-      return channel.call<void>('exo.setNodeBinding', nodeId, key, binding)
-    },
-    resolveEntryBinding(key: string): Promise<{ entryId: string; fieldId?: string } | null> {
-      return channel.call<{ entryId: string; fieldId?: string } | null>(
-        'exo.resolveNodeEntryBinding',
-        nodeId,
-        key,
-      )
     },
     getSlotDescriptor(): Promise<SlotDescriptor | null> {
       return channel.call<SlotDescriptor | null>('exo.getNodeSlotDescriptor', nodeId)

--- a/lib/types/exo.types.ts
+++ b/lib/types/exo.types.ts
@@ -15,12 +15,6 @@ export type EntryBinding = {
   locale?: string
 }
 
-export type ManualBinding = {
-  type: 'manual'
-}
-
-export type Binding = EntryBinding | ManualBinding
-
 /** A reference to a design token. */
 export type DesignTokenValue = {
   type: 'DesignToken'
@@ -40,15 +34,14 @@ export type DesignValue = DesignTokenValue | ManualDesignValue
  * `area` distinguishes content properties (bound to entry fields / authored content)
  * from design properties (presentation values, e.g. design tokens) — the same split
  * the ExO domain model and editor model natively, letting an app render them separately.
- * `binding`, when present, is the same `Binding` union returned by
- * `ExoNodeAPI.getBinding` — an `EntryBinding` carries the `entryId`/`fieldId` a
+ * `binding`, when present, is an `EntryBinding` carrying the `entryId`/`fieldId` a
  * consumer needs to resolve the backing entry; omitted when the property is unbound.
  */
 export interface ComponentPropertyDescriptor<C = unknown, D extends DesignValue = DesignValue> {
   key: string
   area: 'content' | 'design'
   value: C | D
-  binding?: Binding
+  binding?: EntryBinding
 }
 
 /* Data Assembly types */
@@ -152,14 +145,6 @@ export interface ExoNodeAPI {
   ): Unsubscribe
   /** Resolves the descriptors for all of the node's component properties. */
   getProperties(): Promise<ComponentPropertyDescriptor[]>
-  /** Updates a single property by key (content or design, resolved by the host). */
-  updateProperty<T = unknown>(key: string, value: T): Promise<void>
-  /** Resolves the binding for a property key, or `null` if the property is not bound. */
-  getBinding(key: string): Promise<Binding | null>
-  /** Sets the binding for a property key. */
-  setBinding(key: string, binding: Binding): Promise<void>
-  /** Resolves the entry a property is bound to, or `null` if it is not an entry binding. */
-  resolveEntryBinding(key: string): Promise<{ entryId: string; fieldId?: string } | null>
   /** Resolves the slot descriptor for this node, or `null` if the node is not a slot. */
   getSlotDescriptor(): Promise<SlotDescriptor | null>
 }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -145,8 +145,6 @@ export type {
   ExoSDK,
   ResourceLink,
   EntryBinding,
-  ManualBinding,
-  Binding,
   DesignTokenValue,
   ManualDesignValue,
   DesignValue,

--- a/test/unit/exo.spec.ts
+++ b/test/unit/exo.spec.ts
@@ -311,10 +311,6 @@ describe('createExo()', () => {
             'setDesignProperty',
             'onDesignPropertyChanged',
             'getProperties',
-            'updateProperty',
-            'getBinding',
-            'setBinding',
-            'resolveEntryBinding',
             'getSlotDescriptor',
           ])
         })


### PR DESCRIPTION
[EXT-7495](https://contentful.atlassian.net/browse/EXT-7495)

## Summary
- Removes `ExoNodeAPI` methods that have no host implementation and no current consumer: `getBinding`, `setBinding`, `updateProperty`, and `resolveEntryBinding`. Binding reads/writes are being reshaped into a node-scoped Data Assembly surface in a follow-up; `updateProperty` was redundant with the explicit `setContentProperty` / `setDesignProperty` methods.
- Collapses the `Binding` union to `EntryBinding` and removes `ManualBinding`. In the experience/fragment editor, a node's content properties are populated through Data Assembly parameters; there is no manual content binding for this surface. `ComponentPropertyDescriptor.binding` is now typed as `EntryBinding`.
- Keeps `getProperties` + `ComponentPropertyDescriptor` (the property-read path) and `getSlotDescriptor`.

## Notes
- **Semver: minor.** These are type-contract changes, but the experience-toolbar location is feature-flagged with no consumers yet. Flagging explicitly since `@contentful/app-sdk` is a public contract.
- `ManualBinding` and `Binding` are removed from the public type barrel; `EntryBinding` remains exported.

## Test plan
- [x] `npm run check-types`
- [x] `npm run lint`
- [x] `npm test` (529 passing)
- [x] `npm run build`
- [x] `npm run size` (7917 bytes gzipped — slight reduction)

Generated with [Claude Code](https://claude.com/claude-code)

[EXT-7495]: https://contentful.atlassian.net/browse/EXT-7495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ