### PR TITLE
feat: add ExO ids to AgentContext metadata [AIS-201]

### DIFF
--- a/lib/types/agent.types.ts
+++ b/lib/types/agent.types.ts
@@ -4,6 +4,10 @@ export interface AgentContext {
     entryId?: string
     contentTypeId?: string
     lastFocusedFieldId?: string
+    experienceId?: string
+    fragmentId?: string
+    componentId?: string
+    templateId?: string
   }
 }
 

--- a/lib/types/agent.types.ts
+++ b/lib/types/agent.types.ts
@@ -5,9 +5,9 @@ export interface AgentContext {
     contentTypeId?: string
     lastFocusedFieldId?: string
     experienceId?: string
-    fragmentId?: string
+    experienceFragmentId?: string
     componentId?: string
-    templateId?: string
+    experienceTemplateId?: string
   }
 }
 


### PR DESCRIPTION
[AIS-201](https://contentful.atlassian.net/browse/AIS-201)

## Summary
- Widen flat `AgentContext.metadata` with optional `experienceId` / `experienceFragmentId` / `componentId` / `experienceTemplateId`
- Metadata keys track approved entity names; host emits three canvas `view` tokens (`experience.canvas` / `component.canvas` / `template.canvas`) — fragments share Experience Canvas
- Additive, non-breaking — keeps `view: string` (no discriminated union)
- Unblocks host emission of ExO agent views in host

## Test plan
- [x] `npm run check-types`
- [x] `npm test` (545 passing)
- [x] CI green
- [ ] Merge triggers app-sdk minor publish; then bump `@contentful/app-sdk` in host PR

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-201]: https://contentful.atlassian.net/browse/AIS-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ