### PR TITLE
feat: add experience metadata get/set surface [EXT-7501]

### DIFF
--- a/lib/experience.ts
+++ b/lib/experience.ts
@@ -107,11 +107,23 @@ function createExperienceAPI(channel: Channel, initial?: ExperienceSnapshot): Ex
     onChange(cb: (v: ExperienceSnapshot) => void): Unsubscribe {
       return experienceSignal.attach(cb)
     },
-    getMetadata(): ExperienceMetadata {
-      return experienceSignal.getMemoizedArgs()[0].metadata ?? {}
+    getMetadata(): ExperienceMetadata | undefined {
+      return experienceSignal.getMemoizedArgs()[0].metadata
     },
     setMetadata(patch: Partial<ExperienceMetadata>): Promise<void> {
       return channel.call('exo.setExperienceMetadata', patch)
+    },
+    onMetadataChanged(cb: (metadata?: ExperienceMetadata) => void): Unsubscribe {
+      // Diff-guard the memoized snapshot so sys-only churn doesn't fire a spurious metadata change.
+      let previous: string | undefined
+      let seeded = false
+      return experienceSignal.attach((snapshot) => {
+        const next = JSON.stringify(snapshot.metadata)
+        if (seeded && next === previous) return
+        seeded = true
+        previous = next
+        cb(snapshot.metadata)
+      })
     },
     save(): Promise<void> {
       return channel.call('exo.saveExperience')

--- a/lib/experience.ts
+++ b/lib/experience.ts
@@ -6,6 +6,7 @@ import {
   UiMode,
   Unsubscribe,
   ExperienceSnapshot,
+  ExperienceMetadata,
   ExperienceAPI,
   ExperienceNodeAPI,
   ExperienceNodeSnapshot,
@@ -105,6 +106,12 @@ function createExperienceAPI(channel: Channel, initial?: ExperienceSnapshot): Ex
     },
     onChange(cb: (v: ExperienceSnapshot) => void): Unsubscribe {
       return experienceSignal.attach(cb)
+    },
+    getMetadata(): ExperienceMetadata {
+      return experienceSignal.getMemoizedArgs()[0].metadata ?? {}
+    },
+    setMetadata(patch: Partial<ExperienceMetadata>): Promise<void> {
+      return channel.call('exo.setExperienceMetadata', patch)
     },
     save(): Promise<void> {
       return channel.call('exo.saveExperience')

--- a/lib/types/experience.types.ts
+++ b/lib/types/experience.types.ts
@@ -2,6 +2,8 @@
  * Experience SDK types.
  */
 
+import { Link } from './utils'
+
 export type Unsubscribe = () => void
 
 export type UiMode = 'form' | 'visual'
@@ -190,10 +192,21 @@ export interface ExperienceSelectionAPI {
 }
 
 /**
+ * Editable metadata carried by an experience or fragment: taxonomy `tags` and `concepts`,
+ * plus the entity `name`. `tags` and `concepts` are classic `Link`s (`sys.type: 'Link'`),
+ * distinct from the `ResourceLink`s used elsewhere in this surface.
+ */
+export interface ExperienceMetadata {
+  tags?: Link<'Tag', 'Link'>[]
+  concepts?: Link<'TaxonomyConcept', 'Link'>[]
+  name?: string
+}
+
+/**
  * Snapshot of the root entity being edited. Discriminated on `sys.type`:
  * an `Experience` (optionally backed by a template) or a `Fragment` (no template).
- * Mirrors the canonical `experiences-api-schemas` shapes — `Experience.sys.template`
- * is optional there, and `Fragment.sys` carries a `componentType` ResourceLink and no template.
+ * `Experience.sys.template` is optional, and `Fragment.sys` carries a `componentType`
+ * ResourceLink and no template.
  */
 export type ExperienceSnapshot =
   | {
@@ -203,6 +216,7 @@ export type ExperienceSnapshot =
         version: number
         template?: ResourceLink<'Contentful:Template'>
       }
+      metadata?: ExperienceMetadata
     }
   | {
       sys: {
@@ -211,11 +225,21 @@ export type ExperienceSnapshot =
         version: number
         componentType: ResourceLink<'Contentful:ComponentType'>
       }
+      metadata?: ExperienceMetadata
     }
 
 export interface ExperienceAPI {
   get(): ExperienceSnapshot
   onChange(cb: (v: ExperienceSnapshot) => void): Unsubscribe
+  /** Reads the current experience/fragment metadata (tags, concepts, name). */
+  getMetadata(): ExperienceMetadata
+  /**
+   * Applies a partial update to the experience/fragment metadata, persisted on the next
+   * {@link ExperienceAPI.save}. Only the keys present in `patch` are changed; a provided
+   * `tags`/`concepts` array replaces that field wholesale (pass `[]` to clear it), and an
+   * omitted key is left untouched. Resolves once the host has accepted the patch.
+   */
+  setMetadata(patch: Partial<ExperienceMetadata>): Promise<void>
   save(): Promise<void>
   publish(): Promise<void>
   getNode(nodeId: string): ExperienceNodeAPI | null

--- a/lib/types/experience.types.ts
+++ b/lib/types/experience.types.ts
@@ -231,8 +231,8 @@ export type ExperienceSnapshot =
 export interface ExperienceAPI {
   get(): ExperienceSnapshot
   onChange(cb: (v: ExperienceSnapshot) => void): Unsubscribe
-  /** Reads the current experience/fragment metadata (tags, concepts, name). */
-  getMetadata(): ExperienceMetadata
+  /** Reads the current experience/fragment metadata, or `undefined` when the entity carries none (matches entry/asset). */
+  getMetadata(): ExperienceMetadata | undefined
   /**
    * Applies a partial update to the experience/fragment metadata, persisted on the next
    * {@link ExperienceAPI.save}. Only the keys present in `patch` are changed; a provided
@@ -240,6 +240,8 @@ export interface ExperienceAPI {
    * omitted key is left untouched. Resolves once the host has accepted the patch.
    */
   setMetadata(patch: Partial<ExperienceMetadata>): Promise<void>
+  /** Subscribes to metadata changes, invoking `cb` whenever the tags, concepts, or name change. */
+  onMetadataChanged(cb: (metadata?: ExperienceMetadata) => void): Unsubscribe
   save(): Promise<void>
   publish(): Promise<void>
   getNode(nodeId: string): ExperienceNodeAPI | null

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -164,6 +164,7 @@ export type {
   ExperienceNodeSnapshot,
   SlotAllowedResource,
   SlotDescriptor,
+  ExperienceMetadata,
   ExperienceSnapshot,
   ExperienceNodeAPI,
   ExperienceSelectionAPI,

--- a/test/unit/experience.spec.ts
+++ b/test/unit/experience.spec.ts
@@ -200,12 +200,13 @@ describe('createExperience()', () => {
     })
 
     describe('.experience', () => {
-      it('exposes get, onChange, getMetadata, setMetadata, save, publish, getNode, getRootNodes, selection, and dataAssembly', () => {
+      it('exposes get, onChange, getMetadata, setMetadata, onMetadataChanged, save, publish, getNode, getRootNodes, selection, and dataAssembly', () => {
         expect(experience!.experience).to.have.all.keys([
           'get',
           'onChange',
           'getMetadata',
           'setMetadata',
+          'onMetadataChanged',
           'save',
           'publish',
           'getNode',
@@ -304,25 +305,26 @@ describe('createExperience()', () => {
         })
       })
 
+      const mockMetadata = {
+        tags: [{ sys: { type: 'Link' as const, linkType: 'Tag' as const, id: 'tag-1' } }],
+        concepts: [
+          { sys: { type: 'Link' as const, linkType: 'TaxonomyConcept' as const, id: 'c-1' } },
+        ],
+        name: 'Homepage hero',
+      }
+
       describe('.getMetadata()', () => {
-        it('returns an empty object when the snapshot carries no metadata', () => {
-          expect(experience!.experience.getMetadata()).to.deep.equal({})
+        it('returns undefined when the snapshot carries no metadata (matches entry/asset)', () => {
+          expect(experience!.experience.getMetadata()).to.be.undefined // eslint-disable-line no-unused-expressions
         })
 
         it('returns the metadata from the current snapshot', () => {
-          const metadata = {
-            tags: [{ sys: { type: 'Link' as const, linkType: 'Tag' as const, id: 'tag-1' } }],
-            concepts: [
-              { sys: { type: 'Link' as const, linkType: 'TaxonomyConcept' as const, id: 'c-1' } },
-            ],
-            name: 'Homepage hero',
-          }
           const experienceChangedHandler = channelStub.addHandler.getCall(2).args[1]
           experienceChangedHandler({
             sys: { id: 'exp-456', type: 'Experience' as const, version: 2 },
-            metadata,
+            metadata: mockMetadata,
           })
-          expect(experience!.experience.getMetadata()).to.deep.equal(metadata)
+          expect(experience!.experience.getMetadata()).to.deep.equal(mockMetadata)
         })
       })
 
@@ -337,6 +339,55 @@ describe('createExperience()', () => {
           const expectedPromise = Promise.resolve()
           channelStub.call.withArgs('exo.setExperienceMetadata').returns(expectedPromise)
           expect(experience!.experience.setMetadata({ tags: [] })).to.equal(expectedPromise)
+        })
+      })
+
+      describe('.onMetadataChanged(cb)', () => {
+        const dispatchSnapshot = (snapshot: any) =>
+          channelStub.addHandler.getCall(2).args[1](snapshot)
+
+        it('calls cb immediately with the initial metadata (undefined when absent)', () => {
+          const cb = sinon.stub()
+          experience!.experience.onMetadataChanged(cb)
+          expect(cb).to.have.been.calledOnceWith(undefined)
+        })
+
+        it('calls cb when metadata changes on exo.experienceChanged', () => {
+          const cb = sinon.stub()
+          experience!.experience.onMetadataChanged(cb)
+          cb.resetHistory()
+
+          dispatchSnapshot({
+            sys: { id: 'exp-456', type: 'Experience' as const, version: 2 },
+            metadata: mockMetadata,
+          })
+
+          expect(cb).to.have.been.calledOnceWith(mockMetadata)
+        })
+
+        it('does not call cb when a snapshot arrives with unchanged metadata', () => {
+          const cb = sinon.stub()
+          experience!.experience.onMetadataChanged(cb)
+          cb.resetHistory()
+
+          // Same (absent) metadata as the initial snapshot, only sys.version bumped.
+          dispatchSnapshot({ sys: { id: 'exp-456', type: 'Experience' as const, version: 2 } })
+
+          expect(cb).to.not.have.been.called // eslint-disable-line no-unused-expressions
+        })
+
+        it('does not call detached cb when exo.experienceChanged is dispatched', () => {
+          const cb = sinon.stub()
+          const detach = experience!.experience.onMetadataChanged(cb)
+          cb.resetHistory()
+          detach()
+
+          dispatchSnapshot({
+            sys: { id: 'exp-456', type: 'Experience' as const, version: 2 },
+            metadata: mockMetadata,
+          })
+
+          expect(cb).to.not.have.been.called // eslint-disable-line no-unused-expressions
         })
       })
 

--- a/test/unit/experience.spec.ts
+++ b/test/unit/experience.spec.ts
@@ -200,10 +200,12 @@ describe('createExperience()', () => {
     })
 
     describe('.experience', () => {
-      it('exposes get, onChange, save, publish, getNode, getRootNodes, selection, and dataAssembly', () => {
+      it('exposes get, onChange, getMetadata, setMetadata, save, publish, getNode, getRootNodes, selection, and dataAssembly', () => {
         expect(experience!.experience).to.have.all.keys([
           'get',
           'onChange',
+          'getMetadata',
+          'setMetadata',
           'save',
           'publish',
           'getNode',
@@ -299,6 +301,42 @@ describe('createExperience()', () => {
           const expectedPromise = Promise.resolve()
           channelStub.call.withArgs('exo.publishExperience').returns(expectedPromise)
           expect(experience!.experience.publish()).to.equal(expectedPromise)
+        })
+      })
+
+      describe('.getMetadata()', () => {
+        it('returns an empty object when the snapshot carries no metadata', () => {
+          expect(experience!.experience.getMetadata()).to.deep.equal({})
+        })
+
+        it('returns the metadata from the current snapshot', () => {
+          const metadata = {
+            tags: [{ sys: { type: 'Link' as const, linkType: 'Tag' as const, id: 'tag-1' } }],
+            concepts: [
+              { sys: { type: 'Link' as const, linkType: 'TaxonomyConcept' as const, id: 'c-1' } },
+            ],
+            name: 'Homepage hero',
+          }
+          const experienceChangedHandler = channelStub.addHandler.getCall(2).args[1]
+          experienceChangedHandler({
+            sys: { id: 'exp-456', type: 'Experience' as const, version: 2 },
+            metadata,
+          })
+          expect(experience!.experience.getMetadata()).to.deep.equal(metadata)
+        })
+      })
+
+      describe('.setMetadata(patch)', () => {
+        it('calls channel.call with "exo.setExperienceMetadata" and the patch', () => {
+          const patch = { name: 'Renamed' }
+          experience!.experience.setMetadata(patch)
+          expect(channelStub.call).to.have.been.calledWith('exo.setExperienceMetadata', patch)
+        })
+
+        it('returns the promise from channel.call', () => {
+          const expectedPromise = Promise.resolve()
+          channelStub.call.withArgs('exo.setExperienceMetadata').returns(expectedPromise)
+          expect(experience!.experience.setMetadata({ tags: [] })).to.equal(expectedPromise)
         })
       })
 


### PR DESCRIPTION
[EXT-7501](https://contentful.atlassian.net/browse/EXT-7501)

## Summary
- The Experience Toolbar SDK exposed no way to read, subscribe to, or mutate an experience/fragment's metadata (tags, taxonomy concepts, name), though the data already lives on the entity and the host already read-modify-saves it internally.
- Adds `ExperienceMetadata` (tags + concepts as classic `Link`s, plus `name`), threads optional `metadata` onto both `ExperienceSnapshot` arms (Experience *and* Fragment), and adds `getMetadata()` / `setMetadata(patch)` / `onMetadataChanged(cb)` to `ExperienceAPI`.
- `getMetadata()` reads synchronously off the current snapshot and returns `ExperienceMetadata | undefined` — matching the `getMetadata()` contract on the entry/asset locations (`undefined` when the entity carries no metadata).
- `onMetadataChanged(cb)` mirrors entry/asset parity. It derives off the existing experience snapshot signal, firing immediately then only when the metadata actually changes; snapshots that bump only `sys` are ignored.
- `setMetadata(patch)` sends a partial update over the channel and returns `Promise<void>` so an app can await host acceptance before `save()` — matching the other mutating calls (`save`/`publish`/`setDesignProperty`) rather than fire-and-forget.
- Partial-merge semantics: only keys present in `patch` change; a provided `tags`/`concepts` array replaces that field wholesale (pass `[]` to clear), an omitted key is left untouched.
- Additive and pre-GA — no external consumers.

## Scope note
This is **Layer 1** (public SDK surface) of EXT-7501. Layers 2 (`notSupported` stub) and 3 (host bridge read/write) are deliberately deferred: the graceful-degradation stub only matters once the host method exists. This PR settles the public contract those layers implement against. The host `setMetadata` handler + `metadata` on the emitted snapshot land in the toolbar-bridge PR before GA.

## Test plan
- [x] `npm run check-types`
- [x] `npm run lint`
- [x] `npm test` (548 passing)
- [x] `npm run build`
- [x] `npm run size` (8388 bytes gzipped)
- [ ] Host `setMetadata` + snapshot `metadata` implemented in the landing toolbar-bridge PR before GA

[EXT-7501]: https://contentful.atlassian.net/browse/EXT-7501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
