### PR TITLE
feat: expose variant id in agent context [EXA-2362]

### DIFF
--- a/lib/types/agent.types.ts
+++ b/lib/types/agent.types.ts
@@ -5,6 +5,7 @@ export interface AgentContext {
     contentTypeId?: string
     lastFocusedFieldId?: string
     experienceId?: string
+    variantId?: string
     experienceFragmentId?: string
     componentId?: string
     experienceTemplateId?: string

--- a/test/mocks/agent.ts
+++ b/test/mocks/agent.ts
@@ -6,6 +6,7 @@ export const mockAgentContext: AgentContext = {
     entryId: 'test-entry-123',
     contentTypeId: 'test-content-type-456',
     lastFocusedFieldId: 'test-field-789',
+    variantId: 'test-variant-123',
   },
 }
 


### PR DESCRIPTION
# Purpose of PR

[EXA-2362](https://contentful.atlassian.net/browse/EXA-2362)

## Summary

- Expose the active experience variant as optional `variantId` metadata in `AgentContext`.
- Update the shared agent context mock with variant metadata.

This gives agent apps access to the variant currently being edited in the ExO Editor so they can provide context-aware insights.

## Test plan

- [ ] `npm run lint` (dependencies are not installed locally)
- [ ] `npm run check-types` (dependencies are not installed locally)
- [ ] `npm test` (dependencies are not installed locally)

## PR Checklist

- [x] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Typescript typings are added/updated/not required


[EXA-2155]: https://contentful.atlassian.net/browse/EXA-2155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EXA-2362]: https://contentful.atlassian.net/browse/EXA-2362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ