### PR TITLE
feat: node-scoped Data Assembly surface and parameter naming [EXT-7496]

### DIFF
--- a/lib/exo.ts
+++ b/lib/exo.ts
@@ -12,7 +12,9 @@ import {
   ExoNodeType,
   ExoSelectionAPI,
   DataAssemblyAPI,
+  DataAssemblyParameterAPI,
   DataAssemblySnapshot,
+  DataAssemblySummary,
   DataAssemblyParameterDefinition,
   DataAssemblyParameterValue,
   ComponentPropertyDescriptor,
@@ -143,15 +145,7 @@ function createNodeAPI(
     onChange(cb: (node: ExoNodeSnapshot) => void): Unsubscribe {
       return nodeSignal.attach(cb)
     },
-    getContentProperty<T = unknown>(key: string): Promise<T> {
-      return channel.call<T>('exo.getNodeContentProperty', nodeId, key)
-    },
-    setContentProperty<T = unknown>(key: string, value: T): Promise<void> {
-      return channel.call<void>('exo.setNodeContentProperty', nodeId, key, value)
-    },
-    onContentPropertyChanged<T = unknown>(key: string, cb: (value: T) => void): Unsubscribe {
-      return channel.addHandler(`exo.nodeContentPropertyChanged.${nodeId}.${key}`, cb)
-    },
+    dataAssembly: createParameterAPI(channel, NODE_DA_SCOPE, nodeId),
     getDesignProperty<T extends DesignValue = DesignValue>(key: string): Promise<T> {
       return channel.call<T>('exo.getNodeDesignProperty', nodeId, key)
     },
@@ -201,6 +195,49 @@ function createSelectionAPI(channel: Channel): ExoSelectionAPI {
   }
 }
 
+/**
+ * Builds the parameter definition/value methods shared by the experience-level
+ * {@link DataAssemblyAPI} and the node-scoped surface on {@link ExoNodeAPI}. `args` are
+ * prepended to every channel call so a node-scoped API can carry its `nodeId` while the
+ * experience-level one carries none.
+ */
+function createParameterAPI(
+  channel: Channel,
+  scope: { definitions: string; definition: string; setValue: string; setValues: string },
+  ...args: unknown[]
+): DataAssemblyParameterAPI {
+  return {
+    getParameterDefinitions(): Promise<Record<string, DataAssemblyParameterDefinition>> {
+      return channel.call(scope.definitions, ...args)
+    },
+    getParameterDefinition(parameterId: string): Promise<DataAssemblyParameterDefinition | null> {
+      return channel.call(scope.definition, ...args, parameterId)
+    },
+    setParameterValue(parameterId: string, value: DataAssemblyParameterValue): Promise<void> {
+      return channel.call(scope.setValue, ...args, parameterId, value)
+    },
+    setParameterValues(
+      updates: Partial<Record<string, DataAssemblyParameterValue>>,
+    ): Promise<void> {
+      return channel.call(scope.setValues, ...args, updates)
+    },
+  }
+}
+
+const EXPERIENCE_DA_SCOPE = {
+  definitions: 'exo.getDataAssemblyParameterDefinitions',
+  definition: 'exo.getDataAssemblyParameterDefinition',
+  setValue: 'exo.setDataAssemblyParameterValue',
+  setValues: 'exo.setDataAssemblyParameterValues',
+}
+
+const NODE_DA_SCOPE = {
+  definitions: 'exo.getNodeParameterDefinitions',
+  definition: 'exo.getNodeParameterDefinition',
+  setValue: 'exo.setNodeParameterValue',
+  setValues: 'exo.setNodeParameterValues',
+}
+
 function createDataAssemblyAPI(channel: Channel): DataAssemblyAPI {
   const initialSnapshot: DataAssemblySnapshot = { id: '', parameters: {} }
   const dataAssemblySignal = new MemoizedSignal<[DataAssemblySnapshot]>(initialSnapshot)
@@ -213,18 +250,10 @@ function createDataAssemblyAPI(channel: Channel): DataAssemblyAPI {
     get(): DataAssemblySnapshot {
       return dataAssemblySignal.getMemoizedArgs()[0]
     },
-    getParameters(): Promise<Record<string, DataAssemblyParameterDefinition>> {
-      return channel.call('exo.getDataAssemblyParameters')
+    getAvailable(): Promise<DataAssemblySummary[]> {
+      return channel.call('exo.getAvailableDataAssemblies')
     },
-    getParameter(parameterId: string): Promise<DataAssemblyParameterDefinition | null> {
-      return channel.call('exo.getDataAssemblyParameter', parameterId)
-    },
-    setParameter(parameterId: string, value: DataAssemblyParameterValue): Promise<void> {
-      return channel.call('exo.setDataAssemblyParameter', parameterId, value)
-    },
-    setParameters(updates: Partial<Record<string, DataAssemblyParameterValue>>): Promise<void> {
-      return channel.call('exo.setDataAssemblyParameters', updates)
-    },
+    ...createParameterAPI(channel, EXPERIENCE_DA_SCOPE),
     onChange(cb: (snapshot: DataAssemblySnapshot) => void): Unsubscribe {
       return dataAssemblySignal.attach(cb)
     },

--- a/lib/types/exo.types.ts
+++ b/lib/types/exo.types.ts
@@ -86,17 +86,42 @@ export interface DataAssemblySnapshot {
   parameters: Record<string, DataAssemblyParameterDefinition>
 }
 
-export interface DataAssemblyAPI {
+/**
+ * A Data Assembly available within the current experience/fragment, with its parameter
+ * definitions. Returned by {@link DataAssemblyAPI.getAvailable}. Definition-only — no GraphQL
+ * resolvers, `return` mapping, or nested DAs.
+ */
+export interface DataAssemblySummary {
+  id: string
+  name: string
+  description?: string
+  parameters: Record<string, DataAssemblyParameterDefinition>
+}
+
+/**
+ * Reads parameter definitions and writes parameter values for a Data Assembly. A parameter's
+ * *definition* (its allowed resources, name, description) and its *value* (the entry bound to it)
+ * are distinct concepts, reflected in the method names: `get*Definition*` reads, `set*Value*` writes.
+ */
+export interface DataAssemblyParameterAPI {
+  /** Resolves all Data Assembly parameter definitions, keyed by parameter id. */
+  getParameterDefinitions(): Promise<Record<string, DataAssemblyParameterDefinition>>
+  /** Resolves a single parameter definition, or `null` if no parameter has that id. */
+  getParameterDefinition(parameterId: string): Promise<DataAssemblyParameterDefinition | null>
+  /** Sets the value of a single Data Assembly parameter. */
+  setParameterValue(parameterId: string, value: DataAssemblyParameterValue): Promise<void>
+  /** Sets multiple Data Assembly parameter values in a single update. */
+  setParameterValues(updates: Partial<Record<string, DataAssemblyParameterValue>>): Promise<void>
+}
+
+export interface DataAssemblyAPI extends DataAssemblyParameterAPI {
   /** Returns the current Data Assembly snapshot for the active experience/fragment. */
   get(): DataAssemblySnapshot
-  /** Resolves all Data Assembly parameter definitions, keyed by parameter id. */
-  getParameters(): Promise<Record<string, DataAssemblyParameterDefinition>>
-  /** Resolves a single parameter definition, or `null` if no parameter has that id. */
-  getParameter(parameterId: string): Promise<DataAssemblyParameterDefinition | null>
-  /** Sets the value of a single Data Assembly parameter. */
-  setParameter(parameterId: string, value: DataAssemblyParameterValue): Promise<void>
-  /** Sets multiple Data Assembly parameter values in a single update. */
-  setParameters(updates: Partial<Record<string, DataAssemblyParameterValue>>): Promise<void>
+  /**
+   * Resolves the Data Assemblies available in the current experience/fragment, each with its
+   * parameter definitions. Discovery counterpart to {@link get}, which returns only the active DA.
+   */
+  getAvailable(): Promise<DataAssemblySummary[]>
   /** Subscribes to Data Assembly snapshot changes. Returns an unsubscribe function. */
   onChange(cb: (snapshot: DataAssemblySnapshot) => void): Unsubscribe
 }
@@ -128,12 +153,13 @@ export interface ExoNodeAPI {
   get(): ExoNodeSnapshot
   /** Subscribes to changes to this node. Returns an unsubscribe function. */
   onChange(cb: (node: ExoNodeSnapshot) => void): Unsubscribe
-  /** Resolves the value of a content property by key. */
-  getContentProperty<T = unknown>(key: string): Promise<T>
-  /** Sets the value of a content property by key. */
-  setContentProperty<T = unknown>(key: string, value: T): Promise<void>
-  /** Subscribes to changes of a single content property. Returns an unsubscribe function. */
-  onContentPropertyChanged<T = unknown>(key: string, cb: (value: T) => void): Unsubscribe
+  /**
+   * Reads parameter definitions and writes parameter values for this node's Data Assembly.
+   * A node's content is populated through Data Assembly parameters, not free-form content
+   * properties — so content is read/written here. Only meaningful for inline-fragment nodes;
+   * other node types have no Data Assembly and these calls resolve empty / are no-ops.
+   */
+  dataAssembly: DataAssemblyParameterAPI
   /** Resolves the value of a design property by key. */
   getDesignProperty<T extends DesignValue = DesignValue>(key: string): Promise<T>
   /** Sets the value of a design property by key. */

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -154,6 +154,8 @@ export type {
   DataAssemblyParameterDefinition,
   DataAssemblyParameterValue,
   DataAssemblySnapshot,
+  DataAssemblySummary,
+  DataAssemblyParameterAPI,
   DataAssemblyAPI,
   ExoNodeType,
   ExoNodeSnapshot,

--- a/test/unit/exo.spec.ts
+++ b/test/unit/exo.spec.ts
@@ -304,9 +304,7 @@ describe('createExo()', () => {
             'nodeType',
             'get',
             'onChange',
-            'getContentProperty',
-            'setContentProperty',
-            'onContentPropertyChanged',
+            'dataAssembly',
             'getDesignProperty',
             'setDesignProperty',
             'onDesignPropertyChanged',
@@ -331,35 +329,42 @@ describe('createExo()', () => {
           expect(channelStub.addHandler.callCount).to.equal(callsBefore)
         })
 
-        describe('.getContentProperty(key)', () => {
-          it('calls channel.call with the correct arguments', () => {
-            node!.getContentProperty('title')
+        describe('.dataAssembly.getParameterDefinitions()', () => {
+          it('calls channel.call with the node-scoped channel and nodeId', () => {
+            node!.dataAssembly.getParameterDefinitions()
             expect(channelStub.call).to.have.been.calledWith(
-              'exo.getNodeContentProperty',
+              'exo.getNodeParameterDefinitions',
               nodeId,
-              'title',
             )
-          })
-
-          it('returns the promise from channel.call', () => {
-            const expectedPromise = Promise.resolve({
-              key: 'title',
-              area: 'content' as const,
-              value: 'Hello',
-            })
-            channelStub.call.withArgs('exo.getNodeContentProperty').returns(expectedPromise)
-            expect(node!.getContentProperty('title')).to.equal(expectedPromise)
           })
         })
 
-        describe('.setContentProperty(key, value)', () => {
-          it('calls channel.call with the correct arguments', () => {
-            node!.setContentProperty('title', 'New Title')
+        describe('.dataAssembly.getParameterDefinition(parameterId)', () => {
+          it('calls channel.call with the node-scoped channel, nodeId, and parameterId', () => {
+            node!.dataAssembly.getParameterDefinition('heroEntry')
             expect(channelStub.call).to.have.been.calledWith(
-              'exo.setNodeContentProperty',
+              'exo.getNodeParameterDefinition',
               nodeId,
-              'title',
-              'New Title',
+              'heroEntry',
+            )
+          })
+        })
+
+        describe('.dataAssembly.setParameterValue(parameterId, value)', () => {
+          it('calls channel.call with the node-scoped channel, nodeId, parameterId, and value', () => {
+            const value = {
+              sys: {
+                type: 'ResourceLink' as const,
+                linkType: 'Contentful:Entry' as const,
+                urn: 'urn',
+              },
+            }
+            node!.dataAssembly.setParameterValue('heroEntry', value)
+            expect(channelStub.call).to.have.been.calledWith(
+              'exo.setNodeParameterValue',
+              nodeId,
+              'heroEntry',
+              value,
             )
           })
         })
@@ -482,14 +487,15 @@ describe('createExo()', () => {
       })
 
       describe('.dataAssembly', () => {
-        it('exposes get, onChange, getParameters, getParameter, setParameter, setParameters', () => {
+        it('exposes get, getAvailable, onChange, and the parameter definition/value methods', () => {
           expect(exo!.experience.dataAssembly).to.have.all.keys([
             'get',
+            'getAvailable',
             'onChange',
-            'getParameters',
-            'getParameter',
-            'setParameter',
-            'setParameters',
+            'getParameterDefinitions',
+            'getParameterDefinition',
+            'setParameterValue',
+            'setParameterValues',
           ])
         })
 
@@ -537,24 +543,33 @@ describe('createExo()', () => {
           })
         })
 
-        describe('.getParameters()', () => {
-          it('calls channel.call with "exo.getDataAssemblyParameters"', () => {
-            exo!.experience.dataAssembly.getParameters()
-            expect(channelStub.call).to.have.been.calledWith('exo.getDataAssemblyParameters')
+        describe('.getAvailable()', () => {
+          it('calls channel.call with "exo.getAvailableDataAssemblies"', () => {
+            exo!.experience.dataAssembly.getAvailable()
+            expect(channelStub.call).to.have.been.calledWith('exo.getAvailableDataAssemblies')
           })
         })
 
-        describe('.getParameter(parameterId)', () => {
-          it('calls channel.call with "exo.getDataAssemblyParameter" and the parameterId', () => {
-            exo!.experience.dataAssembly.getParameter('param-1')
+        describe('.getParameterDefinitions()', () => {
+          it('calls channel.call with "exo.getDataAssemblyParameterDefinitions"', () => {
+            exo!.experience.dataAssembly.getParameterDefinitions()
             expect(channelStub.call).to.have.been.calledWith(
-              'exo.getDataAssemblyParameter',
+              'exo.getDataAssemblyParameterDefinitions',
+            )
+          })
+        })
+
+        describe('.getParameterDefinition(parameterId)', () => {
+          it('calls channel.call with "exo.getDataAssemblyParameterDefinition" and the parameterId', () => {
+            exo!.experience.dataAssembly.getParameterDefinition('param-1')
+            expect(channelStub.call).to.have.been.calledWith(
+              'exo.getDataAssemblyParameterDefinition',
               'param-1',
             )
           })
         })
 
-        describe('.setParameter(parameterId, value)', () => {
+        describe('.setParameterValue(parameterId, value)', () => {
           it('calls channel.call with the correct arguments', () => {
             const value = {
               sys: {
@@ -563,16 +578,16 @@ describe('createExo()', () => {
                 urn: 'crn:contentful:::content:spaces/sp/entries/entry-1',
               },
             }
-            exo!.experience.dataAssembly.setParameter('param-1', value)
+            exo!.experience.dataAssembly.setParameterValue('param-1', value)
             expect(channelStub.call).to.have.been.calledWith(
-              'exo.setDataAssemblyParameter',
+              'exo.setDataAssemblyParameterValue',
               'param-1',
               value,
             )
           })
         })
 
-        describe('.setParameters(updates)', () => {
+        describe('.setParameterValues(updates)', () => {
           it('calls channel.call with the correct arguments', () => {
             const updates = {
               'param-1': {
@@ -583,9 +598,9 @@ describe('createExo()', () => {
                 },
               },
             }
-            exo!.experience.dataAssembly.setParameters(updates)
+            exo!.experience.dataAssembly.setParameterValues(updates)
             expect(channelStub.call).to.have.been.calledWith(
-              'exo.setDataAssemblyParameters',
+              'exo.setDataAssemblyParameterValues',
               updates,
             )
           })


### PR DESCRIPTION
[EXT-7496](https://contentful.atlassian.net/browse/EXT-7496)

## Summary
- **Node-scoped Data Assembly access.** Replaces the `ExoNodeAPI` content-property methods (`getContentProperty` / `setContentProperty` / `onContentPropertyChanged`) with a `node.dataAssembly` surface. A node's content is populated through Data Assembly parameters rather than free-form content properties, so reading definitions and writing values now uses the same shape as the experience-level API. Node Data Assembly access is only meaningful for inline-fragment nodes.
- **Clearer parameter naming.** A parameter's *definition* and its *value* are distinct concepts, but the previous method names blurred them. Renamed on `DataAssemblyAPI`:
  - `getParameters` → `getParameterDefinitions`
  - `getParameter` → `getParameterDefinition`
  - `setParameter` → `setParameterValue`
  - `setParameters` → `setParameterValues`
  - The shared methods are extracted into `DataAssemblyParameterAPI`, reused by both the experience-level `DataAssemblyAPI` and the node-scoped surface.
- **Data Assembly discovery.** Adds `DataAssemblyAPI.getAvailable(): Promise<DataAssemblySummary[]>` to enumerate the Data Assemblies available in the current experience/fragment (and their parameter definitions) — the discovery counterpart to `get()`, which returns only the active one. Supersedes #2596; incorporates the review feedback there (`getAvailable` naming, definition/value split).

## Notes
- **Semver: minor.** Type-contract changes, but the experience-toolbar location is feature-flagged with no consumers yet. Flagging explicitly since `@contentful/app-sdk` is a public contract.
- New exported types: `DataAssemblySummary`, `DataAssemblyParameterAPI`.
- Downstream forwarding (widget-renderer channels / handlers) follows once this publishes.

## Test plan
- [x] `npm run check-types`
- [x] `npm run lint`
- [x] `npm test` (530 passing)
- [x] `npm run build`
- [x] `npm run size` (8027 bytes gzipped)

Generated with [Claude Code](https://claude.com/claude-code)

[EXT-7496]: https://contentful.atlassian.net/browse/EXT-7496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ