### PR TITLE
feat: rename ExO surface to Experience in app-sdk [EXT-7497]

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -9,7 +9,7 @@ import createEditor from './editor'
 import createNavigator from './navigator'
 import createApp from './app'
 import createAgent from './agent'
-import createExo from './exo'
+import createExperience from './experience'
 import locations from './locations'
 import {
   EntryFieldInfo,
@@ -48,7 +48,7 @@ const LOCATION_TO_API_PRODUCERS: { [location: string]: ProducerFunc[] } = {
   [locations.LOCATION_HOME]: [makeSharedAPI],
   [locations.LOCATION_APP_CONFIG]: [makeSharedAPI, makeAppAPI],
   [locations.LOCATION_AGENT]: [makeSharedAPI, makeAgentAPI, makeWindowAPI],
-  [locations.LOCATION_EXPERIENCE_TOOLBAR]: [makeSharedAPI, makeExoAPI],
+  [locations.LOCATION_EXPERIENCE_TOOLBAR]: [makeSharedAPI, makeExperienceAPI],
 }
 
 export default function createAPI(
@@ -177,8 +177,8 @@ function makeAgentAPI(channel: Channel, { agent }: ConnectMessage) {
   }
 }
 
-function makeExoAPI(channel: Channel, data: ConnectMessage) {
+function makeExperienceAPI(channel: Channel, data: ConnectMessage) {
   return {
-    exo: createExo(channel, data.exo),
+    experiences: createExperience(channel, data.experiences),
   }
 }

--- a/lib/experience.ts
+++ b/lib/experience.ts
@@ -1,16 +1,16 @@
 import { Channel } from './channel'
 import { MemoizedSignal } from './signal'
 import {
-  ExoSDK,
-  ExoContext,
+  ExperienceSDK,
+  ExperienceContext,
   UiMode,
   Unsubscribe,
   ExperienceSnapshot,
   ExperienceAPI,
-  ExoNodeAPI,
-  ExoNodeSnapshot,
-  ExoNodeType,
-  ExoSelectionAPI,
+  ExperienceNodeAPI,
+  ExperienceNodeSnapshot,
+  ExperienceNodeType,
+  ExperienceSelectionAPI,
   DataAssemblyAPI,
   DataAssemblyParameterAPI,
   DataAssemblySnapshot,
@@ -23,40 +23,47 @@ import {
 } from './types'
 
 /**
- * Creates the ExO (Experience Orchestration) SDK namespace for the experience-toolbar location.
+ * Creates the Experience SDK namespace for the experience-toolbar location.
  *
- * Throws when called without handshake `exo` data, mirroring `createAgent`. This keeps the
- * public `ExperienceEditorToolbarAppSDK['exo']` type sound (non-optional, always present).
+ * Throws when called without handshake `experiences` data, mirroring `createAgent`. This keeps the
+ * public `ExperienceEditorToolbarAppSDK['experiences']` type sound (non-optional, always present).
  */
-export default function createExo(
+export default function createExperience(
   channel: Channel,
-  exoInit?: { context?: ExoContext; uiMode?: UiMode; experience?: ExperienceSnapshot },
-): ExoSDK {
-  if (exoInit === undefined) {
+  experienceInit?: {
+    context?: ExperienceContext
+    uiMode?: UiMode
+    experience?: ExperienceSnapshot
+  },
+): ExperienceSDK {
+  if (experienceInit === undefined) {
     throw new Error('Context data is required')
   }
 
-  const initialContext: ExoContext = exoInit.context ?? { type: 'experience', entityId: '' }
-  const contextSignal = new MemoizedSignal<[ExoContext]>(initialContext)
+  const initialContext: ExperienceContext = experienceInit.context ?? {
+    type: 'experience',
+    entityId: '',
+  }
+  const contextSignal = new MemoizedSignal<[ExperienceContext]>(initialContext)
 
-  channel.addHandler('exo.contextChanged', (payload: ExoContext) => {
+  channel.addHandler('exo.contextChanged', (payload: ExperienceContext) => {
     contextSignal.dispatch(payload)
   })
 
-  const initialMode: UiMode = exoInit.uiMode ?? 'form'
+  const initialMode: UiMode = experienceInit.uiMode ?? 'form'
   const uiModeSignal = new MemoizedSignal<[UiMode]>(initialMode)
 
   channel.addHandler('exo.uiModeChanged', (payload: { mode: UiMode }) => {
     uiModeSignal.dispatch(payload.mode)
   })
 
-  const experience = createExperienceAPI(channel, exoInit.experience)
+  const experience = createExperienceAPI(channel, experienceInit.experience)
 
   return {
-    get context(): ExoContext {
+    get context(): ExperienceContext {
       return contextSignal.getMemoizedArgs()[0]
     },
-    onContextChanged(cb: (context: ExoContext) => void): Unsubscribe {
+    onContextChanged(cb: (context: ExperienceContext) => void): Unsubscribe {
       return contextSignal.attach(cb)
     },
     getUiMode(): UiMode {
@@ -90,7 +97,7 @@ function createExperienceAPI(channel: Channel, initial?: ExperienceSnapshot): Ex
   // Cache node APIs by id and reuse them. Each createNodeAPI() registers a channel handler
   // for `exo.nodeChanged.${nodeId}`, so constructing a fresh one per getNode() call would
   // leak a handler on every call over a long-lived session. Construct-once, reuse by id.
-  const nodeApis = new Map<string, ExoNodeAPI>()
+  const nodeApis = new Map<string, ExperienceNodeAPI>()
 
   return {
     get(): ExperienceSnapshot {
@@ -105,7 +112,7 @@ function createExperienceAPI(channel: Channel, initial?: ExperienceSnapshot): Ex
     publish(): Promise<void> {
       return channel.call('exo.publishExperience')
     },
-    getNode(nodeId: string): ExoNodeAPI | null {
+    getNode(nodeId: string): ExperienceNodeAPI | null {
       let nodeApi = nodeApis.get(nodeId)
       if (nodeApi === undefined) {
         nodeApi = createNodeAPI(channel, nodeId)
@@ -113,7 +120,7 @@ function createExperienceAPI(channel: Channel, initial?: ExperienceSnapshot): Ex
       }
       return nodeApi
     },
-    getRootNodes(): ExoNodeAPI[] {
+    getRootNodes(): ExperienceNodeAPI[] {
       // Returns [] in this build: root-node access requires a synchronous view of
       // the node tree, which the host has not yet pushed to the SDK. Until that
       // handshake data is available, callers should resolve nodes by id via
@@ -128,21 +135,21 @@ function createExperienceAPI(channel: Channel, initial?: ExperienceSnapshot): Ex
 function createNodeAPI(
   channel: Channel,
   nodeId: string,
-  nodeType: ExoNodeType = 'Component',
-): ExoNodeAPI {
-  const nodeSignal = new MemoizedSignal<[ExoNodeSnapshot]>({ id: nodeId, nodeType })
+  nodeType: ExperienceNodeType = 'Component',
+): ExperienceNodeAPI {
+  const nodeSignal = new MemoizedSignal<[ExperienceNodeSnapshot]>({ id: nodeId, nodeType })
 
-  channel.addHandler(`exo.nodeChanged.${nodeId}`, (payload: ExoNodeSnapshot) => {
+  channel.addHandler(`exo.nodeChanged.${nodeId}`, (payload: ExperienceNodeSnapshot) => {
     nodeSignal.dispatch(payload)
   })
 
   return {
     id: nodeId,
     nodeType,
-    get(): ExoNodeSnapshot {
+    get(): ExperienceNodeSnapshot {
       return nodeSignal.getMemoizedArgs()[0]
     },
-    onChange(cb: (node: ExoNodeSnapshot) => void): Unsubscribe {
+    onChange(cb: (node: ExperienceNodeSnapshot) => void): Unsubscribe {
       return nodeSignal.attach(cb)
     },
     dataAssembly: createParameterAPI(channel, NODE_DA_SCOPE, nodeId),
@@ -167,23 +174,27 @@ function createNodeAPI(
   }
 }
 
-function createSelectionAPI(channel: Channel): ExoSelectionAPI {
-  const selectionSignal = new MemoizedSignal<[{ nodeId: string | null; nodeType?: ExoNodeType }]>({
+function createSelectionAPI(channel: Channel): ExperienceSelectionAPI {
+  const selectionSignal = new MemoizedSignal<
+    [{ nodeId: string | null; nodeType?: ExperienceNodeType }]
+  >({
     nodeId: null,
   })
 
   channel.addHandler(
     'exo.selectionChanged',
-    (payload: { nodeId: string | null; nodeType?: ExoNodeType }) => {
+    (payload: { nodeId: string | null; nodeType?: ExperienceNodeType }) => {
       selectionSignal.dispatch(payload)
     },
   )
 
   return {
-    get(): { nodeId: string | null; nodeType?: ExoNodeType } {
+    get(): { nodeId: string | null; nodeType?: ExperienceNodeType } {
       return selectionSignal.getMemoizedArgs()[0]
     },
-    onChange(cb: (sel: { nodeId: string | null; nodeType?: ExoNodeType }) => void): Unsubscribe {
+    onChange(
+      cb: (sel: { nodeId: string | null; nodeType?: ExperienceNodeType }) => void,
+    ): Unsubscribe {
       return selectionSignal.attach(cb)
     },
     set(nodeId: string | null): void {
@@ -197,7 +208,7 @@ function createSelectionAPI(channel: Channel): ExoSelectionAPI {
 
 /**
  * Builds the parameter definition/value methods shared by the experience-level
- * {@link DataAssemblyAPI} and the node-scoped surface on {@link ExoNodeAPI}. `args` are
+ * {@link DataAssemblyAPI} and the node-scoped surface on {@link ExperienceNodeAPI}. `args` are
  * prepended to every channel call so a node-scoped API can carry its `nodeId` while the
  * experience-level one carries none.
  */

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -23,7 +23,7 @@ import { EntryFieldInfo, FieldInfo } from './field.types'
 import { Adapter, KeyValueMap } from 'contentful-management'
 import { CMAClient } from './cmaClient.types'
 import { AgentAPI, AgentContext } from './agent.types'
-import { ExoSDK, ExoContext, UiMode, ExperienceSnapshot } from './exo.types'
+import { ExperienceSDK, ExperienceContext, UiMode, ExperienceSnapshot } from './experience.types'
 
 /* User API */
 
@@ -358,8 +358,8 @@ export type ExperienceEditorToolbarAppSDK<
   InstallationParameters extends KeyValueMap = KeyValueMap,
 > = Omit<BaseAppSDK<InstallationParameters, never, never>, 'ids'> & {
   ids: Omit<IdsAPI, EntryScopedIds>
-  /** ExO (Experience Orchestration) SDK for experience-toolbar location */
-  exo: ExoSDK
+  /** Experience SDK for experience-toolbar location */
+  experiences: ExperienceSDK
 }
 
 export type KnownAppSDK<
@@ -446,9 +446,9 @@ export interface ConnectMessage {
   release?: Release
   uiLanguageLocale: string
   agent?: AgentContext
-  /** ExO data; when present, SDK constructs sdk.exo */
-  exo?: {
-    context?: ExoContext
+  /** Experiences data; when present, SDK constructs sdk.experiences */
+  experiences?: {
+    context?: ExperienceContext
     uiMode?: UiMode
     experience?: ExperienceSnapshot
   }

--- a/lib/types/experience.types.ts
+++ b/lib/types/experience.types.ts
@@ -1,5 +1,5 @@
 /**
- * ExO (Experience Orchestration) SDK types.
+ * Experience SDK types.
  */
 
 export type Unsubscribe = () => void
@@ -33,7 +33,7 @@ export type DesignValue = DesignTokenValue | ManualDesignValue
  * Describes a single component property: its key, area, current value, and binding.
  * `area` distinguishes content properties (bound to entry fields / authored content)
  * from design properties (presentation values, e.g. design tokens) — the same split
- * the ExO domain model and editor model natively, letting an app render them separately.
+ * the Experience domain model and editor model natively, letting an app render them separately.
  * `binding`, when present, is an `EntryBinding` carrying the `entryId`/`fieldId` a
  * consumer needs to resolve the backing entry; omitted when the property is unbound.
  */
@@ -127,11 +127,11 @@ export interface DataAssemblyAPI extends DataAssemblyParameterAPI {
 }
 
 /** The type of a node within an experience/fragment tree. */
-export type ExoNodeType = 'Component' | 'Fragment' | 'InlineFragment' | 'Slot'
+export type ExperienceNodeType = 'Component' | 'Fragment' | 'InlineFragment' | 'Slot'
 
-export interface ExoNodeSnapshot {
+export interface ExperienceNodeSnapshot {
   id: string
-  nodeType: ExoNodeType
+  nodeType: ExperienceNodeType
 }
 
 export interface SlotDescriptor {
@@ -144,15 +144,15 @@ export interface SlotDescriptor {
  * API for reading and mutating a single node (component, slot, fragment, etc.) within an
  * experience or fragment tree. Obtained via {@link ExperienceAPI.getNode}.
  */
-export interface ExoNodeAPI {
+export interface ExperienceNodeAPI {
   /** The node's unique id within the experience/fragment tree. */
   id: string
   /** The node's type (component, slot, fragment, etc.). */
-  nodeType: ExoNodeType
+  nodeType: ExperienceNodeType
   /** Returns the current snapshot of this node. */
-  get(): ExoNodeSnapshot
+  get(): ExperienceNodeSnapshot
   /** Subscribes to changes to this node. Returns an unsubscribe function. */
-  onChange(cb: (node: ExoNodeSnapshot) => void): Unsubscribe
+  onChange(cb: (node: ExperienceNodeSnapshot) => void): Unsubscribe
   /**
    * Reads parameter definitions and writes parameter values for this node's Data Assembly.
    * A node's content is populated through Data Assembly parameters, not free-form content
@@ -175,9 +175,9 @@ export interface ExoNodeAPI {
   getSlotDescriptor(): Promise<SlotDescriptor | null>
 }
 
-export interface ExoSelectionAPI {
-  get(): { nodeId: string | null; nodeType?: ExoNodeType }
-  onChange(cb: (sel: { nodeId: string | null; nodeType?: ExoNodeType }) => void): Unsubscribe
+export interface ExperienceSelectionAPI {
+  get(): { nodeId: string | null; nodeType?: ExperienceNodeType }
+  onChange(cb: (sel: { nodeId: string | null; nodeType?: ExperienceNodeType }) => void): Unsubscribe
   set(nodeId: string | null): void
   highlight(nodeId: string, opts?: { flash?: boolean; scrollIntoView?: boolean }): void
 }
@@ -211,20 +211,20 @@ export interface ExperienceAPI {
   onChange(cb: (v: ExperienceSnapshot) => void): Unsubscribe
   save(): Promise<void>
   publish(): Promise<void>
-  getNode(nodeId: string): ExoNodeAPI | null
-  getRootNodes(): ExoNodeAPI[]
-  selection: ExoSelectionAPI
+  getNode(nodeId: string): ExperienceNodeAPI | null
+  getRootNodes(): ExperienceNodeAPI[]
+  selection: ExperienceSelectionAPI
   dataAssembly: DataAssemblyAPI
 }
 
-export interface ExoContext {
+export interface ExperienceContext {
   type: 'experience' | 'fragment'
   entityId: string
 }
 
-export interface ExoSDK {
-  context: ExoContext
-  onContextChanged(cb: (context: ExoContext) => void): Unsubscribe
+export interface ExperienceSDK {
+  context: ExperienceContext
+  onContextChanged(cb: (context: ExperienceContext) => void): Unsubscribe
   getUiMode(): UiMode
   onUiModeChanged(cb: (mode: UiMode) => void): Unsubscribe
   experience: ExperienceAPI

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -141,8 +141,8 @@ export type { CMAClient } from './cmaClient.types'
 export type {
   Unsubscribe,
   UiMode,
-  ExoContext,
-  ExoSDK,
+  ExperienceContext,
+  ExperienceSDK,
   ResourceLink,
   EntryBinding,
   DesignTokenValue,
@@ -157,11 +157,11 @@ export type {
   DataAssemblySummary,
   DataAssemblyParameterAPI,
   DataAssemblyAPI,
-  ExoNodeType,
-  ExoNodeSnapshot,
+  ExperienceNodeType,
+  ExperienceNodeSnapshot,
   SlotDescriptor,
   ExperienceSnapshot,
-  ExoNodeAPI,
-  ExoSelectionAPI,
+  ExperienceNodeAPI,
+  ExperienceSelectionAPI,
   ExperienceAPI,
-} from './exo.types'
+} from './experience.types'

--- a/test/mocks/experience.ts
+++ b/test/mocks/experience.ts
@@ -15,12 +15,12 @@ export const mockExperienceSnapshot: ExperienceSnapshot = {
   },
 }
 
-export const mockExoInit = {
+export const mockExperienceInit = {
   uiMode: 'form' as const,
   experience: mockExperienceSnapshot,
 }
 
-export const mockExoInitVisualMode = {
+export const mockExperienceInitVisualMode = {
   uiMode: 'visual' as const,
   experience: mockExperienceSnapshot,
 }

--- a/test/unit/api.spec.ts
+++ b/test/unit/api.spec.ts
@@ -7,7 +7,7 @@ import {
   ConfigAppSDK,
   ConnectMessage,
   ExperienceEditorToolbarAppSDK,
-  ExoSDK,
+  ExperienceSDK,
   UiMode,
 } from '../../lib/types'
 import { mockRelease, mockReleaseWithoutEntities } from '../mocks/releases'
@@ -140,7 +140,7 @@ describe('createAPI()', () => {
     test(expected, locations.LOCATION_PAGE)
   })
 
-  describe('ExO (experience-toolbar) runtime', () => {
+  describe('Experience (experience-toolbar) runtime', () => {
     const baseData = {
       location: locations.LOCATION_EXPERIENCE_TOOLBAR,
       user: 'USER',
@@ -169,56 +169,56 @@ describe('createAPI()', () => {
       },
     } as unknown as ConnectMessage
 
-    it('with exo: { uiMode: "visual" } in handshake, sdk.exo is defined and getUiMode() returns "visual"', () => {
+    it('with experiences: { uiMode: "visual" } in handshake, sdk.experiences is defined and getUiMode() returns "visual"', () => {
       const channel = { addHandler: () => () => {} } as any
       const dom = makeDOM()
       mockMutationObserver(dom, () => {})
       mockResizeObserver(dom, () => {})
 
-      const data: ConnectMessage = { ...baseData, exo: { uiMode: 'visual' } } as any
+      const data: ConnectMessage = { ...baseData, experiences: { uiMode: 'visual' } } as any
       const api = createAPI(channel, data, dom.window as any as Window) as any
 
-      expect(api.exo).to.be.an('object')
-      expect(api.exo.getUiMode()).to.equal('visual')
+      expect(api.experiences).to.be.an('object')
+      expect(api.experiences.getUiMode()).to.equal('visual')
     })
 
-    it('with exo: {} in handshake, getUiMode() returns "form"', () => {
+    it('with experiences: {} in handshake, getUiMode() returns "form"', () => {
       const channel = { addHandler: () => () => {} } as any
       const dom = makeDOM()
       mockMutationObserver(dom, () => {})
       mockResizeObserver(dom, () => {})
 
-      const data: ConnectMessage = { ...baseData, exo: {} } as any
+      const data: ConnectMessage = { ...baseData, experiences: {} } as any
       const api = createAPI(channel, data, dom.window as any as Window) as any
 
-      expect(api.exo).to.be.an('object')
-      expect(api.exo.getUiMode()).to.equal('form')
+      expect(api.experiences).to.be.an('object')
+      expect(api.experiences.getUiMode()).to.equal('form')
     })
 
-    it('without exo in handshake, building the experience-toolbar API throws', () => {
+    it('without experiences in handshake, building the experience-toolbar API throws', () => {
       const channel = { addHandler: () => () => {} } as any
       const dom = makeDOM()
       mockMutationObserver(dom, () => {})
       mockResizeObserver(dom, () => {})
 
       const data: ConnectMessage = { ...baseData } as any
-      delete (data as any).exo
+      delete (data as any).experiences
 
-      // The experience-toolbar location always carries exo data; building it without is a
-      // protocol violation. Throwing keeps the public `exo: ExoSDK` type sound (non-optional).
+      // The experience-toolbar location always carries experiences data; building it without is a
+      // protocol violation. Throwing keeps the public `experiences: ExperienceSDK` type sound (non-optional).
       expect(() => createAPI(channel, data, dom.window as any as Window)).to.throw(
         'Context data is required',
       )
     })
 
     it('onUiModeChanged fires on exo.uiModeChanged event; unsubscribe stops notifications', () => {
-      const exoHandlers: Array<(payload: { mode: UiMode }) => void> = []
+      const experienceHandlers: Array<(payload: { mode: UiMode }) => void> = []
       const channel = {
         addHandler: (method: string, handler: any) => {
-          if (method === 'exo.uiModeChanged') exoHandlers.push(handler)
+          if (method === 'exo.uiModeChanged') experienceHandlers.push(handler)
           return () => {
-            const i = exoHandlers.indexOf(handler)
-            if (i !== -1) exoHandlers.splice(i, 1)
+            const i = experienceHandlers.indexOf(handler)
+            if (i !== -1) experienceHandlers.splice(i, 1)
           }
         },
       } as any
@@ -226,46 +226,46 @@ describe('createAPI()', () => {
       mockMutationObserver(dom, () => {})
       mockResizeObserver(dom, () => {})
 
-      const data: ConnectMessage = { ...baseData, exo: { uiMode: 'visual' } } as any
+      const data: ConnectMessage = { ...baseData, experiences: { uiMode: 'visual' } } as any
       const api = createAPI(channel, data, dom.window as any as Window) as any
 
       const modes: UiMode[] = []
-      const unsubscribe = api.exo.onUiModeChanged((mode: UiMode) => modes.push(mode))
+      const unsubscribe = api.experiences.onUiModeChanged((mode: UiMode) => modes.push(mode))
 
-      expect(api.exo.getUiMode()).to.equal('visual')
-      expect(exoHandlers).to.have.lengthOf(1)
+      expect(api.experiences.getUiMode()).to.equal('visual')
+      expect(experienceHandlers).to.have.lengthOf(1)
       // MemoizedSignal.attach calls the listener immediately with current value
       expect(modes).to.deep.equal(['visual'])
 
-      const dispatchMode = exoHandlers[0]
+      const dispatchMode = experienceHandlers[0]
       dispatchMode({ mode: 'form' })
       expect(modes).to.deep.equal(['visual', 'form'])
-      expect(api.exo.getUiMode()).to.equal('form')
+      expect(api.experiences.getUiMode()).to.equal('form')
 
       unsubscribe()
       dispatchMode({ mode: 'visual' })
       expect(modes).to.deep.equal(['visual', 'form'])
     })
 
-    it('ExperienceEditorToolbarAppSDK has exo: ExoSDK; getUiMode returns UiMode', () => {
+    it('ExperienceEditorToolbarAppSDK has experiences: ExperienceSDK; getUiMode returns UiMode', () => {
       const channel = { addHandler: () => () => {} } as any
       const dom = makeDOM()
       mockMutationObserver(dom, () => {})
       mockResizeObserver(dom, () => {})
 
-      const data: ConnectMessage = { ...baseData, exo: { uiMode: 'form' } } as any
+      const data: ConnectMessage = { ...baseData, experiences: { uiMode: 'form' } } as any
       const api = createAPI(
         channel,
         data,
         dom.window as any as Window,
       ) as ExperienceEditorToolbarAppSDK
 
-      const exo: ExoSDK = api.exo
-      const mode: UiMode = exo.getUiMode()
+      const experiences: ExperienceSDK = api.experiences
+      const mode: UiMode = experiences.getUiMode()
       expect(mode).to.equal('form')
     })
 
-    it('sdk.exo.context reflects the context from handshake', () => {
+    it('sdk.experiences.context reflects the context from handshake', () => {
       const channel = { addHandler: () => () => {} } as any
       const dom = makeDOM()
       mockMutationObserver(dom, () => {})
@@ -273,23 +273,23 @@ describe('createAPI()', () => {
 
       const data: ConnectMessage = {
         ...baseData,
-        exo: { context: { type: 'fragment', entityId: 'frag-456' }, uiMode: 'form' },
+        experiences: { context: { type: 'fragment', entityId: 'frag-456' }, uiMode: 'form' },
       } as any
       const api = createAPI(channel, data, dom.window as any as Window) as any
 
-      expect(api.exo.context).to.deep.equal({ type: 'fragment', entityId: 'frag-456' })
+      expect(api.experiences.context).to.deep.equal({ type: 'fragment', entityId: 'frag-456' })
     })
 
-    it('sdk.exo.context defaults when not provided in handshake', () => {
+    it('sdk.experiences.context defaults when not provided in handshake', () => {
       const channel = { addHandler: () => () => {} } as any
       const dom = makeDOM()
       mockMutationObserver(dom, () => {})
       mockResizeObserver(dom, () => {})
 
-      const data: ConnectMessage = { ...baseData, exo: { uiMode: 'visual' } } as any
+      const data: ConnectMessage = { ...baseData, experiences: { uiMode: 'visual' } } as any
       const api = createAPI(channel, data, dom.window as any as Window) as any
 
-      expect(api.exo.context).to.deep.equal({ type: 'experience', entityId: '' })
+      expect(api.experiences.context).to.deep.equal({ type: 'experience', entityId: '' })
     })
   })
 

--- a/test/unit/experience.spec.ts
+++ b/test/unit/experience.spec.ts
@@ -1,10 +1,14 @@
 import { describeAttachHandlerMember, sinon, expect } from '../helpers'
 
-import createExo from '../../lib/exo'
+import createExperience from '../../lib/experience'
 import { Channel } from '../../lib/channel'
-import { mockExoInit, mockExoInitVisualMode, mockExperienceSnapshot } from '../mocks/exo'
+import {
+  mockExperienceInit,
+  mockExperienceInitVisualMode,
+  mockExperienceSnapshot,
+} from '../mocks/experience'
 
-describe('createExo()', () => {
+describe('createExperience()', () => {
   let channelStub: any
 
   beforeEach(() => {
@@ -15,26 +19,26 @@ describe('createExo()', () => {
     } as unknown as Channel
   })
 
-  describe('when exoInit is undefined', () => {
-    it('throws (mirrors createAgent; keeps the non-optional exo type sound)', () => {
-      expect(() => createExo(channelStub, undefined)).to.throw('Context data is required')
+  describe('when experienceInit is undefined', () => {
+    it('throws (mirrors createAgent; keeps the non-optional experiences type sound)', () => {
+      expect(() => createExperience(channelStub, undefined)).to.throw('Context data is required')
     })
 
     it('does not register any channel handlers', () => {
-      expect(() => createExo(channelStub, undefined)).to.throw()
+      expect(() => createExperience(channelStub, undefined)).to.throw()
       expect(channelStub.addHandler).to.not.have.been.called // eslint-disable-line no-unused-expressions
     })
   })
 
-  describe('when exoInit is provided', () => {
-    let exo: ReturnType<typeof createExo>
+  describe('when experienceInit is provided', () => {
+    let experience: ReturnType<typeof createExperience>
 
     beforeEach(() => {
-      exo = createExo(channelStub, mockExoInit)
+      experience = createExperience(channelStub, mockExperienceInit)
     })
 
     it('returns an object with context, onContextChanged, getUiMode, onUiModeChanged, and experience', () => {
-      expect(exo).to.have.all.keys([
+      expect(experience).to.have.all.keys([
         'context',
         'onContextChanged',
         'getUiMode',
@@ -69,46 +73,52 @@ describe('createExo()', () => {
 
     describe('.context', () => {
       it('defaults to { type: "experience", entityId: "" } when no context is provided', () => {
-        expect(exo!.context).to.deep.equal({ type: 'experience', entityId: '' })
+        expect(experience!.context).to.deep.equal({ type: 'experience', entityId: '' })
       })
 
-      it('returns the provided context from exoInit', () => {
-        const exoWithContext = createExo(channelStub, {
-          ...mockExoInit,
+      it('returns the provided context from experienceInit', () => {
+        const experienceWithContext = createExperience(channelStub, {
+          ...mockExperienceInit,
           context: { type: 'fragment', entityId: 'frag-123' },
         })
-        expect(exoWithContext!.context).to.deep.equal({ type: 'fragment', entityId: 'frag-123' })
+        expect(experienceWithContext!.context).to.deep.equal({
+          type: 'fragment',
+          entityId: 'frag-123',
+        })
       })
 
       it('returns experience context when explicitly provided', () => {
-        const exoWithContext = createExo(channelStub, {
-          ...mockExoInit,
+        const experienceWithContext = createExperience(channelStub, {
+          ...mockExperienceInit,
           context: { type: 'experience', entityId: 'exp-abc' },
         })
-        expect(exoWithContext!.context).to.deep.equal({ type: 'experience', entityId: 'exp-abc' })
+        expect(experienceWithContext!.context).to.deep.equal({
+          type: 'experience',
+          entityId: 'exp-abc',
+        })
       })
 
       it('updates after exo.contextChanged is dispatched', () => {
         const contextChangedHandler = channelStub.addHandler.getCall(0).args[1]
         contextChangedHandler({ type: 'fragment', entityId: 'frag-new' })
-        expect(exo!.context).to.deep.equal({ type: 'fragment', entityId: 'frag-new' })
+        expect(experience!.context).to.deep.equal({ type: 'fragment', entityId: 'frag-new' })
       })
     })
 
     describe('.onContextChanged(cb)', () => {
       describeAttachHandlerMember('default behaviour', () => {
-        return exo!.onContextChanged(() => {})
+        return experience!.onContextChanged(() => {})
       })
 
       it('calls cb immediately with the initial context', () => {
         const cb = sinon.stub()
-        exo!.onContextChanged(cb)
+        experience!.onContextChanged(cb)
         expect(cb).to.have.been.calledOnceWith({ type: 'experience', entityId: '' })
       })
 
       it('calls cb when exo.contextChanged is dispatched', () => {
         const cb = sinon.stub()
-        exo!.onContextChanged(cb)
+        experience!.onContextChanged(cb)
         cb.resetHistory()
 
         const contextChangedHandler = channelStub.addHandler.getCall(0).args[1]
@@ -119,7 +129,7 @@ describe('createExo()', () => {
 
       it('does not call detached cb when exo.contextChanged is dispatched', () => {
         const cb = sinon.stub()
-        const detach = exo!.onContextChanged(cb)
+        const detach = experience!.onContextChanged(cb)
         cb.resetHistory()
         detach()
 
@@ -131,41 +141,43 @@ describe('createExo()', () => {
     })
 
     describe('.getUiMode()', () => {
-      it('returns the initial uiMode from exoInit', () => {
-        expect(exo!.getUiMode()).to.equal('form')
+      it('returns the initial uiMode from experienceInit', () => {
+        expect(experience!.getUiMode()).to.equal('form')
       })
 
-      it('returns "form" when no uiMode is provided in exoInit', () => {
-        const exoNoMode = createExo(channelStub, { experience: mockExperienceSnapshot })
-        expect(exoNoMode!.getUiMode()).to.equal('form')
+      it('returns "form" when no uiMode is provided in experienceInit', () => {
+        const experienceNoMode = createExperience(channelStub, {
+          experience: mockExperienceSnapshot,
+        })
+        expect(experienceNoMode!.getUiMode()).to.equal('form')
       })
 
       it('returns "visual" when uiMode is visual', () => {
-        const exoVisual = createExo(channelStub, mockExoInitVisualMode)
-        expect(exoVisual!.getUiMode()).to.equal('visual')
+        const experienceVisual = createExperience(channelStub, mockExperienceInitVisualMode)
+        expect(experienceVisual!.getUiMode()).to.equal('visual')
       })
 
       it('updates after exo.uiModeChanged is dispatched', () => {
         const uiModeChangedHandler = channelStub.addHandler.getCall(1).args[1]
         uiModeChangedHandler({ mode: 'visual' })
-        expect(exo!.getUiMode()).to.equal('visual')
+        expect(experience!.getUiMode()).to.equal('visual')
       })
     })
 
     describe('.onUiModeChanged(cb)', () => {
       describeAttachHandlerMember('default behaviour', () => {
-        return exo!.onUiModeChanged(() => {})
+        return experience!.onUiModeChanged(() => {})
       })
 
       it('calls cb immediately with the initial uiMode', () => {
         const cb = sinon.stub()
-        exo!.onUiModeChanged(cb)
+        experience!.onUiModeChanged(cb)
         expect(cb).to.have.been.calledOnceWith('form')
       })
 
       it('calls cb when exo.uiModeChanged is dispatched', () => {
         const cb = sinon.stub()
-        exo!.onUiModeChanged(cb)
+        experience!.onUiModeChanged(cb)
         cb.resetHistory()
 
         const uiModeChangedHandler = channelStub.addHandler.getCall(1).args[1]
@@ -176,7 +188,7 @@ describe('createExo()', () => {
 
       it('does not call detached cb when exo.uiModeChanged is dispatched', () => {
         const cb = sinon.stub()
-        const detach = exo!.onUiModeChanged(cb)
+        const detach = experience!.onUiModeChanged(cb)
         cb.resetHistory()
         detach()
 
@@ -189,7 +201,7 @@ describe('createExo()', () => {
 
     describe('.experience', () => {
       it('exposes get, onChange, save, publish, getNode, getRootNodes, selection, and dataAssembly', () => {
-        expect(exo!.experience).to.have.all.keys([
+        expect(experience!.experience).to.have.all.keys([
           'get',
           'onChange',
           'save',
@@ -202,13 +214,13 @@ describe('createExo()', () => {
       })
 
       describe('.get()', () => {
-        it('returns the initial experience snapshot from exoInit', () => {
-          expect(exo!.experience.get()).to.deep.equal(mockExperienceSnapshot)
+        it('returns the initial experience snapshot from experienceInit', () => {
+          expect(experience!.experience.get()).to.deep.equal(mockExperienceSnapshot)
         })
 
-        it('returns a default snapshot when no experience is provided in exoInit', () => {
-          const exoNoExp = createExo(channelStub, { uiMode: 'form' })
-          const snapshot = exoNoExp!.experience.get()
+        it('returns a default snapshot when no experience is provided in experienceInit', () => {
+          const experienceNoExp = createExperience(channelStub, { uiMode: 'form' })
+          const snapshot = experienceNoExp!.experience.get()
           expect(snapshot.sys.type).to.equal('Experience')
           expect(snapshot.sys.id).to.equal('')
           expect(snapshot.sys.version).to.equal(0)
@@ -220,24 +232,24 @@ describe('createExo()', () => {
           }
           const experienceChangedHandler = channelStub.addHandler.getCall(2).args[1]
           experienceChangedHandler(updatedSnapshot)
-          expect(exo!.experience.get()).to.deep.equal(updatedSnapshot)
+          expect(experience!.experience.get()).to.deep.equal(updatedSnapshot)
         })
       })
 
       describe('.onChange(cb)', () => {
         describeAttachHandlerMember('default behaviour', () => {
-          return exo!.experience.onChange(() => {})
+          return experience!.experience.onChange(() => {})
         })
 
         it('calls cb immediately with the initial experience snapshot', () => {
           const cb = sinon.stub()
-          exo!.experience.onChange(cb)
+          experience!.experience.onChange(cb)
           expect(cb).to.have.been.calledOnceWith(mockExperienceSnapshot)
         })
 
         it('calls cb when exo.experienceChanged is dispatched', () => {
           const cb = sinon.stub()
-          exo!.experience.onChange(cb)
+          experience!.experience.onChange(cb)
           cb.resetHistory()
 
           const updatedSnapshot = {
@@ -251,7 +263,7 @@ describe('createExo()', () => {
 
         it('does not call detached cb when exo.experienceChanged is dispatched', () => {
           const cb = sinon.stub()
-          const detach = exo!.experience.onChange(cb)
+          const detach = experience!.experience.onChange(cb)
           cb.resetHistory()
           detach()
 
@@ -266,39 +278,39 @@ describe('createExo()', () => {
 
       describe('.save()', () => {
         it('calls channel.call with "exo.saveExperience"', () => {
-          exo!.experience.save()
+          experience!.experience.save()
           expect(channelStub.call).to.have.been.calledWith('exo.saveExperience')
         })
 
         it('returns the promise from channel.call', () => {
           const expectedPromise = Promise.resolve()
           channelStub.call.withArgs('exo.saveExperience').returns(expectedPromise)
-          expect(exo!.experience.save()).to.equal(expectedPromise)
+          expect(experience!.experience.save()).to.equal(expectedPromise)
         })
       })
 
       describe('.publish()', () => {
         it('calls channel.call with "exo.publishExperience"', () => {
-          exo!.experience.publish()
+          experience!.experience.publish()
           expect(channelStub.call).to.have.been.calledWith('exo.publishExperience')
         })
 
         it('returns the promise from channel.call', () => {
           const expectedPromise = Promise.resolve()
           channelStub.call.withArgs('exo.publishExperience').returns(expectedPromise)
-          expect(exo!.experience.publish()).to.equal(expectedPromise)
+          expect(experience!.experience.publish()).to.equal(expectedPromise)
         })
       })
 
       describe('.getNode(nodeId)', () => {
         const nodeId = 'node-abc'
-        let node: ReturnType<typeof exo.experience.getNode>
+        let node: ReturnType<typeof experience.experience.getNode>
 
         beforeEach(() => {
-          node = exo!.experience.getNode(nodeId)
+          node = experience!.experience.getNode(nodeId)
         })
 
-        it('returns an ExoNodeAPI object with the correct shape', () => {
+        it('returns an ExperienceNodeAPI object with the correct shape', () => {
           expect(node).to.have.all.keys([
             'id',
             'nodeType',
@@ -323,7 +335,7 @@ describe('createExo()', () => {
 
         it('returns the same cached instance for repeated calls and does not leak handlers', () => {
           const callsBefore = channelStub.addHandler.callCount
-          const again = exo!.experience.getNode(nodeId)
+          const again = experience!.experience.getNode(nodeId)
           expect(again).to.equal(node)
           // No additional exo.nodeChanged.<id> handler registered on the second call.
           expect(channelStub.addHandler.callCount).to.equal(callsBefore)
@@ -396,7 +408,7 @@ describe('createExo()', () => {
 
       describe('.selection', () => {
         it('exposes get, onChange, set, and highlight', () => {
-          expect(exo!.experience.selection).to.have.all.keys([
+          expect(experience!.experience.selection).to.have.all.keys([
             'get',
             'onChange',
             'set',
@@ -406,13 +418,13 @@ describe('createExo()', () => {
 
         describe('.get()', () => {
           it('returns { nodeId: null } initially (nothing selected)', () => {
-            expect(exo!.experience.selection.get()).to.deep.equal({ nodeId: null })
+            expect(experience!.experience.selection.get()).to.deep.equal({ nodeId: null })
           })
 
           it('returns the updated selection after exo.selectionChanged is dispatched', () => {
             const selectionChangedHandler = channelStub.addHandler.getCall(3).args[1]
             selectionChangedHandler({ nodeId: 'node-xyz', nodeType: 'Component' })
-            expect(exo!.experience.selection.get()).to.deep.equal({
+            expect(experience!.experience.selection.get()).to.deep.equal({
               nodeId: 'node-xyz',
               nodeType: 'Component',
             })
@@ -421,18 +433,18 @@ describe('createExo()', () => {
 
         describe('.onChange(cb)', () => {
           describeAttachHandlerMember('default behaviour', () => {
-            return exo!.experience.selection.onChange(() => {})
+            return experience!.experience.selection.onChange(() => {})
           })
 
           it('calls cb immediately with { nodeId: null } (initial selection)', () => {
             const cb = sinon.stub()
-            exo!.experience.selection.onChange(cb)
+            experience!.experience.selection.onChange(cb)
             expect(cb).to.have.been.calledOnceWith({ nodeId: null })
           })
 
           it('calls cb when exo.selectionChanged is dispatched', () => {
             const cb = sinon.stub()
-            exo!.experience.selection.onChange(cb)
+            experience!.experience.selection.onChange(cb)
             cb.resetHistory()
 
             const selectionChangedHandler = channelStub.addHandler.getCall(3).args[1]
@@ -443,7 +455,7 @@ describe('createExo()', () => {
 
           it('calls cb with { nodeId: null } when selection is cleared', () => {
             const cb = sinon.stub()
-            exo!.experience.selection.onChange(cb)
+            experience!.experience.selection.onChange(cb)
             cb.resetHistory()
 
             const selectionChangedHandler = channelStub.addHandler.getCall(3).args[1]
@@ -455,28 +467,31 @@ describe('createExo()', () => {
 
         describe('.set(nodeId)', () => {
           it('sends "exo.setSelection" to channel with the nodeId', () => {
-            exo!.experience.selection.set('node-abc')
+            experience!.experience.selection.set('node-abc')
             expect(channelStub.send).to.have.been.calledWith('exo.setSelection', {
               nodeId: 'node-abc',
             })
           })
 
           it('accepts null to clear the selection', () => {
-            exo!.experience.selection.set(null)
+            experience!.experience.selection.set(null)
             expect(channelStub.send).to.have.been.calledWith('exo.setSelection', { nodeId: null })
           })
         })
 
         describe('.highlight(nodeId)', () => {
           it('sends "exo.highlightNode" to channel with the nodeId', () => {
-            exo!.experience.selection.highlight('node-abc')
+            experience!.experience.selection.highlight('node-abc')
             expect(channelStub.send).to.have.been.calledWith('exo.highlightNode', {
               nodeId: 'node-abc',
             })
           })
 
           it('forwards flash and scrollIntoView options to channel', () => {
-            exo!.experience.selection.highlight('node-abc', { flash: true, scrollIntoView: true })
+            experience!.experience.selection.highlight('node-abc', {
+              flash: true,
+              scrollIntoView: true,
+            })
             expect(channelStub.send).to.have.been.calledWith('exo.highlightNode', {
               nodeId: 'node-abc',
               flash: true,
@@ -488,7 +503,7 @@ describe('createExo()', () => {
 
       describe('.dataAssembly', () => {
         it('exposes get, getAvailable, onChange, and the parameter definition/value methods', () => {
-          expect(exo!.experience.dataAssembly).to.have.all.keys([
+          expect(experience!.experience.dataAssembly).to.have.all.keys([
             'get',
             'getAvailable',
             'onChange',
@@ -501,7 +516,7 @@ describe('createExo()', () => {
 
         describe('.get()', () => {
           it('returns the initial empty DataAssemblySnapshot', () => {
-            const snapshot = exo!.experience.dataAssembly.get()
+            const snapshot = experience!.experience.dataAssembly.get()
             expect(snapshot.id).to.equal('')
             expect(snapshot.parameters).to.deep.equal({})
           })
@@ -514,25 +529,25 @@ describe('createExo()', () => {
             }
             const dataAssemblyChangedHandler = channelStub.addHandler.getCall(4).args[1]
             dataAssemblyChangedHandler(updatedSnapshot)
-            expect(exo!.experience.dataAssembly.get()).to.deep.equal(updatedSnapshot)
+            expect(experience!.experience.dataAssembly.get()).to.deep.equal(updatedSnapshot)
           })
         })
 
         describe('.onChange(cb)', () => {
           describeAttachHandlerMember('default behaviour', () => {
-            return exo!.experience.dataAssembly.onChange(() => {})
+            return experience!.experience.dataAssembly.onChange(() => {})
           })
 
           it('calls cb immediately with the initial snapshot', () => {
             const cb = sinon.stub()
-            exo!.experience.dataAssembly.onChange(cb)
+            experience!.experience.dataAssembly.onChange(cb)
             expect(cb).to.have.been.calledOnce // eslint-disable-line no-unused-expressions
             expect(cb.firstCall.args[0]).to.deep.equal({ id: '', parameters: {} })
           })
 
           it('calls cb when exo.dataAssemblyChanged is dispatched', () => {
             const cb = sinon.stub()
-            exo!.experience.dataAssembly.onChange(cb)
+            experience!.experience.dataAssembly.onChange(cb)
             cb.resetHistory()
 
             const updatedSnapshot = { id: 'da-456', parameters: {} }
@@ -545,14 +560,14 @@ describe('createExo()', () => {
 
         describe('.getAvailable()', () => {
           it('calls channel.call with "exo.getAvailableDataAssemblies"', () => {
-            exo!.experience.dataAssembly.getAvailable()
+            experience!.experience.dataAssembly.getAvailable()
             expect(channelStub.call).to.have.been.calledWith('exo.getAvailableDataAssemblies')
           })
         })
 
         describe('.getParameterDefinitions()', () => {
           it('calls channel.call with "exo.getDataAssemblyParameterDefinitions"', () => {
-            exo!.experience.dataAssembly.getParameterDefinitions()
+            experience!.experience.dataAssembly.getParameterDefinitions()
             expect(channelStub.call).to.have.been.calledWith(
               'exo.getDataAssemblyParameterDefinitions',
             )
@@ -561,7 +576,7 @@ describe('createExo()', () => {
 
         describe('.getParameterDefinition(parameterId)', () => {
           it('calls channel.call with "exo.getDataAssemblyParameterDefinition" and the parameterId', () => {
-            exo!.experience.dataAssembly.getParameterDefinition('param-1')
+            experience!.experience.dataAssembly.getParameterDefinition('param-1')
             expect(channelStub.call).to.have.been.calledWith(
               'exo.getDataAssemblyParameterDefinition',
               'param-1',
@@ -578,7 +593,7 @@ describe('createExo()', () => {
                 urn: 'crn:contentful:::content:spaces/sp/entries/entry-1',
               },
             }
-            exo!.experience.dataAssembly.setParameterValue('param-1', value)
+            experience!.experience.dataAssembly.setParameterValue('param-1', value)
             expect(channelStub.call).to.have.been.calledWith(
               'exo.setDataAssemblyParameterValue',
               'param-1',
@@ -598,7 +613,7 @@ describe('createExo()', () => {
                 },
               },
             }
-            exo!.experience.dataAssembly.setParameterValues(updates)
+            experience!.experience.dataAssembly.setParameterValues(updates)
             expect(channelStub.call).to.have.been.calledWith(
               'exo.setDataAssemblyParameterValues',
               updates,


### PR DESCRIPTION
# Purpose of PR

De-codenames the Experience Orchestration surface in the App SDK: renames the public `Exo*` type identifiers, the `sdk.exo` accessor, and the handshake field to their `Experience*` equivalents, and renames the `exo`-named source files to match.

The `exo` codename was an internal working name. As the experience-toolbar surface moves toward customer visibility, the public contract should carry the product name (`Experience`) rather than the codename — a published, customer-facing type library should not expose internal codenames. Closes the SDK half of [EXT-7497](https://contentful.atlassian.net/browse/EXT-7497).

Public identifier renames (no deprecated aliases):

- `ExoSDK` → `ExperienceSDK`
- `ExoContext` → `ExperienceContext`
- `ExoNodeType` → `ExperienceNodeType`
- `ExoNodeSnapshot` → `ExperienceNodeSnapshot`
- `ExoNodeAPI` → `ExperienceNodeAPI`
- `ExoSelectionAPI` → `ExperienceSelectionAPI`
- accessor `sdk.exo` → `sdk.experiences`, and the `ConnectMessage` handshake field `exo?:` → `experiences?:`

`ExperienceAPI`, `ExperienceSnapshot`, and `ExperienceEditorToolbarAppSDK` already carried the product name and are unchanged. The internal `exo.*` postMessage channel string literals are unchanged — they are a runtime contract with the lockstep-versioned widget-renderer and carry no public-facing identifier. Source files `lib/exo.ts`, `lib/types/exo.types.ts`, and their tests/mocks are renamed to `experience*` via `git mv` (history preserved).

The experience-toolbar surface is net-new and not yet consumed by any external app, so this rename ships as a **minor** — there is no published contract to break, and no compatibility aliases are needed. Host (`user_interface`) and example (`apps`) adoption land in lockstep against the renamed surface.

## What to verify

- `npm run check-types` — 0 errors
- `npm test` — full unit suite green (530 passing)
- `npm run build` — public barrel compiles
- The `exo.*` postMessage channel strings in `lib/experience.ts` are unchanged (Gate #2)

## PR Checklist

- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Typescript typings are added/updated/not required
> Note: This PR was created with the [contentful-github-create-pull-request](https://github.com/contentful/agents-kit/tree/main/libs/contentful-github-create-pull-request) skill, powered by [Agents Kit](https://github.com/contentful/agents-kit). To follow or use this workflow, see the [Agents Kit CLI skill docs](https://github.com/contentful/agents-kit/blob/main/apps/cli/README.md#consuming-skills).


[EXT-7497]: https://contentful.atlassian.net/browse/EXT-7497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ