### PR TITLE
fix: drop experience UI mode from ExO toolbar SDK surface [EXT-7477]

### DIFF
--- a/lib/experience.ts
+++ b/lib/experience.ts
@@ -3,7 +3,6 @@ import { MemoizedSignal } from './signal'
 import {
   ExperienceSDK,
   ExperienceContext,
-  UiMode,
   Unsubscribe,
   ExperienceSnapshot,
   ExperienceMetadata,
@@ -33,7 +32,6 @@ export default function createExperience(
   channel: Channel,
   experienceInit?: {
     context?: ExperienceContext
-    uiMode?: UiMode
     experience?: ExperienceSnapshot
   },
 ): ExperienceSDK {
@@ -51,13 +49,6 @@ export default function createExperience(
     contextSignal.dispatch(payload)
   })
 
-  const initialMode: UiMode = experienceInit.uiMode ?? 'form'
-  const uiModeSignal = new MemoizedSignal<[UiMode]>(initialMode)
-
-  channel.addHandler('exo.uiModeChanged', (payload: { mode: UiMode }) => {
-    uiModeSignal.dispatch(payload.mode)
-  })
-
   const experience = createExperienceAPI(channel, experienceInit.experience)
 
   return {
@@ -66,12 +57,6 @@ export default function createExperience(
     },
     onContextChanged(cb: (context: ExperienceContext) => void): Unsubscribe {
       return contextSignal.attach(cb)
-    },
-    getUiMode(): UiMode {
-      return uiModeSignal.getMemoizedArgs()[0]
-    },
-    onUiModeChanged(cb: (mode: UiMode) => void): Unsubscribe {
-      return uiModeSignal.attach(cb)
     },
     experience,
   }

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -23,7 +23,7 @@ import { EntryFieldInfo, FieldInfo } from './field.types'
 import { Adapter, KeyValueMap } from 'contentful-management'
 import { CMAClient } from './cmaClient.types'
 import { AgentAPI, AgentContext } from './agent.types'
-import { ExperienceSDK, ExperienceContext, UiMode, ExperienceSnapshot } from './experience.types'
+import { ExperienceSDK, ExperienceContext, ExperienceSnapshot } from './experience.types'
 
 /* User API */
 
@@ -449,7 +449,6 @@ export interface ConnectMessage {
   /** Experiences data; when present, SDK constructs sdk.experiences */
   experiences?: {
     context?: ExperienceContext
-    uiMode?: UiMode
     experience?: ExperienceSnapshot
   }
 }

--- a/lib/types/experience.types.ts
+++ b/lib/types/experience.types.ts
@@ -6,8 +6,6 @@ import { Link } from './utils'
 
 export type Unsubscribe = () => void
 
-export type UiMode = 'form' | 'visual'
-
 /* Bindings + property descriptors */
 
 export type EntryBinding = {
@@ -258,7 +256,5 @@ export interface ExperienceContext {
 export interface ExperienceSDK {
   context: ExperienceContext
   onContextChanged(cb: (context: ExperienceContext) => void): Unsubscribe
-  getUiMode(): UiMode
-  onUiModeChanged(cb: (mode: UiMode) => void): Unsubscribe
   experience: ExperienceAPI
 }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -143,7 +143,6 @@ export type { CMAClient } from './cmaClient.types'
 
 export type {
   Unsubscribe,
-  UiMode,
   ExperienceContext,
   ExperienceSDK,
   ResourceLink,

--- a/test/mocks/experience.ts
+++ b/test/mocks/experience.ts
@@ -16,11 +16,5 @@ export const mockExperienceSnapshot: ExperienceSnapshot = {
 }
 
 export const mockExperienceInit = {
-  uiMode: 'form' as const,
-  experience: mockExperienceSnapshot,
-}
-
-export const mockExperienceInitVisualMode = {
-  uiMode: 'visual' as const,
   experience: mockExperienceSnapshot,
 }

--- a/test/unit/api.spec.ts
+++ b/test/unit/api.spec.ts
@@ -8,7 +8,6 @@ import {
   ConnectMessage,
   ExperienceEditorToolbarAppSDK,
   ExperienceSDK,
-  UiMode,
 } from '../../lib/types'
 import { mockRelease, mockReleaseWithoutEntities } from '../mocks/releases'
 import { baseConnectMessage, connectMessageWithAgent } from '../mocks/connectMessage'
@@ -169,20 +168,7 @@ describe('createAPI()', () => {
       },
     } as unknown as ConnectMessage
 
-    it('with experiences: { uiMode: "visual" } in handshake, sdk.experiences is defined and getUiMode() returns "visual"', () => {
-      const channel = { addHandler: () => () => {} } as any
-      const dom = makeDOM()
-      mockMutationObserver(dom, () => {})
-      mockResizeObserver(dom, () => {})
-
-      const data: ConnectMessage = { ...baseData, experiences: { uiMode: 'visual' } } as any
-      const api = createAPI(channel, data, dom.window as any as Window) as any
-
-      expect(api.experiences).to.be.an('object')
-      expect(api.experiences.getUiMode()).to.equal('visual')
-    })
-
-    it('with experiences: {} in handshake, getUiMode() returns "form"', () => {
+    it('with experiences: {} in handshake, sdk.experiences is defined', () => {
       const channel = { addHandler: () => () => {} } as any
       const dom = makeDOM()
       mockMutationObserver(dom, () => {})
@@ -192,7 +178,6 @@ describe('createAPI()', () => {
       const api = createAPI(channel, data, dom.window as any as Window) as any
 
       expect(api.experiences).to.be.an('object')
-      expect(api.experiences.getUiMode()).to.equal('form')
     })
 
     it('without experiences in handshake, building the experience-toolbar API throws', () => {
@@ -211,49 +196,13 @@ describe('createAPI()', () => {
       )
     })
 
-    it('onUiModeChanged fires on exo.uiModeChanged event; unsubscribe stops notifications', () => {
-      const experienceHandlers: Array<(payload: { mode: UiMode }) => void> = []
-      const channel = {
-        addHandler: (method: string, handler: any) => {
-          if (method === 'exo.uiModeChanged') experienceHandlers.push(handler)
-          return () => {
-            const i = experienceHandlers.indexOf(handler)
-            if (i !== -1) experienceHandlers.splice(i, 1)
-          }
-        },
-      } as any
-      const dom = makeDOM()
-      mockMutationObserver(dom, () => {})
-      mockResizeObserver(dom, () => {})
-
-      const data: ConnectMessage = { ...baseData, experiences: { uiMode: 'visual' } } as any
-      const api = createAPI(channel, data, dom.window as any as Window) as any
-
-      const modes: UiMode[] = []
-      const unsubscribe = api.experiences.onUiModeChanged((mode: UiMode) => modes.push(mode))
-
-      expect(api.experiences.getUiMode()).to.equal('visual')
-      expect(experienceHandlers).to.have.lengthOf(1)
-      // MemoizedSignal.attach calls the listener immediately with current value
-      expect(modes).to.deep.equal(['visual'])
-
-      const dispatchMode = experienceHandlers[0]
-      dispatchMode({ mode: 'form' })
-      expect(modes).to.deep.equal(['visual', 'form'])
-      expect(api.experiences.getUiMode()).to.equal('form')
-
-      unsubscribe()
-      dispatchMode({ mode: 'visual' })
-      expect(modes).to.deep.equal(['visual', 'form'])
-    })
-
-    it('ExperienceEditorToolbarAppSDK has experiences: ExperienceSDK; getUiMode returns UiMode', () => {
+    it('ExperienceEditorToolbarAppSDK exposes experiences: ExperienceSDK', () => {
       const channel = { addHandler: () => () => {} } as any
       const dom = makeDOM()
       mockMutationObserver(dom, () => {})
       mockResizeObserver(dom, () => {})
 
-      const data: ConnectMessage = { ...baseData, experiences: { uiMode: 'form' } } as any
+      const data: ConnectMessage = { ...baseData, experiences: {} } as any
       const api = createAPI(
         channel,
         data,
@@ -261,8 +210,7 @@ describe('createAPI()', () => {
       ) as ExperienceEditorToolbarAppSDK
 
       const experiences: ExperienceSDK = api.experiences
-      const mode: UiMode = experiences.getUiMode()
-      expect(mode).to.equal('form')
+      expect(experiences).to.be.an('object')
     })
 
     it('sdk.experiences.context reflects the context from handshake', () => {
@@ -273,7 +221,7 @@ describe('createAPI()', () => {
 
       const data: ConnectMessage = {
         ...baseData,
-        experiences: { context: { type: 'fragment', entityId: 'frag-456' }, uiMode: 'form' },
+        experiences: { context: { type: 'fragment', entityId: 'frag-456' } },
       } as any
       const api = createAPI(channel, data, dom.window as any as Window) as any
 
@@ -286,7 +234,7 @@ describe('createAPI()', () => {
       mockMutationObserver(dom, () => {})
       mockResizeObserver(dom, () => {})
 
-      const data: ConnectMessage = { ...baseData, experiences: { uiMode: 'visual' } } as any
+      const data: ConnectMessage = { ...baseData, experiences: {} } as any
       const api = createAPI(channel, data, dom.window as any as Window) as any
 
       expect(api.experiences.context).to.deep.equal({ type: 'experience', entityId: '' })

--- a/test/unit/experience.spec.ts
+++ b/test/unit/experience.spec.ts
@@ -2,11 +2,7 @@ import { describeAttachHandlerMember, sinon, expect } from '../helpers'
 
 import createExperience from '../../lib/experience'
 import { Channel } from '../../lib/channel'
-import {
-  mockExperienceInit,
-  mockExperienceInitVisualMode,
-  mockExperienceSnapshot,
-} from '../mocks/experience'
+import { mockExperienceInit, mockExperienceSnapshot } from '../mocks/experience'
 
 describe('createExperience()', () => {
   let channelStub: any
@@ -37,35 +33,25 @@ describe('createExperience()', () => {
       experience = createExperience(channelStub, mockExperienceInit)
     })
 
-    it('returns an object with context, onContextChanged, getUiMode, onUiModeChanged, and experience', () => {
-      expect(experience).to.have.all.keys([
-        'context',
-        'onContextChanged',
-        'getUiMode',
-        'onUiModeChanged',
-        'experience',
-      ])
+    it('returns an object with context, onContextChanged, and experience', () => {
+      expect(experience).to.have.all.keys(['context', 'onContextChanged', 'experience'])
     })
 
-    it('registers handlers for contextChanged, uiModeChanged, experienceChanged, selectionChanged, and dataAssemblyChanged', () => {
-      expect(channelStub.addHandler).to.have.callCount(5)
+    it('registers handlers for contextChanged, experienceChanged, selectionChanged, and dataAssemblyChanged', () => {
+      expect(channelStub.addHandler).to.have.callCount(4)
       expect(channelStub.addHandler.getCall(0)).to.have.been.calledWith(
         'exo.contextChanged',
         sinon.match.func,
       )
       expect(channelStub.addHandler.getCall(1)).to.have.been.calledWith(
-        'exo.uiModeChanged',
-        sinon.match.func,
-      )
-      expect(channelStub.addHandler.getCall(2)).to.have.been.calledWith(
         'exo.experienceChanged',
         sinon.match.func,
       )
-      expect(channelStub.addHandler.getCall(3)).to.have.been.calledWith(
+      expect(channelStub.addHandler.getCall(2)).to.have.been.calledWith(
         'exo.selectionChanged',
         sinon.match.func,
       )
-      expect(channelStub.addHandler.getCall(4)).to.have.been.calledWith(
+      expect(channelStub.addHandler.getCall(3)).to.have.been.calledWith(
         'exo.dataAssemblyChanged',
         sinon.match.func,
       )
@@ -140,65 +126,6 @@ describe('createExperience()', () => {
       })
     })
 
-    describe('.getUiMode()', () => {
-      it('returns the initial uiMode from experienceInit', () => {
-        expect(experience!.getUiMode()).to.equal('form')
-      })
-
-      it('returns "form" when no uiMode is provided in experienceInit', () => {
-        const experienceNoMode = createExperience(channelStub, {
-          experience: mockExperienceSnapshot,
-        })
-        expect(experienceNoMode!.getUiMode()).to.equal('form')
-      })
-
-      it('returns "visual" when uiMode is visual', () => {
-        const experienceVisual = createExperience(channelStub, mockExperienceInitVisualMode)
-        expect(experienceVisual!.getUiMode()).to.equal('visual')
-      })
-
-      it('updates after exo.uiModeChanged is dispatched', () => {
-        const uiModeChangedHandler = channelStub.addHandler.getCall(1).args[1]
-        uiModeChangedHandler({ mode: 'visual' })
-        expect(experience!.getUiMode()).to.equal('visual')
-      })
-    })
-
-    describe('.onUiModeChanged(cb)', () => {
-      describeAttachHandlerMember('default behaviour', () => {
-        return experience!.onUiModeChanged(() => {})
-      })
-
-      it('calls cb immediately with the initial uiMode', () => {
-        const cb = sinon.stub()
-        experience!.onUiModeChanged(cb)
-        expect(cb).to.have.been.calledOnceWith('form')
-      })
-
-      it('calls cb when exo.uiModeChanged is dispatched', () => {
-        const cb = sinon.stub()
-        experience!.onUiModeChanged(cb)
-        cb.resetHistory()
-
-        const uiModeChangedHandler = channelStub.addHandler.getCall(1).args[1]
-        uiModeChangedHandler({ mode: 'visual' })
-
-        expect(cb).to.have.been.calledOnceWith('visual')
-      })
-
-      it('does not call detached cb when exo.uiModeChanged is dispatched', () => {
-        const cb = sinon.stub()
-        const detach = experience!.onUiModeChanged(cb)
-        cb.resetHistory()
-        detach()
-
-        const uiModeChangedHandler = channelStub.addHandler.getCall(1).args[1]
-        uiModeChangedHandler({ mode: 'visual' })
-
-        expect(cb).to.not.have.been.called // eslint-disable-line no-unused-expressions
-      })
-    })
-
     describe('.experience', () => {
       it('exposes get, onChange, getMetadata, setMetadata, onMetadataChanged, save, publish, getNode, getRootNodes, selection, and dataAssembly', () => {
         expect(experience!.experience).to.have.all.keys([
@@ -222,7 +149,7 @@ describe('createExperience()', () => {
         })
 
         it('returns a default snapshot when no experience is provided in experienceInit', () => {
-          const experienceNoExp = createExperience(channelStub, { uiMode: 'form' })
+          const experienceNoExp = createExperience(channelStub, {})
           const snapshot = experienceNoExp!.experience.get()
           expect(snapshot.sys.type).to.equal('Experience')
           expect(snapshot.sys.id).to.equal('')
@@ -233,7 +160,7 @@ describe('createExperience()', () => {
           const updatedSnapshot = {
             sys: { id: 'exp-456', type: 'Experience' as const, version: 2 },
           }
-          const experienceChangedHandler = channelStub.addHandler.getCall(2).args[1]
+          const experienceChangedHandler = channelStub.addHandler.getCall(1).args[1]
           experienceChangedHandler(updatedSnapshot)
           expect(experience!.experience.get()).to.deep.equal(updatedSnapshot)
         })
@@ -258,7 +185,7 @@ describe('createExperience()', () => {
           const updatedSnapshot = {
             sys: { id: 'exp-789', type: 'Experience' as const, version: 3 },
           }
-          const experienceChangedHandler = channelStub.addHandler.getCall(2).args[1]
+          const experienceChangedHandler = channelStub.addHandler.getCall(1).args[1]
           experienceChangedHandler(updatedSnapshot)
 
           expect(cb).to.have.been.calledOnceWith(updatedSnapshot)
@@ -270,7 +197,7 @@ describe('createExperience()', () => {
           cb.resetHistory()
           detach()
 
-          const experienceChangedHandler = channelStub.addHandler.getCall(2).args[1]
+          const experienceChangedHandler = channelStub.addHandler.getCall(1).args[1]
           experienceChangedHandler({
             sys: { id: 'exp-999', type: 'Experience' as const, version: 4 },
           })
@@ -319,7 +246,7 @@ describe('createExperience()', () => {
         })
 
         it('returns the metadata from the current snapshot', () => {
-          const experienceChangedHandler = channelStub.addHandler.getCall(2).args[1]
+          const experienceChangedHandler = channelStub.addHandler.getCall(1).args[1]
           experienceChangedHandler({
             sys: { id: 'exp-456', type: 'Experience' as const, version: 2 },
             metadata: mockMetadata,
@@ -344,7 +271,7 @@ describe('createExperience()', () => {
 
       describe('.onMetadataChanged(cb)', () => {
         const dispatchSnapshot = (snapshot: any) =>
-          channelStub.addHandler.getCall(2).args[1](snapshot)
+          channelStub.addHandler.getCall(1).args[1](snapshot)
 
         it('calls cb immediately with the initial metadata (undefined when absent)', () => {
           const cb = sinon.stub()
@@ -511,7 +438,7 @@ describe('createExperience()', () => {
           })
 
           it('returns the updated selection after exo.selectionChanged is dispatched', () => {
-            const selectionChangedHandler = channelStub.addHandler.getCall(3).args[1]
+            const selectionChangedHandler = channelStub.addHandler.getCall(2).args[1]
             selectionChangedHandler({ nodeId: 'node-xyz', nodeType: 'Component' })
             expect(experience!.experience.selection.get()).to.deep.equal({
               nodeId: 'node-xyz',
@@ -536,7 +463,7 @@ describe('createExperience()', () => {
             experience!.experience.selection.onChange(cb)
             cb.resetHistory()
 
-            const selectionChangedHandler = channelStub.addHandler.getCall(3).args[1]
+            const selectionChangedHandler = channelStub.addHandler.getCall(2).args[1]
             selectionChangedHandler({ nodeId: 'node-xyz', nodeType: 'Component' })
 
             expect(cb).to.have.been.calledOnceWith({ nodeId: 'node-xyz', nodeType: 'Component' })
@@ -547,7 +474,7 @@ describe('createExperience()', () => {
             experience!.experience.selection.onChange(cb)
             cb.resetHistory()
 
-            const selectionChangedHandler = channelStub.addHandler.getCall(3).args[1]
+            const selectionChangedHandler = channelStub.addHandler.getCall(2).args[1]
             selectionChangedHandler({ nodeId: null })
 
             expect(cb).to.have.been.calledOnceWith({ nodeId: null })
@@ -616,7 +543,7 @@ describe('createExperience()', () => {
               name: 'My Assembly',
               parameters: {},
             }
-            const dataAssemblyChangedHandler = channelStub.addHandler.getCall(4).args[1]
+            const dataAssemblyChangedHandler = channelStub.addHandler.getCall(3).args[1]
             dataAssemblyChangedHandler(updatedSnapshot)
             expect(experience!.experience.dataAssembly.get()).to.deep.equal(updatedSnapshot)
           })
@@ -640,7 +567,7 @@ describe('createExperience()', () => {
             cb.resetHistory()
 
             const updatedSnapshot = { id: 'da-456', parameters: {} }
-            const dataAssemblyChangedHandler = channelStub.addHandler.getCall(4).args[1]
+            const dataAssemblyChangedHandler = channelStub.addHandler.getCall(3).args[1]
             dataAssemblyChangedHandler(updatedSnapshot)
 
             expect(cb).to.have.been.calledOnceWith(updatedSnapshot)


### PR DESCRIPTION
[EXT-7477](https://contentful.atlassian.net/browse/EXT-7477)

## Summary
- Removes `getUiMode()` / `onUiModeChanged()` and the `UiMode` type from the experience-toolbar SDK (`sdk.experiences`), along with the `uiMode` handshake field and the `exo.uiModeChanged` channel handler.
- This surface landed in `4.63.0` but is not yet backed by the host: `getUiMode()` only ever returned its `'form'` default and `onUiModeChanged()` never fired. Rather than ship a public method that doesn't resolve to real behavior, we're removing the placeholder until the editor mode model is finalized, at which point it can be reintroduced against a settled contract.
- Non-functional change for consumers — no app can observe a behavioral difference, since the API never returned live data.

## Test plan
- [x] `npm run check-types`
- [x] `npm run lint`
- [x] `npm test` (537 passing)
- [x] `npm run build`
- [x] `npm run size` (8319 bytes gzipped)

Generated with [Claude Code](https://claude.com/claude-code)

[EXT-7477]: https://contentful.atlassian.net/browse/EXT-7477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ