### PR TITLE
feat: add navigator.openExperience and openComponent [AIS-202]

### DIFF
--- a/lib/navigator.ts
+++ b/lib/navigator.ts
@@ -79,6 +79,12 @@ export default function createNavigator(
         releaseId,
       }) as Promise<void>
     },
+    openExperience: (experienceId: string) => {
+      return channel.call('navigateToExperience', { id: experienceId }) as Promise<void>
+    },
+    openComponent: (componentId: string) => {
+      return channel.call('navigateToComponent', { id: componentId }) as Promise<void>
+    },
     onSlideInNavigation: (handler) => {
       return _onSlideInSignal.attach(handler)
     },

--- a/lib/navigator.ts
+++ b/lib/navigator.ts
@@ -80,7 +80,10 @@ export default function createNavigator(
       }) as Promise<void>
     },
     openExperience: (experienceId: string) => {
-      return channel.call('navigateToExperience', { id: experienceId }) as Promise<void>
+      return channel.call('navigateToExperience', {
+        id: experienceId,
+        releaseId,
+      }) as Promise<void>
     },
     openComponent: (componentId: string) => {
       return channel.call('navigateToComponent', { id: componentId }) as Promise<void>

--- a/lib/types/navigator.types.ts
+++ b/lib/types/navigator.types.ts
@@ -78,7 +78,11 @@ export interface NavigatorAPI {
   openAppConfig: () => Promise<void>
   openEntriesList: (options?: Pick<NavigatorAPIOptions, 'releaseId'>) => Promise<void>
   openAssetsList: (options?: Pick<NavigatorAPIOptions, 'releaseId'>) => Promise<void>
-  /** Opens an existing Experience in the Experience Canvas (full-page). */
+  /**
+   * Opens an existing Experience in the Experience Canvas (full-page).
+   * When the SDK session has an active release, navigation preserves that release context
+   * (same ambient model as `openEntry` / `openEntriesList`).
+   */
   openExperience: (experienceId: string) => Promise<void>
   /** Opens an existing Component in the Component Canvas (full-page). */
   openComponent: (componentId: string) => Promise<void>

--- a/lib/types/navigator.types.ts
+++ b/lib/types/navigator.types.ts
@@ -78,5 +78,9 @@ export interface NavigatorAPI {
   openAppConfig: () => Promise<void>
   openEntriesList: (options?: Pick<NavigatorAPIOptions, 'releaseId'>) => Promise<void>
   openAssetsList: (options?: Pick<NavigatorAPIOptions, 'releaseId'>) => Promise<void>
+  /** Opens an existing Experience in the Experience Canvas (full-page). */
+  openExperience: (experienceId: string) => Promise<void>
+  /** Opens an existing Component in the Component Canvas (full-page). */
+  openComponent: (componentId: string) => Promise<void>
   onSlideInNavigation: (fn: (slide: NavigatorSlideInfo) => void) => () => void
 }

--- a/test/unit/navigator.spec.ts
+++ b/test/unit/navigator.spec.ts
@@ -111,6 +111,18 @@ const SCENARIOS = [
     expected: { route: 'assets', releaseId: undefined },
     channelMethod: 'navigateToSpaceEnvRoute',
   },
+  {
+    method: 'openExperience',
+    args: ['experience-id'],
+    expected: { id: 'experience-id' },
+    channelMethod: 'navigateToExperience',
+  },
+  {
+    method: 'openComponent',
+    args: ['component-id'],
+    expected: { id: 'component-id' },
+    channelMethod: 'navigateToComponent',
+  },
 ]
 
 describe('createNavigator()', () => {

--- a/test/unit/navigator.spec.ts
+++ b/test/unit/navigator.spec.ts
@@ -114,7 +114,7 @@ const SCENARIOS = [
   {
     method: 'openExperience',
     args: ['experience-id'],
-    expected: { id: 'experience-id' },
+    expected: { id: 'experience-id', releaseId: undefined },
     channelMethod: 'navigateToExperience',
   },
   {
@@ -312,6 +312,28 @@ describe('createNavigator()', () => {
       })
     })
 
+    describe('openExperience with release', () => {
+      it('should pass releaseId when release exists', () => {
+        const navigator = createNavigator(channel, ids, mockRelease)
+
+        navigator.openExperience('experience-id')
+        expect(channel.call).to.have.been.calledWith('navigateToExperience', {
+          id: 'experience-id',
+          releaseId: 'test-release-id',
+        })
+      })
+
+      it('should pass releaseId as undefined when release is undefined', () => {
+        const navigator = createNavigator(channel, ids, undefined)
+
+        navigator.openExperience('experience-id')
+        expect(channel.call).to.have.been.calledWith('navigateToExperience', {
+          id: 'experience-id',
+          releaseId: undefined,
+        })
+      })
+    })
+
     describe('methods that do not handle releaseId', () => {
       it('should not pass releaseId in openNewEntry', () => {
         const navigator = createNavigator(channel, ids, mockRelease)
@@ -372,6 +394,15 @@ describe('createNavigator()', () => {
 
         navigator.openAppConfig()
         expect(channel.call).to.have.been.calledWith('navigateToAppConfig')
+      })
+
+      it('should not pass releaseId in openComponent', () => {
+        const navigator = createNavigator(channel, ids, mockRelease)
+
+        navigator.openComponent('component-id')
+        expect(channel.call).to.have.been.calledWith('navigateToComponent', {
+          id: 'component-id',
+        })
       })
     })
   })


### PR DESCRIPTION
[AIS-202](https://contentful.atlassian.net/browse/AIS-202)

## Summary
- Add `sdk.navigator.openExperience(experienceId)` and `sdk.navigator.openComponent(componentId)` to `NavigatorAPI` (SDK-wide, full-page, `Promise<void>`).
- Channel methods: `navigateToExperience` / `navigateToComponent` with `{ id }` payload.
- First publish in the AIS-202 chain

## Test plan
- [x] `npm test -- --grep createNavigator` (includes new scenarios)
- [ ] Downstream:  handlers + UI and and bump this release

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-202]: https://contentful.atlassian.net/browse/AIS-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ