### PR TITLE
ci: use Node-bundled npm and defer GH Packages .npmrc in Release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,11 +71,6 @@ jobs:
           git config --global user.name 'contentful-automation[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+contentful-automation[bot]@users.noreply.github.com'
 
-      - name: Setup npmrc for publishing
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}" > .npmrc
-          echo "@contentful:registry=https://npm.pkg.github.com" >> .npmrc
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -83,18 +78,19 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install latest npm
-        run: |
-          # Work around the npm self-upgrade regression on Node 22.22.2.
-          # See: https://github.com/npm/cli/issues/9151
-          npm install -g npm@11.11.1
-          npm install -g npm@latest
-
       - name: Install dependencies
         run: npm ci
 
       - name: Build
         run: npm run build
+
+      # After install: @contentful:registry rewrite is for publishing
+      # @contentful/app-sdk to GitHub Packages. Applying it before npm ci
+      # breaks under npm 12 (EALLOWREMOTE vs lockfile registry.npmjs.org URLs).
+      - name: Setup npmrc for publishing
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}" > .npmrc
+          echo "@contentful:registry=https://npm.pkg.github.com" >> .npmrc
 
       - name: Run Release
         run: |


### PR DESCRIPTION
## Summary
- Stop floating `npm@latest` on Release (it pulled npm 12 and broke `npm ci` with `EALLOWREMOTE`)
- Use the npm shipped with Node 22, matching CI
- Keep the `@contentful:registry=https://npm.pkg.github.com` rewrite for `@contentful/app-sdk` publish, but apply it only after install/build so lockfile `registry.npmjs.org` URLs resolve normally

## Test plan
- [x] CI passes on this PR
- [ ] After merge, Release completes `npm ci` without `EALLOWREMOTE`
- [ ] Release still publishes `contentful-ui-extensions-sdk` to `registry.npmjs.org`
- [ ] Release still publishes `@contentful/app-sdk` to `npm.pkg.github.com`
- [ ] Confirm Release logs show Node-bundled npm (currently ~10.9.x), not npm 12


Made with [Cursor](https://cursor.com)