### PR TITLE
fix: clarify createClient resolution and improve unresolved error [AIS-59]

### DIFF
--- a/lib/cma.ts
+++ b/lib/cma.ts
@@ -4,10 +4,9 @@ import { CMAClient } from './types/cmaClient.types'
 import type { IdsAPI } from './types/api.types'
 import type { Channel } from './channel'
 
-// `contentful-management` is external, so its bundled shape depends on the
-// consumer's bundler: some expose `createClient` directly, others wrap it under
-// `default` (CJS↔ESM interop). Resolve both so a bare named import can't end up
-// `undefined` and throw `createClient is not a function` inside `init()`.
+// `contentful-management` is an external dependency, so the runtime shape
+// depends on the consumer's bundler: `createClient` may sit on the namespace
+// directly or under `default` (interop wrapper). Resolve both.
 type ContentfulManagementModule = typeof contentfulManagement & {
   default?: Partial<typeof contentfulManagement>
 }
@@ -18,10 +17,12 @@ export function resolveCreateClient(
   const createClient = mod.createClient ?? mod.default?.createClient
 
   if (typeof createClient !== 'function') {
+    const received = mod === null || mod === undefined ? String(mod) : typeof mod
     throw new TypeError(
-      "Could not resolve `createClient` from 'contentful-management'. " +
-        'This usually means an incompatible or duplicate version was bundled. ' +
-        'Ensure a single contentful-management copy resolves in your app.',
+      `Could not resolve \`createClient\` from 'contentful-management' (resolved to a ${received}). ` +
+        'Ensure your bundler bundles contentful-management as a module — some ' +
+        'bundlers emit its `.cjs` entry as a static asset; excluding `.cjs` from ' +
+        'asset/file loaders resolves this.',
     )
   }
 

--- a/test/unit/cma.spec.ts
+++ b/test/unit/cma.spec.ts
@@ -47,6 +47,16 @@ describe('createCMAClient()', function () {
         /Could not resolve `createClient`/,
       )
     })
+
+    // A bundler can resolve `contentful-management` to a non-module (e.g. its
+    // `.cjs` entry emitted as a static asset URL). The error names the resolved
+    // type and points at bundler config.
+    it('reports the resolved type for a non-module value', function () {
+      expect(() => resolveCreateClient('/static/media/index.abc123.cjs' as any)).to.throw(
+        TypeError,
+        /resolved to a string.*\.cjs/s,
+      )
+    })
   })
 
   // Apps are space-env scoped per CMA Adapter Permissions


### PR DESCRIPTION
[AIS-59](https://contentful.atlassian.net/browse/AIS-59) — follow-up to #2614.

## Summary
- #2614 added `resolveCreateClient()` to resolve `createClient` from either the namespace or `default`. This polishes it after investigating the actual production failure.
- The `default` fallback handles a real interop shape (a bundler tagging the CJS build `__esModule` and nesting exports on `.default`), so it stays — but the comment now says *why* it exists, so it doesn't read as a cargo-culted fallback later.
- The unresolved-error message previously blamed "duplicate versions". The failure we actually saw is a bundler resolving `contentful-management` to a **non-module**: some bundlers (e.g. Create React App's file-loader) emit CM v12's `.cjs` entry as a static asset, so the import is a URL string. The error now reports what the import resolved to and points at the `.cjs`/asset-loader config.
- Adds a regression test for the non-module (string) case.

## Notes
- No behavior change for the happy path; this is messaging + a test.
- The consumer-side fix for affected CRA apps (excluding `.cjs` from the file-loader) is handled separately in the app repos.

## Test plan
- [x] `npm run check-types`
- [x] `npm run lint`
- [x] `npm test` (541 passing)
- [x] `npm run build` — error text present in compiled dist
- [x] `npm run size` (~8.4 KB gzipped)

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-59]: https://contentful.atlassian.net/browse/AIS-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ