### PR TITLE
fix: resolve createClient defensively across CM interop shapes [AIS-59]

### DIFF
--- a/lib/cma.ts
+++ b/lib/cma.ts
@@ -1,11 +1,35 @@
-import { createClient } from 'contentful-management'
+import * as contentfulManagement from 'contentful-management'
 import { createAdapter } from './cmaAdapter'
 import { CMAClient } from './types/cmaClient.types'
 import type { IdsAPI } from './types/api.types'
 import type { Channel } from './channel'
 
+// `contentful-management` is external, so its bundled shape depends on the
+// consumer's bundler: some expose `createClient` directly, others wrap it under
+// `default` (CJS↔ESM interop). Resolve both so a bare named import can't end up
+// `undefined` and throw `createClient is not a function` inside `init()`.
+type ContentfulManagementModule = typeof contentfulManagement & {
+  default?: Partial<typeof contentfulManagement>
+}
+
+export function resolveCreateClient(
+  mod: ContentfulManagementModule,
+): typeof contentfulManagement.createClient {
+  const createClient = mod.createClient ?? mod.default?.createClient
+
+  if (typeof createClient !== 'function') {
+    throw new TypeError(
+      "Could not resolve `createClient` from 'contentful-management'. " +
+        'This usually means an incompatible or duplicate version was bundled. ' +
+        'Ensure a single contentful-management copy resolves in your app.',
+    )
+  }
+
+  return createClient
+}
+
 export function createCMAClient(ids: IdsAPI, channel: Channel): CMAClient {
-  return createClient(
+  return resolveCreateClient(contentfulManagement as ContentfulManagementModule)(
     { apiAdapter: createAdapter(channel) },
     {
       type: 'plain',

--- a/test/unit/cma.spec.ts
+++ b/test/unit/cma.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { createCMAClient } from '../../lib/cma'
+import { createCMAClient, resolveCreateClient } from '../../lib/cma'
 import { IdsAPI } from '../../lib/types'
 
 describe('createCMAClient()', function () {
@@ -18,6 +18,35 @@ describe('createCMAClient()', function () {
   it('Creates a CMA client', function () {
     const client = createCMAClient(ids, { addHandler: () => {} } as any)
     expect(client).to.be.an('object')
+  })
+
+  // Regression: `contentful-management` can be bundled with `createClient` either
+  // as a direct namespace member or wrapped under `default` (CJS↔ESM interop).
+  // Both must resolve, otherwise `init()` throws `createClient is not a function`.
+  describe('resolveCreateClient() interop', function () {
+    const fn = () => undefined
+
+    it('resolves createClient as a direct namespace member', function () {
+      expect(resolveCreateClient({ createClient: fn } as any)).to.equal(fn)
+    })
+
+    it('resolves createClient wrapped under default', function () {
+      expect(resolveCreateClient({ default: { createClient: fn } } as any)).to.equal(fn)
+    })
+
+    it('prefers the direct namespace member over default', function () {
+      const wrapped = () => undefined
+      expect(
+        resolveCreateClient({ createClient: fn, default: { createClient: wrapped } } as any),
+      ).to.equal(fn)
+    })
+
+    it('throws a helpful error when createClient cannot be resolved', function () {
+      expect(() => resolveCreateClient({} as any)).to.throw(
+        TypeError,
+        /Could not resolve `createClient`/,
+      )
+    })
   })
 
   // Apps are space-env scoped per CMA Adapter Permissions


### PR DESCRIPTION
[AIS-59](https://contentful.atlassian.net/browse/AIS-59)

## Summary
- `init()` eagerly builds `sdk.cma` via `createCMAClient()`, which used a named `import { createClient } from 'contentful-management'`. Since `contentful-management` is an **external** dependency, the shape the consumer's bundler resolves varies — CM v12 is ESM-first, and under webpack CJS↔ESM interop (especially with a dual-copy tree where app-sdk pulls a nested CM v12 alongside the app's own copy) the named import resolves to `undefined`.
- Result: `t.createClient is not a function` thrown **inside `init()`**, before any app location renders. This broke the VWO FME marketplace app (`71oYmQJFCIWn9pxizjN8dZ`) for every location including config, and affects any consumer on app-sdk ≥4.58 that triggers CMA init.
- Fix: resolve `createClient` from either the module namespace or a `default`-wrapped interop result, throwing a clear, actionable error if neither is present. No public API change; bundle size delta is negligible.

## Root cause detail
app-sdk **4.51→4.58** bumped its `contentful-management` dependency `^11`→`^12.3.1`. CM v11 was CJS (named export survives interop); CM v12 ships an `exports` map favoring its ESM build and its CJS build omits `__esModule`, so webpack's interop doesn't surface the named `createClient` where the UMD `require('contentful-management').createClient` access expects it.

## Test plan
- [x] `npm run check-types`
- [x] `npm run lint`
- [x] `npm test` (540 passing, incl. 4 new `resolveCreateClient()` interop regression cases)
- [x] `npm run build` — confirmed compiled UMD now emits `e.createClient ?? e.default?.createClient`
- [x] `npm run size` — 8310 bytes gzipped (no meaningful change)
- [ ] After release: bump `@contentful/app-sdk` in `marketplace-partner-apps/apps/vwo-fme` and confirm the iframe loads without `createClient is not a function`

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-59]: https://contentful.atlassian.net/browse/AIS-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ