### PR TITLE
fix: correct SlotDescriptor to allowedResources[] shape [EXT-7477]

### DIFF
--- a/lib/types/experience.types.ts
+++ b/lib/types/experience.types.ts
@@ -134,9 +134,16 @@ export interface ExperienceNodeSnapshot {
   nodeType: ExperienceNodeType
 }
 
+/** One allowed resource for a slot: the Component(s) that may be placed in it. */
+export interface SlotAllowedResource {
+  type: 'Contentful:ComponentType'
+  source: string
+  allowedTypes: string[]
+}
+
 export interface SlotDescriptor {
   id: string
-  allowedComponentTypeIds: string[]
+  allowedResources: SlotAllowedResource[]
   currentItems: Array<{ nodeId: string; nodeType: 'Fragment' | 'InlineFragment' }>
 }
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -162,6 +162,7 @@ export type {
   DataAssemblyAPI,
   ExperienceNodeType,
   ExperienceNodeSnapshot,
+  SlotAllowedResource,
   SlotDescriptor,
   ExperienceSnapshot,
   ExperienceNodeAPI,


### PR DESCRIPTION
[EXT-7477](https://contentful.atlassian.net/browse/EXT-7477)

## Summary
- `SlotDescriptor.allowedComponentTypeIds: string[]` did not match the canonical component-type slot schema. Slots carry structured `allowedResources` (`{ type: 'Contentful:ComponentType'; source; allowedTypes: string[] }`), not a flat id list. This was flagged during the EXT-7477 `sdk.experiences` surface review.
- Replaces the field with `allowedResources: SlotAllowedResource[]` and exports the new `SlotAllowedResource` type.
- The ExO toolbar location is **pre-GA with no external consumers**, so this contract change is safe to make now.

## Coordination note
The host bridge's `getNodeSlotDescriptor` already resolves `allowedResources[].allowedTypes` and was flattening it purely to satisfy the old flat type. Once this lands, the host can pass the structured shape through unchanged. The host-side return shape must be aligned to match this in the toolbar-bridge PR, so this SDK type and that host change should be verified together before GA.

## Test plan
- [x] `npm run check-types`
- [x] `npm run lint`
- [x] `npm test` (540 passing)
- [x] `npm run build`
- [x] `npm run size` (8310 bytes gzipped)
- [ ] Confirm host `getNodeSlotDescriptor` returns the matching `allowedResources[]` shape before GA

Generated with [Claude Code](https://claude.com/claude-code)

[EXT-7477]: https://contentful.atlassian.net/browse/EXT-7477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ