### PR TITLE
feat: align App SDK ExO vocabulary to canonical names [AIS-307]

### DIFF
--- a/lib/experience.ts
+++ b/lib/experience.ts
@@ -26,7 +26,7 @@ import {
  * Creates the Experience SDK namespace for the experience-toolbar location.
  *
  * Throws when called without handshake `experiences` data, mirroring `createAgent`. This keeps the
- * public `ExperienceEditorToolbarAppSDK['experiences']` type sound (non-optional, always present).
+ * public `ExperienceCanvasToolbarAppSDK['experiences']` type sound (non-optional, always present).
  */
 export default function createExperience(
   channel: Channel,

--- a/lib/types/api.types.ts
+++ b/lib/types/api.types.ts
@@ -354,7 +354,7 @@ export type AgentAppSDK<InstallationParameters extends KeyValueMap = KeyValueMap
   window: WindowAPI
 }
 
-export type ExperienceEditorToolbarAppSDK<
+export type ExperienceCanvasToolbarAppSDK<
   InstallationParameters extends KeyValueMap = KeyValueMap,
 > = Omit<BaseAppSDK<InstallationParameters, never, never>, 'ids'> & {
   ids: Omit<IdsAPI, EntryScopedIds>
@@ -377,7 +377,7 @@ export type KnownAppSDK<
   | ConfigAppSDK<InstallationParameters>
   | HomeAppSDK<InstallationParameters>
   | AgentAppSDK<InstallationParameters>
-  | ExperienceEditorToolbarAppSDK<InstallationParameters>
+  | ExperienceCanvasToolbarAppSDK<InstallationParameters>
 
 /** @deprecated consider using {@link BaseAppSDK} */
 export type BaseExtensionSDK = BaseAppSDK

--- a/lib/types/experience.types.ts
+++ b/lib/types/experience.types.ts
@@ -51,7 +51,7 @@ export type SameSpaceContentSource = 'crn:contentful:::content:spaces/$self/envi
 
 /**
  * A reference to a Contentful resource, addressed by `urn`. `linkType` is a `Contentful:`-prefixed
- * resource type (e.g. `'Contentful:Template'`).
+ * resource type (e.g. `'Contentful:Template'` / its canonical `'Contentful:ExperienceTemplate'`).
  */
 export interface ResourceLink<T extends string = string> {
   sys: {
@@ -126,17 +126,30 @@ export interface DataAssemblyAPI extends DataAssemblyParameterAPI {
   onChange(cb: (snapshot: DataAssemblySnapshot) => void): Unsubscribe
 }
 
-/** The type of a node within an experience/fragment tree. */
-export type ExperienceNodeType = 'Component' | 'Fragment' | 'InlineFragment' | 'Slot'
+/**
+ * The type of a node within an experience/fragment tree. Accepts both the current
+ * (`Fragment`/`InlineFragment`) and upcoming canonical (`ExperienceFragment`/`InlineExperienceFragment`)
+ * vocabulary — the same node entity, named differently across the ExO data-model transition.
+ */
+export type ExperienceNodeType =
+  | 'Component'
+  | 'Fragment'
+  | 'ExperienceFragment'
+  | 'InlineFragment'
+  | 'InlineExperienceFragment'
+  | 'Slot'
 
 export interface ExperienceNodeSnapshot {
   id: string
   nodeType: ExperienceNodeType
 }
 
-/** One allowed resource for a slot: the Component(s) that may be placed in it. */
+/**
+ * One allowed resource for a slot: the Component(s) that may be placed in it. `type` accepts both
+ * the current (`Contentful:ComponentType`) and upcoming canonical (`Contentful:Component`) URN.
+ */
 export interface SlotAllowedResource {
-  type: 'Contentful:ComponentType'
+  type: 'Contentful:ComponentType' | 'Contentful:Component'
   source: string
   allowedTypes: string[]
 }
@@ -144,7 +157,10 @@ export interface SlotAllowedResource {
 export interface SlotDescriptor {
   id: string
   allowedResources: SlotAllowedResource[]
-  currentItems: Array<{ nodeId: string; nodeType: 'Fragment' | 'InlineFragment' }>
+  currentItems: Array<{
+    nodeId: string
+    nodeType: 'Fragment' | 'ExperienceFragment' | 'InlineFragment' | 'InlineExperienceFragment'
+  }>
 }
 
 /**
@@ -201,10 +217,13 @@ export interface ExperienceMetadata {
 }
 
 /**
- * Snapshot of the root entity being edited. Discriminated on `sys.type`:
- * an `Experience` (optionally backed by a template) or a `Fragment` (no template).
- * `Experience.sys.template` is optional, and `Fragment.sys` carries a `componentType`
- * ResourceLink and no template.
+ * Snapshot of the root entity being edited, discriminated on `sys.type`. Three arms:
+ * an `Experience` (optionally backed by a template) plus two shapes of the same fragment
+ * entity — `Fragment` (current vocabulary: `sys.componentType`, `Contentful:ComponentType`)
+ * and `ExperienceFragment` (upcoming canonical vocabulary: `sys.component`, `Contentful:Component`).
+ * `Fragment` and `ExperienceFragment` are the same entity in legacy vs canonical shape; both are
+ * accepted so apps stay forward-compatible across the ExO data-model transition. The `Experience`
+ * arm carries an optional `template`/`experienceTemplate` (an experience may be un-templated).
  */
 export type ExperienceSnapshot =
   | {
@@ -213,6 +232,7 @@ export type ExperienceSnapshot =
         type: 'Experience'
         version: number
         template?: ResourceLink<'Contentful:Template'>
+        experienceTemplate?: ResourceLink<'Contentful:ExperienceTemplate'>
       }
       metadata?: ExperienceMetadata
     }
@@ -222,6 +242,15 @@ export type ExperienceSnapshot =
         type: 'Fragment'
         version: number
         componentType: ResourceLink<'Contentful:ComponentType'>
+      }
+      metadata?: ExperienceMetadata
+    }
+  | {
+      sys: {
+        id: string
+        type: 'ExperienceFragment'
+        version: number
+        component: ResourceLink<'Contentful:Component'>
       }
       metadata?: ExperienceMetadata
     }
@@ -249,7 +278,7 @@ export interface ExperienceAPI {
 }
 
 export interface ExperienceContext {
-  type: 'experience' | 'fragment'
+  type: 'experience' | 'fragment' | 'experienceFragment'
   entityId: string
 }
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,3 +1,7 @@
+import type { KeyValueMap } from 'contentful-management'
+
+import type { ExperienceCanvasToolbarAppSDK } from './api.types'
+
 export type {
   AppExtensionSDK,
   BaseExtensionSDK,
@@ -35,8 +39,13 @@ export type {
   JSONPatchItem,
   HostnamesAPI,
   AgentAppSDK,
-  ExperienceEditorToolbarAppSDK,
+  ExperienceCanvasToolbarAppSDK,
 } from './api.types'
+
+/** @deprecated Renamed to ExperienceCanvasToolbarAppSDK. Alias kept for the internal migration window; will be removed. */
+export type ExperienceEditorToolbarAppSDK<
+  InstallationParameters extends KeyValueMap = KeyValueMap,
+> = ExperienceCanvasToolbarAppSDK<InstallationParameters>
 
 export type {
   AgentAPI,

--- a/test/mocks/experience.ts
+++ b/test/mocks/experience.ts
@@ -15,6 +15,38 @@ export const mockExperienceSnapshot: ExperienceSnapshot = {
   },
 }
 
+// Legacy fragment vocabulary (current host reads): 'Fragment' + sys.componentType.
+export const mockFragmentSnapshot: ExperienceSnapshot = {
+  sys: {
+    id: 'frag-123',
+    type: 'Fragment',
+    version: 1,
+    componentType: {
+      sys: {
+        type: 'ResourceLink',
+        linkType: 'Contentful:ComponentType',
+        urn: 'crn:contentful:::content:spaces/sp/componentTypes/ct-1',
+      },
+    },
+  },
+}
+
+// Canonical fragment vocabulary (post-transition host reads): 'ExperienceFragment' + sys.component.
+export const mockExperienceFragmentSnapshot: ExperienceSnapshot = {
+  sys: {
+    id: 'frag-123',
+    type: 'ExperienceFragment',
+    version: 1,
+    component: {
+      sys: {
+        type: 'ResourceLink',
+        linkType: 'Contentful:Component',
+        urn: 'crn:contentful:::content:spaces/sp/components/c-1',
+      },
+    },
+  },
+}
+
 export const mockExperienceInit = {
   experience: mockExperienceSnapshot,
 }

--- a/test/unit/api.spec.ts
+++ b/test/unit/api.spec.ts
@@ -6,7 +6,7 @@ import {
   AgentAppSDK,
   ConfigAppSDK,
   ConnectMessage,
-  ExperienceEditorToolbarAppSDK,
+  ExperienceCanvasToolbarAppSDK,
   ExperienceSDK,
 } from '../../lib/types'
 import { mockRelease, mockReleaseWithoutEntities } from '../mocks/releases'
@@ -196,7 +196,7 @@ describe('createAPI()', () => {
       )
     })
 
-    it('ExperienceEditorToolbarAppSDK exposes experiences: ExperienceSDK', () => {
+    it('ExperienceCanvasToolbarAppSDK exposes experiences: ExperienceSDK', () => {
       const channel = { addHandler: () => () => {} } as any
       const dom = makeDOM()
       mockMutationObserver(dom, () => {})
@@ -207,7 +207,7 @@ describe('createAPI()', () => {
         channel,
         data,
         dom.window as any as Window,
-      ) as ExperienceEditorToolbarAppSDK
+      ) as ExperienceCanvasToolbarAppSDK
 
       const experiences: ExperienceSDK = api.experiences
       expect(experiences).to.be.an('object')
@@ -251,7 +251,7 @@ describe('createAPI()', () => {
         channel,
         data,
         dom.window as any as Window,
-      ) as ExperienceEditorToolbarAppSDK
+      ) as ExperienceCanvasToolbarAppSDK
 
       expect(api.window).to.not.equal(undefined)
       expect(api.window.startAutoResizer).to.be.a('function')

--- a/test/unit/experience.spec.ts
+++ b/test/unit/experience.spec.ts
@@ -2,7 +2,12 @@ import { describeAttachHandlerMember, sinon, expect } from '../helpers'
 
 import createExperience from '../../lib/experience'
 import { Channel } from '../../lib/channel'
-import { mockExperienceInit, mockExperienceSnapshot } from '../mocks/experience'
+import {
+  mockExperienceInit,
+  mockExperienceSnapshot,
+  mockFragmentSnapshot,
+  mockExperienceFragmentSnapshot,
+} from '../mocks/experience'
 
 describe('createExperience()', () => {
   let channelStub: any
@@ -163,6 +168,22 @@ describe('createExperience()', () => {
           const experienceChangedHandler = channelStub.addHandler.getCall(1).args[1]
           experienceChangedHandler(updatedSnapshot)
           expect(experience!.experience.get()).to.deep.equal(updatedSnapshot)
+        })
+
+        it('carries the legacy Fragment snapshot shape (componentType) through unchanged', () => {
+          const experienceChangedHandler = channelStub.addHandler.getCall(1).args[1]
+          experienceChangedHandler(mockFragmentSnapshot)
+          const snapshot = experience!.experience.get()
+          expect(snapshot.sys.type).to.equal('Fragment')
+          expect(snapshot).to.deep.equal(mockFragmentSnapshot)
+        })
+
+        it('carries the canonical ExperienceFragment snapshot shape (component) through unchanged', () => {
+          const experienceChangedHandler = channelStub.addHandler.getCall(1).args[1]
+          experienceChangedHandler(mockExperienceFragmentSnapshot)
+          const snapshot = experience!.experience.get()
+          expect(snapshot.sys.type).to.equal('ExperienceFragment')
+          expect(snapshot).to.deep.equal(mockExperienceFragmentSnapshot)
         })
       })
 


### PR DESCRIPTION
[AIS-307](https://contentful.atlassian.net/browse/AIS-307)

## Summary
Aligns the public App SDK's ExO surface to canonical product vocabulary, in two additive parts:

**1. Toolbar location type rename**
- Renames the experience-toolbar location SDK type `ExperienceEditorToolbarAppSDK` to the canonical name `ExperienceCanvasToolbarAppSDK`.
- Keeps a deprecated `ExperienceEditorToolbarAppSDK` alias so existing consumers keep compiling during the migration window; it will be removed in a later release.
- Updates the `KnownAppSDK` union, the re-export in `lib/types/index.ts`, JSDoc references, and the unit test to the canonical name.

**2. Experience type vocabulary dual-accept**
- The Experience SDK types now accept **both** the current and upcoming ExO entity vocabulary, so apps stay forward-compatible across the upcoming data-model transition:
  - `Fragment` snapshot arm (with `sys.componentType` / `Contentful:ComponentType`) **and** a new canonical `ExperienceFragment` arm (with `sys.component` / `Contentful:Component`) — the same entity in legacy vs canonical shape.
  - `ExperienceContext.type` accepts `'fragment'` and `'experienceFragment'`.
  - `ExperienceNodeType` and `SlotDescriptor.currentItems[].nodeType` accept `Fragment`/`ExperienceFragment` and `InlineFragment`/`InlineExperienceFragment`.
  - `SlotAllowedResource.type` accepts `Contentful:ComponentType` and `Contentful:Component`.
  - The `Experience` snapshot arm carries optional `template` / `experienceTemplate` (matching `Contentful:Template` / `Contentful:ExperienceTemplate` URNs).
- **Runtime values are unchanged** — only the public types widen. A later release retires the legacy names.

Out of scope (intentionally unchanged):
- The location wire string (`experience-toolbar`) is unchanged.
- Example-app / experience-packages consumers are handled separately.

## Semver note (for reviewer)
This is **additive / dual-accept (`feat`)**: the alias and widened unions keep existing consumers compiling. One caveat worth a confirm — widening the union returned by `experience.get()` with the new `'ExperienceFragment'` arm means any consumer doing an **exhaustive `switch`** on `sys.type` would need to add the `'ExperienceFragment'` case. The experience-toolbar location is not yet GA, so real-world exposure is minimal — flagging so we can confirm `feat` together.

## Test plan
- [x] `npm run check-types`
- [x] `npm run lint`
- [x] `npm test` (551 passing)
- [x] `npm run build`
- [x] `npm run size`

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-307]: https://contentful.atlassian.net/browse/AIS-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
