### PR TITLE
docs: seed decision records with dual-package publish ADR [EXT-7536]

### DIFF
--- a/docs/ADRs/2021-01-15-publish-one-source-under-two-npm-names.md
+++ b/docs/ADRs/2021-01-15-publish-one-source-under-two-npm-names.md
@@ -1,0 +1,131 @@
+# Publish one source tree under two npm package names
+
+## Status
+
+Accepted
+
+## Context
+
+This repository is named `ui-extensions-sdk` and has published to npm as
+`contentful-ui-extensions-sdk` since its early releases. The product it ships was subsequently
+renamed: UI Extensions became the App Framework, and this library became the **App SDK**. The
+repository name, the historical package name, and the current product name therefore all differ.
+
+A published npm package cannot be renamed in place. Existing installs, committed lockfiles,
+CI pipelines, CDN script tags, and third-party documentation all reference the old specifier.
+Publishing the renamed library only under a new name would strand every existing consumer on
+whatever version they had pinned, with no upgrade path that did not require a code change.
+
+When semantic-release was introduced (`8b61283`, #455), the publish step was therefore made
+multi-name. It initially hedged across the full cross-product of scoped and unscoped variants
+of both the old and new product names — four packages:
+
+```js
+const PACKAGES = [
+  'contentful-ui-extensions-sdk',
+  '@contentful/ui-extensions-sdk',
+  'contentful-app-sdk',
+  '@contentful/app-sdk',
+]
+```
+
+Eleven days later (`a785854`, #493) that list was narrowed to two, and the README was changed
+to recommend `@contentful/app-sdk`. Publishing four names meant four release surfaces and four
+sets of npm metadata to keep coherent, for two names nobody was asked to use.
+
+Alternatives considered:
+
+- **Rename in place, publish only `@contentful/app-sdk`.** Rejected — strands the installed
+  base, which is large and includes customer apps this team does not control.
+- **Keep publishing all four names.** Rejected in #493 — quadruples the publish surface to
+  defend specifiers no documentation pointed at.
+- **`npm deprecate` the legacy name and stop publishing it.** Rejected — a deprecation warning
+  does not make a pinned lockfile resolve a new specifier, so consumers would silently stop
+  receiving fixes, including security fixes.
+
+## Decision
+
+Publish every release from this single source tree under exactly **two** npm package names, at
+identical versions with identical contents:
+
+| Package                        | Role                                                                     |
+| ------------------------------ | ------------------------------------------------------------------------ |
+| `@contentful/app-sdk`          | Current, recommended specifier — use in all new code, examples, and docs |
+| `contentful-ui-extensions-sdk` | Legacy alias, retained indefinitely for installed-base compatibility     |
+
+`contentful-ui-extensions-sdk` remains the `name` committed in `package.json`; the scoped name
+is applied at publish time.
+
+### Mechanism
+
+semantic-release does not perform the publish. It is configured with `@semantic-release/npm`'s
+`npmPublish: false`, so it determines the next version, writes `CHANGELOG.md`, commits, and
+tags — then delegates publishing to `@semantic-release/exec`:
+
+```json
+{
+  "verifyConditionsCmd": "node ./scripts/verify.js",
+  "publishCmd": "npm run publish-all"
+}
+```
+
+`scripts/publish.js` iterates the `PACKAGES` list in `scripts/shared.js`. For each name it
+calls `setPackageName(name)` — which rewrites `package.json#name` on disk and re-runs
+`npm install` — then runs `npm publish --access public --tag <tag>`. `restorePackageJson()`
+runs in a `finally` to put the committed name back.
+
+`scripts/verify.js` dry-runs each name during semantic-release's `verifyConditions` step. That
+step runs _before_ the next version is known, and `npm publish --dry-run` fails if the version
+already exists on the registry, so verify.js temporarily writes a version that cannot collide:
+`0.0.0-verify.<timestamp>`.
+
+The dist-tag is derived from the version rather than the branch: a version matching
+`\d+\.\d+\.\d+-alpha\.\d+` publishes under `canary`, everything else under `latest`.
+
+## Consequences
+
+### What this enables
+
+- Consumers pinned to `contentful-ui-extensions-sdk` continue to receive every feature and
+  security fix with no migration and no code change, indefinitely.
+- New consumers get a conventionally scoped, correctly named package.
+- There is exactly one source tree, one build, one version number, and one changelog. Both
+  names are published from the same artifacts in the same run, so they cannot drift in content
+  — at the time of writing both resolve to `4.69.0` on the public registry.
+
+### Trade-offs accepted
+
+- **`package.json` is mutated mid-publish.** `setPackageName` writes the file with
+  `JSON.stringify(packageJson)` — no indentation — and `restorePackageJson` rewrites it with
+  two-space indentation and _no_ trailing newline. A crash between the two leaves a
+  wrong-named, reformatted `package.json` in the tree. The restore is the publish path's own
+  cleanup, not a general safety net: manual edits to `name` are not protected, which is why
+  `AGENTS.md` carries an explicit "never edit `name` directly" rule. (`scripts/verify.js`
+  appends a trailing newline when it rewrites the file; `restorePackageJson` does not.)
+- **The committed canonical name is the legacy one.** Any tool that reads
+  `package.json#name` — dependency graphs, provenance metadata, registry dashboards — reports
+  the deprecated specifier rather than the recommended one, so descriptions elsewhere have to
+  compensate by naming both (`catalog-info.yaml` does exactly this).
+- **The publish surface is doubled.** `publish.js` publishes sequentially and throws on the
+  first failure, so a failure on the second name leaves the release published under one name
+  only, at a version already tagged in git. Recovery is manual.
+- **`verifyConditions` needs a throwaway version.** The `0.0.0-verify.<timestamp>` workaround
+  exists solely because the dry-run happens before versioning; it is load-bearing, not
+  incidental.
+- **The scoped name adds registry-routing coupling the unscoped name does not have.** The
+  release workflow writes an `.npmrc` mapping `@contentful` to GitHub Packages, and the
+  ordering of that write relative to `npm ci` is load-bearing: applying it before install
+  broke the release under npm 12, since lockfile URLs point at the public registry
+  (`6021e29`, #2629).
+- **Every piece of documentation must state which name to prefer**, because both are valid,
+  current, and identical. The README, `AGENTS.md`, and `ARCHITECTURE.md` each carry that
+  disambiguation.
+
+### Follow-up work
+
+- **No sunset criteria are recorded for the legacy name.** Neither the README nor `AGENTS.md`
+  states what would have to be true to stop publishing `contentful-ui-extensions-sdk`. "Retained
+  indefinitely" is the de facto policy; if that is intentional it should be stated, and if it is
+  not, the conditions for retiring it should be written down.
+- `restorePackageJson` could write the file byte-identically to what is committed — two-space
+  indentation plus a trailing newline — so an interrupted publish leaves no spurious diff.

--- a/docs/ADRs/README.md
+++ b/docs/ADRs/README.md
@@ -1,0 +1,29 @@
+# Architecture Decision Records
+
+Each ADR records a single architectural decision, the context that forced it, and the
+consequences this repository now lives with. They are historical records — an accepted ADR is
+not edited to reflect later changes. When a decision is reversed, add a new ADR and mark the
+old one `Superseded by`.
+
+| Date                                                                 | Status   | Title                                               |
+| -------------------------------------------------------------------- | -------- | --------------------------------------------------- |
+| [2021-01-15](./2021-01-15-publish-one-source-under-two-npm-names.md) | Accepted | Publish one source tree under two npm package names |
+
+## Conventions
+
+- **Filename** — `YYYY-MM-DD-short-title.md`. The date is the date of the decision, taken from
+  the commit, pull request, or discussion that made it — not the date the ADR was written. The
+  filename is the canonical identifier; there is no separate sequential numbering.
+- **Sections** — `Status`, `Context`, `Decision`, `Consequences`.
+- **Status** — one of `Accepted`, `Deprecated`, or
+  `Superseded by [YYYY-MM-DD-title](./YYYY-MM-DD-title.md)`.
+- **One decision per record.** Corrections and follow-ups that flow from a decision belong in
+  that decision's `Consequences`, not in new ADRs.
+- **Cite evidence.** Reference commits and pull requests in this repository so a reader can
+  verify the reasoning. Verify commit hashes against `git log` before writing them. This
+  repository is public — cite only publicly visible sources.
+
+> **Note on location:** these records live under `docs/` because that is where decision records
+> are expected to be found. Everything else in `docs/` is legacy GitHub Pages content — see
+> [`../WARNING.txt`](../WARNING.txt). Adding files here is additive and does not affect the
+> paths that content is served from.


### PR DESCRIPTION
[EXT-7536](https://contentful.atlassian.net/browse/EXT-7536)

## Summary
- Adds `docs/ADRs/` with its first decision record, satisfying the `decision-records-present` readiness control (which found no `.md` under `docs/ADRs/`, `docs/adr/`, `docs/decision-records/`, or `docs/decisions/`).
- The record covers **why this repo publishes one source tree under two npm names** — `@contentful/app-sdk` (recommended) and `contentful-ui-extensions-sdk` (legacy alias). `AGENTS.md` sharp edge #5 already documents the *mechanism* and states the names "diverged for historical reasons" without saying what they were; this ADR supplies that missing rationale.
- Docs only. No source, build, or release configuration is touched.

### Why this decision was worth the first record

An npm package cannot be renamed in place, so publishing the renamed library only as `@contentful/app-sdk` would have stranded every consumer with a pinned lockfile. Multi-name publishing began in `8b61283` (#455) hedging across **four** names — the scoped and unscoped variants of both the old and new product names — and was narrowed to two eleven days later in `a785854` (#493), which also switched the README to recommend the scoped name.

The ADR also records the mechanism and what it costs us:

| Aspect | Detail |
|---|---|
| Publish path | semantic-release runs with `@semantic-release/npm`'s `npmPublish: false` and delegates to `scripts/publish.js` via `@semantic-release/exec` |
| Name switching | `setPackageName` rewrites `package.json#name` on disk per package; `restorePackageJson` restores it in a `finally` |
| Dry-run | `verify.js` writes a throwaway `0.0.0-verify.<timestamp>` version, because `verifyConditions` runs *before* the next version is known |
| Sequential publish | `publish.js` throws on the first failure, so a second-name failure leaves a release published under one name at a version already tagged |
| Registry coupling | The scoped name pulls in the `@contentful` → GitHub Packages `.npmrc` rewrite, whose ordering relative to `npm ci` broke the release under npm 12 (`6021e29`, #2629) |

Two follow-ups are recorded in the ADR rather than fixed here: no sunset criteria exist for the legacy name, and `restorePackageJson` drops the trailing newline that the committed `package.json` has (verified — it does end in `\n`), so an interrupted publish leaves a spurious one-byte diff.

### Notes for the reviewer

- **Placement.** `docs/` in this repo is legacy GitHub Pages content with an explicit `docs/WARNING.txt` saying people may still rely on its files being deployed. The readiness control only accepts paths under `docs/`, so that is where the records go. Adding markdown is additive and changes no existing served path; `docs/ADRs/README.md` carries a note pointing at the warning so the next person understands the mix.
- **Date.** The filename is dated `2021-01-15` — the date of `a785854`, when the two-name shape was settled — not today, per the convention recorded in `docs/ADRs/README.md`. `#455` is cited as the introduction.
- **Verification.** Every commit hash was checked against `git log` rather than transcribed, and both package names were confirmed to resolve to the same version (`4.69.0`) on the public registry.
- No corrections to `AGENTS.md` / `ARCHITECTURE.md` / `CONTRIBUTING.md` were needed — they are accurate and current, so this PR leaves them alone.

## Test plan
- [ ] Files render correctly on GitHub, including the tables
- [ ] The relative links in `docs/ADRs/README.md` resolve (the ADR, and `../WARNING.txt`)
- [ ] Spot-check the ADR's commit hashes and PR references against `git log`
- [ ] Confirm no release is triggered — `docs:` only, which the commit-analyzer does not treat as releasable
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)

[EXT-7536]: https://contentful.atlassian.net/browse/EXT-7536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ