### PR TITLE
feat: expose window API on experience-toolbar SDK [AIS-311]

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -48,7 +48,7 @@ const LOCATION_TO_API_PRODUCERS: { [location: string]: ProducerFunc[] } = {
   [locations.LOCATION_HOME]: [makeSharedAPI],
   [locations.LOCATION_APP_CONFIG]: [makeSharedAPI, makeAppAPI],
   [locations.LOCATION_AGENT]: [makeSharedAPI, makeAgentAPI, makeWindowAPI],
-  [locations.LOCATION_EXPERIENCE_TOOLBAR]: [makeSharedAPI, makeExperienceAPI],
+  [locations.LOCATION_EXPERIENCE_TOOLBAR]: [makeSharedAPI, makeExperienceAPI, makeWindowAPI],
 }
 
 export default function createAPI(

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -360,6 +360,8 @@ export type ExperienceEditorToolbarAppSDK<
   ids: Omit<IdsAPI, EntryScopedIds>
   /** Experience SDK for experience-toolbar location */
   experiences: ExperienceSDK
+  /** Methods to update the size of the iframe the app is contained within.  */
+  window: WindowAPI
 }
 
 export type KnownAppSDK<

--- a/test/unit/api.spec.ts
+++ b/test/unit/api.spec.ts
@@ -239,6 +239,25 @@ describe('createAPI()', () => {
 
       expect(api.experiences.context).to.deep.equal({ type: 'experience', entityId: '' })
     })
+
+    it('exposes a window API for auto-resize', () => {
+      const channel = { addHandler: () => () => {} } as any
+      const dom = makeDOM()
+      mockMutationObserver(dom, () => {})
+      mockResizeObserver(dom, () => {})
+
+      const data: ConnectMessage = { ...baseData, experiences: {} } as any
+      const api = createAPI(
+        channel,
+        data,
+        dom.window as any as Window,
+      ) as ExperienceEditorToolbarAppSDK
+
+      expect(api.window).to.not.equal(undefined)
+      expect(api.window.startAutoResizer).to.be.a('function')
+      expect(api.window.stopAutoResizer).to.be.a('function')
+      expect(api.window.updateHeight).to.be.a('function')
+    })
   })
 
   it('returns correct shape of the app API (app)', () => {


### PR DESCRIPTION
[AIS-311](https://contentful.atlassian.net/browse/AIS-311) · Fast-follow to [AIS-310](https://contentful.atlassian.net/browse/AIS-310) 

## Summary
- The ExO toolbar's new stacked "Apps" panel ([AIS-310](https://contentful.atlassian.net/browse/AIS-310)) needs generic apps to auto-resize to their content. The host already honors an app's `setHeight` when the widget renders non-full-size, so **AIS-310 works at runtime today** — this PR closes the *type* gap so app developers can call `sdk.window.startAutoResizer()` / `useAutoResizer()` idiomatically.
- **Root cause:** in the location→connector table, `LOCATION_AGENT` maps to `[shared, agent, window]` but `LOCATION_EXPERIENCE_TOOLBAR` was `[shared, experiences]` — missing the window connector. And `ExperienceEditorToolbarAppSDK` had no `window: WindowAPI` member (contrast `AgentAppSDK`).
- **Fix (mirrors the agent location):**
  - `lib/api.ts` — add `makeWindowAPI` to the `LOCATION_EXPERIENCE_TOOLBAR` producer list.
  - `lib/types/api.types.ts` — add `window: WindowAPI` to `ExperienceEditorToolbarAppSDK`.
  - `test/unit/api.spec.ts` — assert `connect()` for the toolbar location yields a `window` API exposing `startAutoResizer` / `stopAutoResizer` / `updateHeight` (mirrors the existing agent-location test).

## Notes
- Additive, backward-compatible — no change to `experiences` or any existing member; no runtime dependency added.

## Test plan
- [x] `npm run check-types` clean
- [x] `npm run lint` clean
- [x] `npm test` — 549 passing, incl. new toolbar window-API test
- [x] `npm run build` + `npm run size` (8384 bytes gzipped)

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-311]: https://contentful.atlassian.net/browse/AIS-311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIS-310]: https://contentful.atlassian.net/browse/AIS-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIS-310]: https://contentful.atlassian.net/browse/AIS-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ